### PR TITLE
Small share indicies

### DIFF
--- a/coordinator-cli/src/main.rs
+++ b/coordinator-cli/src/main.rs
@@ -87,12 +87,13 @@ fn process_outbox(
 ) -> anyhow::Result<()> {
     while let Some(message) = outbox.pop_front() {
         match message {
-            CoordinatorSend::ToDevice(core_message) => {
+            CoordinatorSend::ToDevice {
+                message,
+                destinations,
+            } => {
                 ports.usb_sender().send(CoordinatorSendMessage {
-                    target_destinations: Destination::Particular(
-                        core_message.default_destinations(),
-                    ),
-                    message_body: CoordinatorSendBody::Core(core_message),
+                    target_destinations: Destination::from(destinations),
+                    message_body: CoordinatorSendBody::Core(message),
                 });
             }
             CoordinatorSend::ToUser(to_user_message) => match to_user_message {

--- a/coordinator-cli/src/signer.rs
+++ b/coordinator-cli/src/signer.rs
@@ -85,7 +85,10 @@ impl<'a, 'b> Signer<'a, 'b> {
             .coordinator
             .start_sign(message, chosen_signers.clone())?;
 
-        let mut dispatcher = SigningDispatcher::from_filter_out_start_sign(&mut sign_request_sends);
+        let mut dispatcher = SigningDispatcher::from_filter_out_start_sign(
+            &mut sign_request_sends,
+            chosen_signers.clone(),
+        );
 
         for device in self.ports.registered_devices() {
             dispatcher.connected(*device);

--- a/frostsnap_coordinator/src/signing.rs
+++ b/frostsnap_coordinator/src/signing.rs
@@ -32,9 +32,10 @@ impl SigningDispatcher {
             .iter()
             .enumerate()
             .find_map(|(i, m)| match m {
-                CoordinatorSend::ToDevice(CoordinatorToDeviceMessage::RequestSign(request)) => {
-                    Some((i, request.clone()))
-                }
+                CoordinatorSend::ToDevice {
+                    message: CoordinatorToDeviceMessage::RequestSign(request),
+                    ..
+                } => Some((i, request.clone())),
                 _ => None,
             })
             .expect("must have a sign request");
@@ -86,10 +87,8 @@ impl SigningDispatcher {
 
     pub fn resend_sign_request(&mut self) -> Option<CoordinatorSendMessage> {
         if !self.need_to_send_to.is_empty() {
-            let target_destinations = Destination::from(self.need_to_send_to.clone());
-            self.need_to_send_to = BTreeSet::new();
             return Some(CoordinatorSendMessage {
-                target_destinations,
+                target_destinations: Destination::from(core::mem::take(&mut self.need_to_send_to)),
                 message_body: CoordinatorSendBody::Core(CoordinatorToDeviceMessage::RequestSign(
                     self.request.clone(),
                 )),

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -64,6 +64,7 @@ pub enum CoordinatorState {
 
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode)]
 pub struct SigningSessionState {
+    pub targets: BTreeSet<DeviceId>,
     pub sessions: Vec<SignSessionProgress>,
     pub request: SignRequest,
 }
@@ -78,13 +79,13 @@ impl SigningSessionState {
 #[derive(Clone, Debug)]
 pub enum KeyGenState {
     WaitingForResponses {
-        devices: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
+        device_to_share_index: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
         responses: BTreeMap<DeviceId, Option<KeyGenResponse>>,
         threshold: usize,
     },
     WaitingForAcks {
         frost_key: FrostKey<Normal>,
-        devices: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
+        device_to_share_index: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
         device_nonces: BTreeMap<DeviceId, DeviceNonces>,
         acks: BTreeMap<DeviceId, bool>,
         session_hash: SessionHash,
@@ -100,7 +101,7 @@ pub struct DeviceNonces {
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, serde::Serialize, serde::Deserialize)]
 pub struct CoordinatorFrostKeyState {
     frost_key: FrostKey<Normal>,
-    devices: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
+    device_to_share_index: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
     device_nonces: BTreeMap<DeviceId, DeviceNonces>,
 }
 
@@ -155,7 +156,7 @@ impl FrostCoordinator {
             }
             CoordinatorState::KeyGen(keygen_state) => match keygen_state {
                 KeyGenState::WaitingForResponses {
-                    devices,
+                    device_to_share_index,
                     responses,
                     threshold,
                 } => {
@@ -193,7 +194,7 @@ impl FrostCoordinator {
                                         .iter()
                                         .map(|(device_id, response)| {
                                             (
-                                                *devices
+                                                *device_to_share_index
                                                     .get(device_id)
                                                     .expect("this device is a part of keygen"),
                                                 response.encrypted_shares.my_poly.clone(),
@@ -204,7 +205,7 @@ impl FrostCoordinator {
                                         .iter()
                                         .map(|(device_id, response)| {
                                             (
-                                                *devices
+                                                *device_to_share_index
                                                     .get(device_id)
                                                     .expect("this device is a part of keygen"),
                                                 response
@@ -244,7 +245,7 @@ impl FrostCoordinator {
 
                                     self.state =
                                         CoordinatorState::KeyGen(KeyGenState::WaitingForAcks {
-                                            devices: devices.clone(),
+                                            device_to_share_index: device_to_share_index.clone(),
                                             frost_key,
                                             device_nonces,
                                             acks: responses
@@ -283,7 +284,7 @@ impl FrostCoordinator {
                     }
                 }
                 KeyGenState::WaitingForAcks {
-                    devices,
+                    device_to_share_index,
                     frost_key,
                     device_nonces,
                     acks,
@@ -319,7 +320,7 @@ impl FrostCoordinator {
                         if all_acks {
                             let key = CoordinatorFrostKeyState {
                                 frost_key: frost_key.clone(),
-                                devices: devices.clone(),
+                                device_to_share_index: device_to_share_index.clone(),
                                 device_nonces: device_nonces.clone(),
                             };
                             let key_id = key.frost_key.key_id();
@@ -348,8 +349,10 @@ impl FrostCoordinator {
                     let frost = frost::new_without_nonce_generation::<Sha256>();
                     let mut outgoing = vec![];
 
-                    let from_share_index =
-                        key.devices.get(&from).expect("we don't know this device");
+                    let from_share_index = key
+                        .device_to_share_index
+                        .get(&from)
+                        .expect("we don't know this device");
 
                     let nonce_for_device = key.device_nonces.get_mut(&from).ok_or(
                         Error::coordinator_invalid_message(&message, "Signer is unknown"),
@@ -478,7 +481,7 @@ impl FrostCoordinator {
         }
         match self.state {
             CoordinatorState::Registration => {
-                let device_indexes: BTreeMap<_, _> = devices
+                let device_to_share_index: BTreeMap<_, _> = devices
                     .iter()
                     .enumerate()
                     .map(|(index, device_id)| {
@@ -490,13 +493,13 @@ impl FrostCoordinator {
                     .collect();
 
                 self.state = CoordinatorState::KeyGen(KeyGenState::WaitingForResponses {
-                    devices: device_indexes.clone(),
+                    device_to_share_index: device_to_share_index.clone(),
                     responses: devices.iter().map(|&device_id| (device_id, None)).collect(),
                     threshold,
                 });
 
                 Ok(CoordinatorToDeviceMessage::DoKeyGen {
-                    devices: device_indexes,
+                    device_to_share_index,
                     threshold,
                 })
             }
@@ -526,12 +529,13 @@ impl FrostCoordinator {
                 let n_signatures = sign_items.len();
 
                 let signing_nonces = signing_parties
-                    .into_iter()
+                    .iter()
                     .map(|device_id| {
-                        let nonces_for_device = key
-                            .device_nonces
-                            .get_mut(&device_id)
-                            .ok_or(StartSignError::UnknownDevice { device_id })?;
+                        let nonces_for_device = key.device_nonces.get_mut(device_id).ok_or(
+                            StartSignError::UnknownDevice {
+                                device_id: *device_id,
+                            },
+                        )?;
                         let index_of_first_nonce = nonces_for_device.counter;
                         let index_of_last_nonce =
                             index_of_first_nonce + nonces_for_device.nonces.len();
@@ -543,7 +547,7 @@ impl FrostCoordinator {
                             .collect::<Vec<_>>();
                         if nonces.len() < n_signatures {
                             return Err(StartSignError::NotEnoughNoncesForDevice {
-                                device_id,
+                                device_id: *device_id,
                                 have: nonces.len(),
                                 need: n_signatures,
                             });
@@ -553,7 +557,9 @@ impl FrostCoordinator {
                         nonces_for_device.counter += n_signatures;
 
                         Ok((
-                            device_id,
+                            *key.device_to_share_index
+                                .get(device_id)
+                                .expect("we must know about this device"),
                             (nonces, index_of_first_nonce, index_of_last_nonce),
                         ))
                     })
@@ -568,12 +574,7 @@ impl FrostCoordinator {
                         let b_message = Message::raw(&sign_item.message[..]);
                         let indexed_nonces = signing_nonces
                             .iter()
-                            .map(|(id, (nonce, _, _))| {
-                                (
-                                    *key.devices.get(id).expect("we must know about this device"),
-                                    nonce[i],
-                                )
-                            })
+                            .map(|(index, (nonce, _, _))| (*index, nonce[i]))
                             .collect();
 
                         let xonly_frost_key = sign_item.derive_key(key.frost_key());
@@ -590,12 +591,14 @@ impl FrostCoordinator {
 
                 let key = key.clone();
                 let sign_request = SignRequest {
+                    targets: signing_parties.clone(),
                     sign_task,
                     nonces: signing_nonces.clone(),
                 };
                 self.state = CoordinatorState::Signing {
                     key: key.clone(),
                     sign_state: SigningSessionState {
+                        targets: signing_parties,
                         sessions,
                         request: sign_request.clone(),
                     },

--- a/frostsnap_core/src/lib.rs
+++ b/frostsnap_core/src/lib.rs
@@ -9,6 +9,7 @@ mod macros;
 pub mod message;
 pub mod nostr;
 pub mod xpub;
+
 pub use bincode;
 pub use key_id::*;
 pub use serde;
@@ -23,7 +24,7 @@ extern crate alloc;
 
 use crate::message::*;
 use alloc::{string::String, string::ToString, vec::Vec};
-use schnorr_fun::fun::{hex, marker::*, Point, Scalar, Tag};
+use schnorr_fun::fun::{hex, Point, Tag};
 use sha2::digest::Digest;
 use sha2::Sha256;
 
@@ -48,10 +49,6 @@ impl_fromstr_deserialize! {
 }
 
 impl DeviceId {
-    pub fn to_poly_index(&self) -> Scalar<Public> {
-        Scalar::from_hash(Sha256::default().chain_update(self.0)).public()
-    }
-
     pub fn new(point: Point) -> Self {
         Self(point.to_bytes())
     }

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -32,7 +32,10 @@ pub enum DeviceSend {
 
 #[derive(Clone, Debug)]
 pub enum CoordinatorSend {
-    ToDevice(CoordinatorToDeviceMessage),
+    ToDevice {
+        message: CoordinatorToDeviceMessage,
+        destinations: BTreeSet<DeviceId>,
+    },
     ToUser(CoordinatorToUserMessage),
     ToStorage(CoordinatorToStorageMessage),
 }
@@ -55,7 +58,6 @@ pub struct SignRequest {
     // mechanism
     pub nonces: BTreeMap<Scalar<Public, NonZero>, (Vec<Nonce>, usize, usize)>,
     pub sign_task: SignTask,
-    pub targets: BTreeSet<DeviceId>,
 }
 
 impl SignRequest {
@@ -71,21 +73,6 @@ impl SignRequest {
 impl Gist for CoordinatorToDeviceMessage {
     fn gist(&self) -> String {
         self.kind().into()
-    }
-}
-
-impl CoordinatorToDeviceMessage {
-    pub fn default_destinations(&self) -> BTreeSet<DeviceId> {
-        match self {
-            CoordinatorToDeviceMessage::DoKeyGen {
-                device_to_share_index,
-                ..
-            } => device_to_share_index.keys().cloned().collect(),
-            CoordinatorToDeviceMessage::FinishKeyGen { shares_provided } => {
-                shares_provided.keys().cloned().collect()
-            }
-            CoordinatorToDeviceMessage::RequestSign(SignRequest { targets, .. }) => targets.clone(),
-        }
     }
 }
 

--- a/frostsnap_core/tests/endtoend.rs
+++ b/frostsnap_core/tests/endtoend.rs
@@ -1,6 +1,6 @@
 use frostsnap_core::message::{
-    CoordinatorToUserKeyGenMessage, CoordinatorToUserMessage, CoordinatorToUserSigningMessage,
-    DeviceToUserMessage, EncodedSignature, SignTask,
+    CoordinatorSend, CoordinatorToUserKeyGenMessage, CoordinatorToUserMessage,
+    CoordinatorToUserSigningMessage, DeviceToUserMessage, EncodedSignature, SignTask,
 };
 use frostsnap_core::{
     CoordinatorState, DeviceId, FrostCoordinator, FrostSigner, KeyId, SessionHash,
@@ -119,7 +119,14 @@ fn test_end_to_end() {
     let mut run = Run::new(coordinator, devices);
 
     let keygen_init = vec![run.coordinator.do_keygen(&device_set, threshold).unwrap()];
-    run.extend(keygen_init);
+    let sends_with_destination: Vec<_> = keygen_init
+        .into_iter()
+        .map(|message| CoordinatorSend::ToDevice {
+            message,
+            destinations: device_set.clone(),
+        })
+        .collect();
+    run.extend(sends_with_destination);
 
     let mut env = TestEnv::default();
     run.run_until_finished(&mut env);

--- a/frostsnap_core/tests/malicious.rs
+++ b/frostsnap_core/tests/malicious.rs
@@ -6,7 +6,8 @@ use frostsnap_core::{DeviceId, FrostCoordinator, FrostSigner};
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use schnorr_fun::frost;
-use std::collections::BTreeSet;
+use schnorr_fun::fun::Scalar;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::common::{Env, Run, Send};
 mod common;
@@ -19,6 +20,11 @@ fn keygen_maliciously_replace_public_poly() {
     let mut test_rng = ChaCha20Rng::from_seed([42u8; 32]);
     let mut device = FrostSigner::new_random(&mut test_rng);
     let devices = BTreeSet::from_iter([device.device_id()]);
+    let devices: BTreeMap<_, _> = devices
+        .into_iter()
+        .enumerate()
+        .map(|(index, id)| (id, Scalar::from((index + 1) as u32).non_zero().unwrap()))
+        .collect();
     let _ = device
         .recv_coordinator_message(CoordinatorToDeviceMessage::DoKeyGen {
             devices: devices.clone(),

--- a/frostsnapp/native/src/coordinator.rs
+++ b/frostsnapp/native/src/coordinator.rs
@@ -189,10 +189,13 @@ impl FfiCoordinator {
 
                 while let Some(message) = coordinator_outbox.pop_front() {
                     match message {
-                        CoordinatorSend::ToDevice(msg) => {
+                        CoordinatorSend::ToDevice {
+                            message,
+                            destinations,
+                        } => {
                             let send_message = CoordinatorSendMessage {
-                                target_destinations: Destination::from(msg.default_destinations()),
-                                message_body: CoordinatorSendBody::Core(msg),
+                                target_destinations: Destination::from(destinations),
+                                message_body: CoordinatorSendBody::Core(message),
                             };
 
                             usb_sender.send(send_message);
@@ -322,7 +325,10 @@ impl FfiCoordinator {
             *coordinator = FrostCoordinator::default();
             coordinator.do_keygen(&devices, threshold).unwrap()
         };
-        let keygen_message = CoordinatorSend::ToDevice(keygen_message);
+        let keygen_message = CoordinatorSend::ToDevice {
+            destinations: devices,
+            message: keygen_message,
+        };
         self.pending_for_outbox
             .lock()
             .unwrap()


### PR DESCRIPTION
Currently we use a hash of the DeviceId to determine the scalar party index.
But we want to use small simple indices (`1,2,3,...`) to achieve significantly smaller backups (1 bech32m character vs 52 characters).

This PR is WIP exploration of having the coordinators decide these party indexes during keygen.

Signers will need to remember their share index (inside `FrostsnapKey`).

Coordinators will want to remember `BTreeMap<DeviceId, ShareIndex>`