### PR TITLE
Less serde more bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
 name = "frostsnap_core"
 version = "0.1.0"
 dependencies = [
+ "bincode 2.0.0-rc.3",
  "bitcoin",
  "chacha20",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,9 @@ resolver = "2"
 
 [patch.crates-io]
 miniscript = { version = "9", git = 'https://github.com/apoelstra/rust-miniscript', rev = "f1c12724d04b7ad28d25c866383a948cd493e698" }
+
+[workspace.dependencies]
+bincode = {  version = "2.0.0-rc.3", features = ["serde", "alloc", "derive"], default-features = false }
+serde = { version = "1", features = ["derive","alloc"], default-features = false }
+frostsnap_core = { path = "frostsnap_core", default-features = false }
+frostsnap_comms = { path = "frostsnap_comms", default-features = false }

--- a/coordinator-cli/Cargo.toml
+++ b/coordinator-cli/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bincode = { version = "2.0.0-rc.3", default-features = false, features = ["derive", "serde", "std"] } 
-frostsnap_core = { path = "../frostsnap_core", features = ["std"] }
-frostsnap_comms = { path = "../frostsnap_comms" }
+frostsnap_core = { workspace = true, features = ["std", "serde_json"] }
+frostsnap_comms = { workspace = true }
 hex = "0.4.3"
 sha2 = "0.9"
 rand = { version = "0.8" }
@@ -27,3 +26,4 @@ bdk_file_store = { rev = "26ade1172622f66cb95c831c4a8e7535409e8e81", git = "http
 bdk_coin_select = { rev = "9129b43f1ee75185f3cc3a0f27edcd00df59a61d", git = "https://github.com/llfourn/bdk.git" }
 bech32 = "0.9.1"
 tungstenite = { version = "0.19", features = ["rustls-tls-webpki-roots"] }
+bincode = {workspace = true, features = ["std"]}

--- a/coordinator-cli/src/db.rs
+++ b/coordinator-cli/src/db.rs
@@ -1,5 +1,5 @@
 use bdk_file_store::Store;
-use frostsnap_core::{CoordinatorFrostKey, DeviceId};
+use frostsnap_core::{bincode, CoordinatorFrostKey, DeviceId};
 use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -45,7 +45,7 @@ pub struct Db {
     store: Store<'static, ChangeSet>,
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
 pub struct State {
     pub key: CoordinatorFrostKey,
     pub device_labels: HashMap<DeviceId, String>,

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -18,8 +18,8 @@ rgb-led = ["dep:esp-hal-smartled", "dep:smart-leds"]
 purple = [ "dep:ssd1306", "dep:display-interface-spi", "dep:display-interface", "dep:esp-hal-smartled", "dep:smart-leds" ]
 
 [dependencies]
-frostsnap_core = { path = "../frostsnap_core", default-features = false }
-frostsnap_comms = { path = "../frostsnap_comms", default-features = false }
+frostsnap_core = { workspace = true }
+frostsnap_comms = { workspace = true }
 # esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "a0b72bdfa5a07a6c9387e4658b0d5c87f254d8ea" }
 esp32c3-hal = "0.9.0"
 esp-alloc = "0.3.0"
@@ -30,7 +30,7 @@ nb = "1.1.0"
 fugit = "0.3.6"
 embedded-storage = "0.3.0"
 esp-storage = { version = "0.1.0", features = ["esp32c3"] }
-bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "derive", "serde"] }
+bincode = { workspace = true }
 
 display-interface = { version = "0.4.1", optional = true }
 ssd1306 = { version = "0.8", optional = true }

--- a/device/src/state.rs
+++ b/device/src/state.rs
@@ -1,6 +1,5 @@
 #[derive(bincode::Encode, bincode::Decode, Debug, Clone)]
 
 pub struct FrostState {
-    #[bincode(with_serde)]
     pub signer: frostsnap_core::FrostSigner,
 }

--- a/frostsnap_comms/Cargo.toml
+++ b/frostsnap_comms/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "derive", "serde"] } 
-frostsnap_core = { path = "../frostsnap_core", default-features = false }
-serde = { version = "1", features = ["derive"], default-features = false }
+frostsnap_core = { workspace = true }
+serde = { workspace = true }
+bincode =  { workspace = true }
 
 [features]
 std = []

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -8,11 +8,11 @@ extern crate std;
 #[allow(unused)]
 #[macro_use]
 extern crate alloc;
-use core::marker::PhantomData;
-
 use alloc::vec::Vec;
 use alloc::{collections::BTreeSet, string::String};
 use bincode::{de::read::Reader, enc::write::Writer, Decode, Encode};
+use core::marker::PhantomData;
+use frostsnap_core::bincode;
 use frostsnap_core::{
     message::{CoordinatorToDeviceMessage, DeviceToCoordinatorBody, DeviceToCoordindatorMessage},
     DeviceId,
@@ -37,14 +37,13 @@ pub enum DeviceReceiveSerial<D> {
 
 #[derive(Encode, Decode, Debug, Clone)]
 pub struct DeviceReceiveMessage {
-    #[bincode(with_serde)]
     pub target_destinations: BTreeSet<DeviceId>,
     pub message_body: DeviceReceiveBody,
 }
 
 #[derive(Encode, Decode, Debug, Clone)]
 pub enum DeviceReceiveBody {
-    Core(#[bincode(with_serde)] CoordinatorToDeviceMessage),
+    Core(CoordinatorToDeviceMessage),
     AnnounceAck { device_label: String },
 }
 
@@ -137,18 +136,13 @@ pub enum DeviceSendSerial<D> {
 
 #[derive(Encode, Decode, Debug, Clone)]
 pub enum DeviceSendMessage {
-    Core(#[bincode(with_serde)] DeviceToCoordindatorMessage),
-    Debug {
-        message: String,
-        #[bincode(with_serde)]
-        device: DeviceId,
-    },
+    Core(DeviceToCoordindatorMessage),
+    Debug { message: String, device: DeviceId },
     Announce(Announce),
 }
 
 #[derive(Encode, Decode, Debug, Clone)]
 pub struct Announce {
-    #[bincode(with_serde)]
     pub from: DeviceId,
 }
 

--- a/frostsnap_core/Cargo.toml
+++ b/frostsnap_core/Cargo.toml
@@ -7,12 +7,13 @@ edition = "2021"
 
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
-schnorr_fun = { version = "0.9.1", features = ["serde", "alloc"], default-features = false }
+schnorr_fun = { version = "0.9.1", features = ["bincode", "serde","alloc"], default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 sha2 = {  version = "0.10", default-features = false }
 chacha20 = { version = "0.9", default-features = false }
-serde = { version = "1", features = ["derive"], default-features = false }
+serde = { workspace = true }
 bitcoin = { version = "0.29", features = ["no-std", "serde"], default-features = false }
+bincode = { workspace = true }
 serde_json = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/frostsnap_core/src/encrypted_share.rs
+++ b/frostsnap_core/src/encrypted_share.rs
@@ -12,8 +12,7 @@ use sha2::{
 };
 
 use crate::DeviceId;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, bincode::Encode, bincode::Decode)]
 pub struct EncryptedShare {
     R: Point,
     e: [u8; 32],

--- a/frostsnap_core/src/lib.rs
+++ b/frostsnap_core/src/lib.rs
@@ -5,6 +5,8 @@
 #[macro_use]
 extern crate std;
 
+pub use bincode;
+
 pub mod encrypted_share;
 pub mod message;
 pub mod nostr;
@@ -24,6 +26,7 @@ use alloc::{
     vec::Vec,
 };
 
+use bincode::{Decode, Encode};
 use rand_chacha::ChaCha20Rng;
 use rand_core::RngCore;
 use schnorr_fun::{
@@ -32,6 +35,7 @@ use schnorr_fun::{
     musig::{Nonce, NonceKeyPair},
     nonce, Message,
 };
+use serde::{Deserialize, Serialize};
 use sha2::digest::Digest;
 use sha2::Sha256;
 
@@ -450,7 +454,7 @@ impl FrostCoordinator {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
 pub struct CoordinatorFrostKey {
     frost_key: FrostKey<Normal>,
     device_nonces: BTreeMap<DeviceId, DeviceNonces>,
@@ -504,14 +508,14 @@ impl CoordinatorState {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
 pub struct DeviceNonces {
     counter: usize,
     nonces: VecDeque<Nonce>,
 }
 
 #[derive(
-    Clone, Copy, Debug, PartialEq, Hash, Eq, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
+    Clone, Copy, Debug, PartialEq, Hash, Eq, Ord, PartialOrd, Encode, Decode, Serialize, Deserialize,
 )]
 pub struct DeviceId {
     pub pubkey: Point,
@@ -537,7 +541,7 @@ pub fn gen_pop_message(device_ids: impl IntoIterator<Item = DeviceId>) -> [u8; 3
     hasher.finalize().into()
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode)]
 pub struct FrostSigner {
     keypair: KeyPair,
     state: SignerState,
@@ -954,7 +958,7 @@ impl FrostSigner {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode)]
 pub enum SignerState {
     Registered,
     KeyGen {
@@ -985,7 +989,7 @@ impl SignerState {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode)]
 pub struct FrostsnapKey {
     /// The joint key
     pub frost_key: FrostKey<Normal>,

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -28,7 +28,7 @@ pub enum CoordinatorSend {
     ToStorage(CoordinatorToStorageMessage),
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode)]
 pub enum CoordinatorToDeviceMessage {
     DoKeyGen {
         devices: BTreeSet<DeviceId>,
@@ -74,13 +74,13 @@ pub enum CoordinatorToStorageMessage {
     UpdateState(CoordinatorFrostKey),
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode)]
 pub struct DeviceToCoordindatorMessage {
     pub from: DeviceId,
     pub body: DeviceToCoordinatorBody,
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode)]
 pub enum DeviceToCoordinatorBody {
     KeyGenResponse(KeyGenResponse),
     SignatureShare {
@@ -98,14 +98,14 @@ impl DeviceToCoordinatorBody {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode, Eq, PartialEq)]
 pub struct KeyGenProvideShares {
     pub my_poly: Vec<Point>,
     pub encrypted_shares: BTreeMap<DeviceId, EncryptedShare>,
     pub proof_of_possession: Signature,
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, bincode::Encode, bincode::Decode, Eq, PartialEq)]
 pub struct KeyGenResponse {
     pub encrypted_shares: KeyGenProvideShares,
     pub nonces: [Nonce; NONCE_BATCH_SIZE],
@@ -129,23 +129,21 @@ pub enum DeviceToStorageMessage {
     ExpendNonce,
 }
 
-#[derive(
-    Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd,
-)]
+#[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum SignTask {
-    Plain(Vec<u8>),                     // 1 nonce & sig
-    Nostr(crate::nostr::UnsignedEvent), // 1 nonce & sig
+    Plain(Vec<u8>),                                            // 1 nonce & sig
+    Nostr(#[bincode(with_serde)] crate::nostr::UnsignedEvent), // 1 nonce & sig
     Transaction {
+        #[bincode(with_serde)]
         tx_template: bitcoin::Transaction,
         prevouts: Vec<TxInput>,
     }, // N nonces and sigs
 }
 
-#[derive(
-    Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd,
-)]
+#[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct TxInput {
     /// The txout we're spending.
+    #[bincode(with_serde)]
     pub prevout: bitcoin::TxOut,
     /// The derivation path of our ket if it's ours
     pub bip32_path: Option<Vec<u32>>,


### PR DESCRIPTION
Stop #[bincode(with_serde)] in most places we can by upgrading to new version of `schnorr_fun`. This makes decoding and encoding more efficient in general.

Use workspace to manage dependencies a little better.

Some things still need both serde and bincode for now.