### PR TITLE
Implement peek_read for device UART Reader

### DIFF
--- a/device/src/uart.rs
+++ b/device/src/uart.rs
@@ -40,7 +40,10 @@ where
             }
         }
 
-        println!("Peeking read {:?}", self.from_buffer_cache);
+        println!(
+            "Peeking read {} bytes: {:?}",
+            n_bytes, self.from_buffer_cache
+        );
         return if self.from_buffer_cache.len() == 0 {
             None
         } else {
@@ -65,11 +68,15 @@ where
 
         // Take bytes from existing cached first
         for byte in &self.from_buffer_cache {
+            if i == bytes.len() {
+                return Ok(());
+            }
             bytes[i] = *byte;
-            i += 1
+            i += 1;
         }
         self.consume(i);
 
+        let mut error_count = 0;
         while i < bytes.len() {
             match self.uart.read() {
                 Err(e) => {


### PR DESCRIPTION
Attempt at fixing https://github.com/frostkey/frost-esp32/issues/11

By implementing additional trait methods `peek_read` and `consume` as mentioned for buffers on the bincode docs.
https://docs.rs/bincode/2.0.0-rc.2/bincode/de/read/trait.Reader.html

My approach is to `peek_read` bytes into a field `from_buffer_cache` on `UartReader`, which `consume()` clears.

I've also modified `read()` to first take bytes from the `from_buffer_cache`, and then read additional bytes as usual if need be.

In this current state, the peek_read is working just as well as before, but still does not yet solve the issue with the keygen message. Perhaps another possibility is that the `coordinator-cli` is writing too fast?

There are a whole bunch of printlns to try and figure out what is going on.