### PR TITLE
DownstreamDisconnect message

### DIFF
--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -12,7 +12,8 @@ use frostsnap_comms::{
 };
 use frostsnap_comms::{DeviceReceiveMessage, Downstream};
 use frostsnap_core::message::{
-    CoordinatorToDeviceMessage, DeviceSend, DeviceToCoordinatorBody, DeviceToUserMessage,
+    CoordinatorToDeviceMessage, DeviceSend, DeviceToCoordinatorBody, DeviceToCoordindatorMessage,
+    DeviceToUserMessage,
 };
 use frostsnap_core::schnorr_fun::fun::marker::Normal;
 use frostsnap_core::schnorr_fun::fun::KeyPair;
@@ -130,6 +131,12 @@ where
                                 message: format!("Failed to decode on downstream port: {e}"),
                                 device: frost_signer.device_id(),
                             });
+                            sends_upstream.push(DeviceSendMessage::Core(
+                                DeviceToCoordindatorMessage {
+                                    from: frost_signer.device_id(),
+                                    body: DeviceToCoordinatorBody::DownstreamDisconnect,
+                                },
+                            ));
                             downstream_active = false;
                             ui.set_downstream_connection_state(false);
                         }

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -138,6 +138,7 @@ impl<D> DeviceSendSerial<D> {
                 DeviceSendMessage::Core(message) => match message.body {
                     DeviceToCoordinatorBody::KeyGenResponse(_) => "KeyGenResponse",
                     DeviceToCoordinatorBody::SignatureShare { .. } => "SignatureShare",
+                    DeviceToCoordinatorBody::DownstreamDisconnect => "DownstreamDisconnect",
                 },
                 DeviceSendMessage::Debug { .. } => "Debug",
                 DeviceSendMessage::Announce(_) => "Announce",

--- a/frostsnap_core/src/lib.rs
+++ b/frostsnap_core/src/lib.rs
@@ -157,6 +157,10 @@ impl FrostCoordinator {
                         }
                     }
                 }
+                DeviceToCoordinatorBody::DownstreamDisconnect => {
+                    // For now, take no action with the hope that the device is reconnected
+                    Ok(vec![])
+                }
                 _ => Err(Error::coordinator_message_kind(&self.state, &message)),
             },
             CoordinatorState::Signing { key, sessions } => match &message.body {
@@ -257,6 +261,10 @@ impl FrostCoordinator {
                     }
 
                     Ok(outgoing)
+                }
+                DeviceToCoordinatorBody::DownstreamDisconnect => {
+                    // For now, take no action with the hope that the device is reconnected
+                    Ok(vec![])
                 }
                 _ => Err(Error::coordinator_message_kind(&self.state, &message)),
             },

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -88,6 +88,7 @@ pub enum DeviceToCoordinatorBody {
         signature_shares: Vec<Scalar<Public, Zero>>,
         new_nonces: Vec<Nonce>,
     },
+    DownstreamDisconnect,
 }
 
 impl DeviceToCoordinatorBody {
@@ -95,6 +96,7 @@ impl DeviceToCoordinatorBody {
         match self {
             DeviceToCoordinatorBody::KeyGenResponse(_) => "KeyGenProvideShares",
             DeviceToCoordinatorBody::SignatureShare { .. } => "SignatureShare",
+            DeviceToCoordinatorBody::DownstreamDisconnect => "DownstreamDisconnect",
         }
     }
 }


### PR DESCRIPTION
A start on implementing https://github.com/frostsnap/frostsnap/issues/86

Currently the device has no knowledge of the device_id connected immediately downstream. Perhaps we can get this through ordering of messages which are received. I.e. first "Announce" gets stored to the variable

```
downstream_connected = Some(device_id)
```
instead of `true/false`.

We also need to decide how to handle these messages when the coordinator receives these messages during keygen or signing.