### PR TITLE
Typed error variants for signer and coordinator

### DIFF
--- a/frostsnap_core/tests/malicious.rs
+++ b/frostsnap_core/tests/malicious.rs
@@ -31,6 +31,6 @@ fn keygen_maliciously_replace_public_poly() {
     });
     assert!(matches!(
         result,
-        Err(frostsnap_core::SignerError::InvalidMessage { .. })
+        Err(frostsnap_core::SignerError::ToldWrongPoly)
     ))
 }

--- a/frostsnap_core/tests/malicious.rs
+++ b/frostsnap_core/tests/malicious.rs
@@ -31,6 +31,6 @@ fn keygen_maliciously_replace_public_poly() {
     });
     assert!(matches!(
         result,
-        Err(frostsnap_core::Error::InvalidMessage { .. })
+        Err(frostsnap_core::SignerError::InvalidMessage { .. })
     ))
 }


### PR DESCRIPTION
Implements https://github.com/frostsnap/frostsnap/issues/13

There is a little bit more code but I think it makes sense to separate coordinator and signer errors.

Types will allow for any appropriate error handling on device, as well as more resilient testing (in place of matching on generic errors or error string content).

I have left the `MessageKind` error as is.
