### PR TITLE
[core] non-deterministic keygen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "fugit",
  "mipidsi",
  "nb 1.1.0",
+ "rand_chacha",
  "smart-leds",
  "ssd1306",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ frostsnap_comms = { path = "frostsnap_comms", default-features = false }
 frostsnap_coordinator = { path = "frostsnap_coordinator" }
 tracing = { version = "0.1" }
 llsdb = { git = "https://github.com/LLFourn/llsdb.git" }
+rand_chacha = { version = "0.3", default-features = false }

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -47,6 +47,7 @@ esp-hal-smartled = { version = "0.6.0", features = [
     "esp32c3",
 ], optional = true }
 smart-leds = { version = "0.3.0", optional = true }
+rand_chacha = { workspace = true }
 
 [[bin]]
 name = "frostypede"

--- a/device/src/bin/frostypede.rs
+++ b/device/src/bin/frostypede.rs
@@ -166,7 +166,7 @@ fn main() -> ! {
         upstream_jtag,
         upstream_uart,
         downstream_uart,
-        rng,
+        seed_rng: rng,
         ui,
         timer: timer0,
         downstream_detect,

--- a/frostsnap_core/Cargo.toml
+++ b/frostsnap_core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 schnorr_fun = { version = "0.9.2", features = ["bincode", "serde","alloc"], default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
+rand_chacha = { workspace = true }
 sha2 = {  version = "0.10", default-features = false }
 chacha20 = { version = "0.9", default-features = false }
 serde = { workspace = true }


### PR DESCRIPTION
A `Hal::Rng` `seed_rng` seeds a `ChaCha20Rng` which is passed into `recv_coordinator_message()`.

We also use this rng to seed the `aux_rand`, stored and used for nonce generation (note: we discussed we might later change this seed to some pubkey/HMAC from coordinator).



