### PR TITLE
Serial Ring Buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "fugit",
  "mipidsi",
  "nb 1.1.0",
+ "ringbuffer",
  "smart-leds",
  "ssd1306",
 ]
@@ -1354,6 +1355,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "ringbuffer"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00cd23b78b7c0c29b99a7840f540c48def3cfd303024faf2f45d7b064e4cb930"
 
 [[package]]
 name = "riscv"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,33 +31,32 @@ checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -79,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -89,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "atomic-polyfill"
@@ -232,9 +231,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -268,9 +267,9 @@ checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
@@ -286,9 +285,12 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -319,20 +321,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstream",
  "anstyle",
@@ -342,21 +343,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "colorchoice"
@@ -412,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crypto-common"
@@ -447,7 +448,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.26",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -458,7 +459,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -523,7 +524,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "serde",
  "serde_json",
  "webpki",
@@ -542,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-graphics"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2a8e0250a7e1212828166b01eed0219e488ebb2599f44624a29c9bd249f397"
+checksum = "0649998afacf6d575d126d83e68b78c0ab0e00ca2ac7e9b3db11b4cbe8274ef0"
 dependencies = [
  "az",
  "byteorder",
@@ -591,9 +592,9 @@ checksum = "156d7a2fdd98ebbf9ae579cbceca3058cff946e13f8e17b90e3511db0508c723"
 
 [[package]]
 name = "embedded-text"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b827f4c84bfaa28714340de142ec3ba44520cef81f8d83ff20f513774b91f21e"
+checksum = "99d1ddf27f12261a5ee084537036819f15e05a9e6581d9c6b0f27d60a92e5797"
 dependencies = [
  "az",
  "embedded-graphics",
@@ -605,27 +606,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "esp-alloc"
@@ -653,7 +633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4498ddbbbf9a21e64f9269d2b4dd4059c34863ff54c702fb99e435f967767"
 dependencies = [
  "basic-toml",
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "cfg-if",
  "critical-section",
  "embedded-dma",
@@ -673,16 +653,16 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042d5a1ef0e01d6de045972779e4aced3a10e6170169a5cb2de7bef31802e28a"
+checksum = "d4cdf19581f9b0bb2b57b1549a2e639342825344b52f34048ddb29c46efa30de"
 dependencies = [
  "darling",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -912,12 +892,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,17 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,12 +1012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
-
-[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "micromath"
@@ -1103,7 +1060,8 @@ checksum = "39617bc909d64b068dcffd0e3e31679195b5576d0c83fadc52690268cc2b2b55"
 [[package]]
 name = "miniscript"
 version = "9.0.2"
-source = "git+https://github.com/apoelstra/rust-miniscript?rev=f1c12724d04b7ad28d25c866383a948cd493e698#f1c12724d04b7ad28d25c866383a948cd493e698"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b106477a0709e2da253e5559ba4ab20a272f8577f1eefff72f3a905b5d35f5"
 dependencies = [
  "bitcoin",
 ]
@@ -1138,14 +1096,13 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -1160,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -1205,9 +1162,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkg-config"
@@ -1266,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1305,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1317,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1328,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rgb"
@@ -1358,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cd23b78b7c0c29b99a7840f540c48def3cfd303024faf2f45d7b064e4cb930"
+checksum = "4eba9638e96ac5a324654f8d47fb71c5e21abef0f072740ed9c1d4b0801faa37"
 
 [[package]]
 name = "riscv"
@@ -1400,23 +1357,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
-dependencies = [
- "bitflags 2.3.3",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
  "ring",
@@ -1426,21 +1370,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.1",
+ "rustls-webpki 0.101.4",
  "sct",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
 dependencies = [
  "ring",
  "untrusted",
@@ -1448,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -1479,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -1554,29 +1498,29 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -1585,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353dc2cbfc67c9a14a89a1292a9d8e819bd51066b083e08c1974ba08e3f48c62"
+checksum = "c32634e2bd4311420caa504404a55fad2131292c485c97014cbed89a5899885f"
 dependencies = [
  "CoreFoundation-sys",
  "IOKit-sys",
@@ -1686,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "ssd1306"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1eaea5daefc39bfa675e4e75e484af7e54628ffe4fc5300e52bde5905f6b677"
+checksum = "5eff5d3218556bd92f998fce3f47dac6fc326bd416eae279d6e6e92d9b4d0d5d"
 dependencies = [
  "display-interface",
  "display-interface-i2c",
@@ -1702,12 +1646,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1756,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1767,22 +1705,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1847,7 +1785,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1898,7 +1836,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls 0.21.5",
+ "rustls 0.21.7",
  "sha1",
  "thiserror",
  "url",
@@ -1942,9 +1880,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2020,7 +1958,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.31",
  "wasm-bindgen-shared",
 ]
 
@@ -2042,7 +1980,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2065,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
  "ring",
  "untrusted",
@@ -2088,7 +2026,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki 0.100.1",
+ "rustls-webpki 0.100.2",
 ]
 
 [[package]]
@@ -2124,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2139,51 +2077,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.0"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ members = [
 resolver = "2"
 
 
-[patch.crates-io]
-miniscript = { version = "9", git = 'https://github.com/apoelstra/rust-miniscript', rev = "f1c12724d04b7ad28d25c866383a948cd493e698" }
-
 [workspace.dependencies]
 bincode = {  version = "2.0.0-rc.3", features = ["serde", "alloc", "derive"], default-features = false }
 serde = { version = "1", features = ["derive","alloc"], default-features = false }

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -30,7 +30,7 @@ critical-section = "1.1.1"
 nb = "1.1.0"
 fugit = "0.3.6"
 embedded-storage = "0.3.0"
-ringbuffer = { version = "0.14.1", default-features = false, features = ["alloc"] }
+ringbuffer = { version = "0.14.2", default-features = false, features = ["alloc"] }
 esp-storage = { version = "0.2.0", features = ["esp32c3"] }
 bincode = { workspace = true }
 

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -30,6 +30,7 @@ critical-section = "1.1.1"
 nb = "1.1.0"
 fugit = "0.3.6"
 embedded-storage = "0.3.0"
+ringbuffer = { version = "0.14.1", default-features = false, features = ["alloc"] }
 esp-storage = { version = "0.2.0", features = ["esp32c3"] }
 bincode = { workspace = true }
 

--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -14,7 +14,6 @@ use frostsnap_comms::{DeviceReceiveMessage, Downstream};
 use frostsnap_core::message::{
     CoordinatorToDeviceMessage, DeviceSend, DeviceToCoordinatorBody, DeviceToUserMessage,
 };
-use frostsnap_core::schnorr_fun::fun::hex;
 use frostsnap_core::schnorr_fun::fun::marker::Normal;
 use frostsnap_core::schnorr_fun::fun::KeyPair;
 use frostsnap_core::schnorr_fun::fun::Scalar;
@@ -101,8 +100,8 @@ where
             }
 
             if downstream_active {
-                while downstream_serial.poll_read() {
-                    match downstream_serial.receive_from_downstream() {
+                while let Some(device_send) = downstream_serial.receive_from_downstream() {
+                    match device_send {
                         Ok(device_send) => {
                             let forward_upstream = match device_send {
                                 DeviceSendSerial::MagicBytes(_) => {
@@ -179,10 +178,8 @@ where
                         ))
                     }
 
-                    while upstream_serial.poll_read() {
-                        let prior_to_read_buff = upstream_serial.clone_buffer_to_vec();
-
-                        match upstream_serial.receive_from_coordinator() {
+                    while let Some(received_message) = upstream_serial.receive_from_coordinator() {
+                        match received_message {
                             Ok(received_message) => {
                                 match received_message {
                                     DeviceReceiveSerial::MagicBytes(_) => {
@@ -262,11 +259,8 @@ where
                             }
                             Err(e) => {
                                 panic!(
-                                    "upstream read fail (got label: {}) {} ({}) {}",
+                                    "upstream read fail (got label: {}): {e}",
                                     ui.get_device_label().is_some(),
-                                    e,
-                                    prior_to_read_buff.len(),
-                                    hex::encode(&prior_to_read_buff)
                                 );
                             }
                         };

--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -180,7 +180,7 @@ where
                     }
 
                     while upstream_serial.poll_read() {
-                        let prior_to_read_buff = upstream_serial.read_buffer().to_vec();
+                        let prior_to_read_buff = upstream_serial.clone_buffer_to_vec();
 
                         match upstream_serial.receive_from_coordinator() {
                             Ok(received_message) => {

--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -108,9 +108,8 @@ where
                                     // soft reset downstream if it sends unexpected magic bytes so we restablish
                                     // downstream_active = false;
                                     DeviceSendMessage::Debug {
-                                        message: format!(
-                                            "downstream device sent unexpected magic bytes"
-                                        ),
+                                        message: "downstream device sent unexpected magic bytes"
+                                            .to_string(),
                                         device: frost_signer.device_id(),
                                     }
                                 }
@@ -197,7 +196,7 @@ where
                                             let _ = forwarding_message
                                                 .target_destinations
                                                 .remove(&frost_signer.device_id());
-                                            if forwarding_message.target_destinations.len() > 0 {
+                                            if !forwarding_message.target_destinations.is_empty() {
                                                 sends_downstream.push(forwarding_message);
                                             }
                                         }

--- a/device/src/io.rs
+++ b/device/src/io.rs
@@ -19,8 +19,6 @@ use frostsnap_comms::Direction;
 use frostsnap_comms::Downstream;
 use frostsnap_comms::MagicBytes;
 use frostsnap_comms::Upstream;
-use ringbuffer::RingBufferRead;
-use ringbuffer::RingBufferWrite;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 
 const RING_BUFFER_SIZE_LOG_2: usize = 8; // i.e. 256 bytes

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -5,7 +5,6 @@
 #[macro_use]
 extern crate std;
 
-#[allow(unused)]
 #[macro_use]
 extern crate alloc;
 use alloc::vec::Vec;
@@ -174,7 +173,6 @@ fn _make_progress_on_magic_bytes(
     magic_bytes: &[u8],
     mut progress: usize,
 ) -> (usize, bool) {
-
     for byte in remaining {
         if byte == magic_bytes[progress] {
             progress += 1;
@@ -196,7 +194,11 @@ pub fn find_and_remove_magic_bytes<D: Direction>(buff: &mut Vec<u8>) -> bool {
 
 fn _find_and_remove_magic_bytes(buff: &mut Vec<u8>, magic_bytes: &[u8]) -> bool {
     let mut consumed = 0;
-    let (_, found) = _make_progress_on_magic_bytes(buff.iter().cloned().inspect(|_| consumed += 1), magic_bytes, 0);
+    let (_, found) = _make_progress_on_magic_bytes(
+        buff.iter().cloned().inspect(|_| consumed += 1),
+        magic_bytes,
+        0,
+    );
 
     if found {
         *buff = buff.split_off(consumed);

--- a/frostsnap_coordinator/src/serial_port.rs
+++ b/frostsnap_coordinator/src/serial_port.rs
@@ -40,12 +40,13 @@ impl<S: Serial> FramedSerialPort<S> {
             return Ok(false);
         }
         self.inner.fill_buf()?;
-        let (consume, progress, found) = frostsnap_comms::make_progress_on_magic_bytes::<Downstream>(
-            self.inner.buffer(),
+        let mut consumed = 0;
+        let (progress, found) = frostsnap_comms::make_progress_on_magic_bytes::<Downstream>(
+            self.inner.buffer().iter().cloned().inspect(|_| consumed += 1),
             self.magic_bytes_progress,
         );
+        self.inner.consume(consumed);
         self.magic_bytes_progress = progress;
-        self.inner.consume(consume);
         Ok(found)
     }
 

--- a/frostsnap_coordinator/src/serial_port.rs
+++ b/frostsnap_coordinator/src/serial_port.rs
@@ -42,7 +42,11 @@ impl<S: Serial> FramedSerialPort<S> {
         self.inner.fill_buf()?;
         let mut consumed = 0;
         let (progress, found) = frostsnap_comms::make_progress_on_magic_bytes::<Downstream>(
-            self.inner.buffer().iter().cloned().inspect(|_| consumed += 1),
+            self.inner
+                .buffer()
+                .iter()
+                .cloned()
+                .inspect(|_| consumed += 1),
             self.magic_bytes_progress,
         );
         self.inner.consume(consumed);

--- a/frostsnap_core/src/encrypted_share.rs
+++ b/frostsnap_core/src/encrypted_share.rs
@@ -52,12 +52,12 @@ impl crate::KeyGenProvideShares {
     ) -> Self {
         let pop_message = crate::gen_pop_message(devices.clone());
         let proof_of_possession =
-            frost.create_proof_of_possession(&my_poly, schnorr_fun::Message::raw(&pop_message));
+            frost.create_proof_of_possession(my_poly, schnorr_fun::Message::raw(&pop_message));
 
         let encrypted_shares = devices
             .iter()
             .map(|&device| {
-                let share = frost.create_share(&my_poly, device.to_poly_index());
+                let share = frost.create_share(my_poly, device.to_poly_index());
                 (
                     device,
                     EncryptedShare::new(device.pubkey, secure_rng, &share),
@@ -66,7 +66,7 @@ impl crate::KeyGenProvideShares {
             .collect();
 
         Self {
-            my_poly: schnorr_fun::frost::to_point_poly(&my_poly),
+            my_poly: schnorr_fun::frost::to_point_poly(my_poly),
             proof_of_possession,
             encrypted_shares,
         }

--- a/frostsnap_core/src/lib.rs
+++ b/frostsnap_core/src/lib.rs
@@ -1,10 +1,8 @@
 #![no_std]
 
 #[cfg(feature = "std")]
-#[allow(unused)]
 #[macro_use]
 extern crate std;
-use bincode;
 pub mod encrypted_share;
 pub mod message;
 pub mod nostr;
@@ -37,7 +35,7 @@ use serde::{Deserialize, Serialize};
 use sha2::digest::Digest;
 use sha2::Sha256;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FrostCoordinator {
     state: CoordinatorState,
 }
@@ -190,10 +188,9 @@ impl FrostCoordinator {
                     {
                         let session = &mut session_progress.sign_session;
                         let xonly_frost_key = &session_progress.key;
-                        if session
+                        if !session
                             .participants()
-                            .find(|x_coord| *x_coord == message.from.to_poly_index())
-                            .is_none()
+                            .any(|x_coord| x_coord == message.from.to_poly_index())
                         {
                             return Err(Error::coordinator_invalid_message(
                                 &message,
@@ -221,7 +218,7 @@ impl FrostCoordinator {
                         }
                     }
 
-                    nonce_for_device.nonces.extend(new_nonces.into_iter());
+                    nonce_for_device.nonces.extend(new_nonces.iter());
 
                     let mut outgoing = vec![CoordinatorSend::ToStorage(
                         CoordinatorToStorageMessage::UpdateState(key.clone()),
@@ -296,20 +293,18 @@ impl FrostCoordinator {
 
     pub fn keygen_ack(&mut self, ack: bool) -> Result<Vec<CoordinatorSend>, ActionError> {
         match &mut self.state {
-            CoordinatorState::FrostKey { awaiting_user, key } if *awaiting_user == true => {
-                match ack {
-                    true => {
-                        *awaiting_user = false;
-                        Ok(vec![CoordinatorSend::ToStorage(
-                            CoordinatorToStorageMessage::UpdateState(key.clone()),
-                        )])
-                    }
-                    false => {
-                        self.state = CoordinatorState::Registration;
-                        Ok(vec![])
-                    }
+            CoordinatorState::FrostKey { awaiting_user, key } if *awaiting_user => match ack {
+                true => {
+                    *awaiting_user = false;
+                    Ok(vec![CoordinatorSend::ToStorage(
+                        CoordinatorToStorageMessage::UpdateState(key.clone()),
+                    )])
                 }
-            }
+                false => {
+                    self.state = CoordinatorState::Registration;
+                    Ok(vec![])
+                }
+            },
             _ => Err(ActionError::WrongState {
                 in_state: self.state.name(),
                 action: "keygen_ack",
@@ -495,6 +490,12 @@ pub struct SignSessionProgress {
     key: FrostKey<EvenY>,
 }
 
+impl Default for CoordinatorState {
+    fn default() -> Self {
+        Self::Registration
+    }
+}
+
 impl CoordinatorState {
     pub fn name(&self) -> &'static str {
         match self {
@@ -534,7 +535,7 @@ impl DeviceId {
 pub fn gen_pop_message(device_ids: impl IntoIterator<Item = DeviceId>) -> [u8; 32] {
     let mut hasher = Sha256::default().tag(b"frostsnap/pop");
     for id in device_ids {
-        hasher.update(&id.pubkey.to_bytes());
+        hasher.update(id.pubkey.to_bytes());
     }
     hasher.finalize().into()
 }
@@ -685,11 +686,12 @@ impl FrostSigner {
                 if point_polys
                     .get(&self.device_id().to_poly_index())
                     .expect("we have a point poly in this finish keygen")
-                    != &frost::to_point_poly(&scalar_poly)
+                    != &frost::to_point_poly(scalar_poly)
                 {
                     return Err(Error::signer_invalid_message(
                         &message,
-                        format!("Coordinator told us we are using a different point poly than we expected"),
+                        "Coordinator told us we are using a different point poly than we expected"
+                            .to_string(),
                     ));
                 }
 
@@ -728,7 +730,7 @@ impl FrostSigner {
                 let my_shares = transpose_shares
                     .get(&self.device_id())
                     .expect("this device is part of the keygen")
-                    .into_iter()
+                    .iter()
                     .map(|(provider_id, (encrypted_secret_share, pop))| {
                         (
                             provider_id.to_poly_index(),
@@ -823,7 +825,7 @@ impl FrostSigner {
 
     pub fn keygen_ack(&mut self, ack: bool) -> Result<Vec<DeviceSend>, ActionError> {
         match &mut self.state {
-            SignerState::FrostKey { awaiting_ack, .. } if *awaiting_ack == true => {
+            SignerState::FrostKey { awaiting_ack, .. } if *awaiting_ack => {
                 if ack {
                     *awaiting_ack = false;
                     Ok(vec![DeviceSend::ToStorage(
@@ -870,7 +872,7 @@ impl FrostSigner {
                     sign_items.iter().zip(secret_nonces).enumerate()
                 {
                     let nonces_at_index = nonces
-                        .into_iter()
+                        .iter()
                         .map(|(id, (nonces, _, _))| (id.to_poly_index(), nonces[nonce_index]))
                         .collect();
 

--- a/frostsnap_core/src/lib.rs
+++ b/frostsnap_core/src/lib.rs
@@ -16,6 +16,7 @@ extern crate alloc;
 
 use crate::message::*;
 use alloc::{
+    boxed::Box,
     collections::{BTreeMap, BTreeSet, VecDeque},
     string::String,
     string::ToString,
@@ -653,7 +654,7 @@ impl FrostSigner {
 
                         body: DeviceToCoordinatorBody::KeyGenResponse(KeyGenResponse {
                             encrypted_shares,
-                            nonces,
+                            nonces: Box::new(nonces),
                         }),
                     },
                 )])

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -206,7 +206,7 @@ impl SignTask {
                     let sighash = sighash_cache
                         .taproot_key_spend_signature_hash(
                             i,
-                            &bitcoin::psbt::Prevouts::All(&prevouts),
+                            &bitcoin::psbt::Prevouts::All(prevouts),
                             schnorr_sighashty,
                         )
                         .unwrap(); // TODO remove unwrap

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -3,6 +3,7 @@ use crate::CoordinatorFrostKey;
 use crate::Vec;
 use crate::NONCE_BATCH_SIZE;
 
+use alloc::boxed::Box;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
 use schnorr_fun::fun::marker::Public;
@@ -108,7 +109,7 @@ pub struct KeyGenProvideShares {
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, Eq, PartialEq)]
 pub struct KeyGenResponse {
     pub encrypted_shares: KeyGenProvideShares,
-    pub nonces: [Nonce; NONCE_BATCH_SIZE],
+    pub nonces: Box<[Nonce; NONCE_BATCH_SIZE]>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Fixes allocation failures https://github.com/frostsnap/frostsnap/issues/58 , I haven't got any after signing many times (5+, 4-of-4) in a row with similar timed presses.

Things feel much faster in general.

Marking draft because
- ~[ ] `upstream_buffer_uart` and `upstream_buffer_jtag` could be from the same buffer.~
- [x] I took the consuming outside of `find_and_remove_magic_bytes` because i'm keeping track of `buffer_filled` and rotating outside. Edit: just renamed functions
- [x] Broke magic bytes tests
- [x] Sometimes the end device (of 4) is failing to register
- [x] Get rid of RingBuffer `Vec`s. Edit: i think i got rid of all the vecs that I can? Only remaining vec is the peek for magic bytes