### PR TITLE
Upgrade esp-hal v0.16.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           tar -zxf riscv32-elf-ubuntu-22.04-nightly-2023.05.24-nightly.tar.gz
           echo "PATH=$PATH:${GITHUB_WORKSPACE}/device/riscv/bin" >> $GITHUB_ENV
           ls ${GITHUB_WORKSPACE}/device/riscv/bin
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: riscv32imc-unknown-none-elf
           components: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bare-metal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +325,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "core-isa-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ec98e54b735872e54b2335c2e5a5c7fa7d9c3bfd45500f75280f84089a0083"
+dependencies = [
+ "anyhow",
+ "enum-as-inner",
+ "regex",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
 name = "core2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,7 +392,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.51",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -384,7 +403,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -462,46 +481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-executor"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec648daedd2143466eff4b3e8002024f9f6c1de4ab7666bb679688752624c925"
-dependencies = [
- "critical-section",
- "document-features",
- "embassy-executor-macros",
- "embassy-time-driver",
- "embassy-time-queue-driver",
-]
-
-[[package]]
-name = "embassy-executor-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad454accf80050e9cf7a51e994132ba0e56286b31f9317b68703897c328c59b5"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.51",
-]
-
-[[package]]
-name = "embassy-time-driver"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
-dependencies = [
- "document-features",
-]
-
-[[package]]
-name = "embassy-time-queue-driver"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
-
-[[package]]
 name = "embedded-dma"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +556,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "enumset"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,7 +585,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -614,69 +605,77 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-hal-common"
-version = "0.15.0"
+name = "esp-hal"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c468eb364cc570da74dfb8adfda9f308c34259fcd19a4c695a46554a26b7478a"
+checksum = "cc3e9b3333d2ae42f5c9b4890e162cb756fb1b067ab5f642b89fc9f29be424fa"
 dependencies = [
  "basic-toml",
  "bitfield",
  "bitflags 2.4.2",
  "cfg-if",
  "critical-section",
- "embassy-executor",
+ "document-features",
  "embedded-dma",
  "embedded-hal 0.2.7",
  "enumset",
  "esp-hal-procmacros",
  "esp-riscv-rt",
+ "esp32",
  "esp32c2",
  "esp32c3",
  "esp32c6",
  "esp32h2",
+ "esp32p4",
+ "esp32s2",
+ "esp32s3",
  "fugit",
- "heapless 0.8.0",
  "nb 1.1.0",
  "paste",
  "portable-atomic",
+ "rand_core",
  "riscv",
  "serde",
- "strum",
+ "strum 0.26.2",
  "void",
+ "xtensa-lx-rt",
 ]
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4614e76646736f8adf18133d82d51f0da2b8899f38efb0a703b996a252b15e"
+checksum = "05084ecf8446fe60e0aff6c3873c96dca56dc383a449324ca555edbb80ae60c0"
 dependencies = [
  "darling",
+ "document-features",
  "litrs",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "esp-hal-smartled"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9092996f68b8553655bb36e2476b90825477dee18d32589c160c1e7e12dffe5"
+checksum = "16070db09f056cad1407a0abe1fe0606a3623295428de3e06e89d9a5033da5f3"
 dependencies = [
- "esp-hal-common",
+ "document-features",
+ "esp-hal",
  "fugit",
  "smart-leds-trait",
 ]
 
 [[package]]
 name = "esp-riscv-rt"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c734d963f250000961ffcb6135d814a3be0456020fe54f06d71c4277769326"
+checksum = "e599762d31156fa2322db4d5a0784c13b6122b79c1fa7bed70953de2f7d731f1"
 dependencies = [
+ "document-features",
  "riscv",
  "riscv-rt-macros",
 ]
@@ -692,10 +691,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp32c2"
-version = "0.17.0"
+name = "esp32"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad287b8cbc78f61fa7c81202e8bb7b1e438715ca0dc9654fc5c326458e9ba5d"
+checksum = "343ac30c4537d3f8526490db4264091a9785a55bcdfc22fc34482751a501d8d2"
+dependencies = [
+ "critical-section",
+ "vcell",
+ "xtensa-lx",
+]
+
+[[package]]
+name = "esp32c2"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e30c9147b7a1f388887dfd2fe7da4d6159a0248603674af5f3a5282a46cd11"
 dependencies = [
  "critical-section",
  "vcell",
@@ -703,28 +713,19 @@ dependencies = [
 
 [[package]]
 name = "esp32c3"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398875eca3b0a51216110bd988bc72f79e564a0039fc93d81c10113c3e5f1a55"
+checksum = "4a7ee710c1e4f16b5e840cdfec3f4e7642b7517a877c5c4b7e1cafa9a14117c5"
 dependencies = [
  "critical-section",
  "vcell",
 ]
 
 [[package]]
-name = "esp32c3-hal"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6bc2ca4947de92664ce7ca728fdcebedc96b1574ff3491db71d4db35491c5d"
-dependencies = [
- "esp-hal-common",
-]
-
-[[package]]
 name = "esp32c6"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683d47088fa94123072f0d8fc6dbdad0ecd2fb013d2095170179a5bec4e09d2"
+checksum = "ff0275425ea3a7675b7b5903163a93b65e8ce5b9c8a7749ed397279ed2ade3e3"
 dependencies = [
  "critical-section",
  "vcell",
@@ -732,12 +733,44 @@ dependencies = [
 
 [[package]]
 name = "esp32h2"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cb744fe4793cf793355162551bbee5a1e07cb121004931e02847a6059b2c51"
+checksum = "e606c8e60d3e68afda997fa9fcc8d8fe1d2e3c172505bb03eb9ab79b4bca4d6a"
 dependencies = [
  "critical-section",
  "vcell",
+]
+
+[[package]]
+name = "esp32p4"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03c0bc7973e6805e3c3c3c979e9418ba30380d8c16989a477440dbce8cf1965"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
+name = "esp32s2"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbcb8e9a4097fbf1c455fc776ad46a4bb7861d5bad3c3cd4549b666ad906ce4"
+dependencies = [
+ "critical-section",
+ "vcell",
+ "xtensa-lx",
+]
+
+[[package]]
+name = "esp32s3"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "044e216560a33aa5d6c98163c8ae4278845ec3bae7b9cab520da0697be4f23a6"
+dependencies = [
+ "critical-section",
+ "vcell",
+ "xtensa-lx",
 ]
 
 [[package]]
@@ -837,9 +870,9 @@ dependencies = [
  "embedded-storage",
  "embedded-text",
  "esp-alloc",
+ "esp-hal",
  "esp-hal-smartled",
  "esp-storage",
- "esp32c3-hal",
  "frostsnap_comms",
  "frostsnap_core",
  "mipidsi",
@@ -901,15 +934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,19 +946,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32 0.2.1",
+ "hash32",
  "rustc_version",
  "spin",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -1123,6 +1137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
+name = "minijinja"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb3bf58a1ec4f3f228bec851a2066c7717ad308817cd8a08f67c10660c6ff7b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "miniscript"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,9 +1173,15 @@ dependencies = [
  "display-interface",
  "embedded-graphics-core",
  "embedded-hal 0.2.7",
- "heapless 0.7.17",
+ "heapless",
  "nb 1.1.0",
 ]
+
+[[package]]
+name = "mutex-trait"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4bb1638d419e12f8b1c43d9e639abd0d1424285bdea2f76aa231e233c63cd3a"
 
 [[package]]
 name = "native"
@@ -1309,11 +1338,10 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_datetime",
  "toml_edit",
 ]
 
@@ -1358,6 +1386,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r0"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
 name = "rand"
@@ -1603,7 +1637,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1716,24 +1750,43 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.51",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1755,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.51"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1781,7 +1834,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1805,15 +1858,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1850,7 +1903,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1972,7 +2025,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -1994,7 +2047,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.51",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2195,4 +2248,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "xtensa-lx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e758f94e1a1f71758f94052a2766dcb12604998eb372b8b2e30576e3ab1ba1e6"
+dependencies = [
+ "bare-metal",
+ "mutex-trait",
+ "spin",
+]
+
+[[package]]
+name = "xtensa-lx-rt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904102108b780c9a5e3275c5f3c63dc348ec43ae5da5237868515498b447d51a"
+dependencies = [
+ "bare-metal",
+ "core-isa-parser",
+ "minijinja",
+ "r0",
+ "xtensa-lx-rt-proc-macros",
+]
+
+[[package]]
+name = "xtensa-lx-rt-proc-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082cdede098bbec9af15b0e74085e5f3d16f2923597de7aed7b8112003af2da7"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,27 +3,6 @@
 version = 3
 
 [[package]]
-name = "CoreFoundation-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
-dependencies = [
- "libc",
- "mach",
-]
-
-[[package]]
-name = "IOKit-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
-dependencies = [
- "CoreFoundation-sys",
- "libc",
- "mach",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "allo-isolate"
-version = "0.1.20"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56b7997817c178b853573e8bdfb6c3afe02810b43f17d766d6703560074b0c3"
+checksum = "f2f5a5fd28223e6f3cafb7d9cd685f51eafdd71d33ca1229f8316925d5957240"
 dependencies = [
  "anyhow",
  "atomic",
@@ -82,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "atomic"
@@ -94,9 +73,9 @@ checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
@@ -130,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "basic-toml"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
+checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
 dependencies = [
  "serde",
 ]
@@ -188,12 +167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-
-[[package]]
 name = "bitcoin"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,9 +212,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "block-buffer"
@@ -260,9 +233,9 @@ checksum = "832133bbabbbaa9fbdba793456a2827627a7d2b8fb96032fa1e7666d7895832b"
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byte-slice-cast"
@@ -272,9 +245,9 @@ checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 
 [[package]]
 name = "byteorder"
@@ -284,12 +257,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 
 [[package]]
 name = "cfg-if"
@@ -310,16 +280,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -344,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core2"
@@ -359,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -384,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -394,27 +364,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.39",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -449,7 +419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4895cd4e54e5536ef370d7f1eec787aad8275dd8ad15815aebfa71dd847b4ebf"
 dependencies = [
  "display-interface",
- "embedded-hal",
+ "embedded-hal 0.2.7",
 ]
 
 [[package]]
@@ -460,7 +430,16 @@ checksum = "489378ad054862146fbd1f09f51d585ccbe4bd1e2feadcda2a13ac33f840e1a5"
 dependencies = [
  "byte-slice-cast",
  "display-interface",
- "embedded-hal",
+ "embedded-hal 0.2.7",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -481,6 +460,46 @@ dependencies = [
  "webpki-roots",
  "winapi",
 ]
+
+[[package]]
+name = "embassy-executor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec648daedd2143466eff4b3e8002024f9f6c1de4ab7666bb679688752624c925"
+dependencies = [
+ "critical-section",
+ "document-features",
+ "embassy-executor-macros",
+ "embassy-time-driver",
+ "embassy-time-queue-driver",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad454accf80050e9cf7a51e994132ba0e56286b31f9317b68703897c328c59b5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
 
 [[package]]
 name = "embedded-dma"
@@ -535,16 +554,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-io"
-version = "0.6.1"
+name = "embedded-hal"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "embedded-storage"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156d7a2fdd98ebbf9ae579cbceca3058cff946e13f8e17b90e3511db0508c723"
+checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
 
 [[package]]
 name = "embedded-text"
@@ -555,6 +574,27 @@ dependencies = [
  "az",
  "embedded-graphics",
  "object-chain",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226c0da7462c13fb57e5cc9e0dc8f0635e7d27f276a3a7fd30054647f669007d"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -574,35 +614,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-backtrace"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f1f532fb2f820e2eeb7e5c7d479cdb8bdd939fe5d5a33c511e94371b0667ae"
-dependencies = [
- "esp-println",
-]
-
-[[package]]
 name = "esp-hal-common"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad320b6bb4fc71179b3997e8ca2d10c513729783070867767d1d84364d200513"
+checksum = "c468eb364cc570da74dfb8adfda9f308c34259fcd19a4c695a46554a26b7478a"
 dependencies = [
  "basic-toml",
  "bitfield",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "critical-section",
+ "embassy-executor",
  "embedded-dma",
- "embedded-hal",
- "embedded-io",
+ "embedded-hal 0.2.7",
+ "enumset",
  "esp-hal-procmacros",
  "esp-riscv-rt",
+ "esp32c2",
  "esp32c3",
+ "esp32c6",
+ "esp32h2",
  "fugit",
+ "heapless 0.8.0",
  "nb 1.1.0",
  "paste",
- "riscv-atomic-emulation-trap",
+ "portable-atomic",
+ "riscv",
  "serde",
  "strum",
  "void",
@@ -610,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064c5793a4b6eabc95f6452c7320c035265d85066998f2544e8c8cdfe7b7ff44"
+checksum = "8d4614e76646736f8adf18133d82d51f0da2b8899f38efb0a703b996a252b15e"
 dependencies = [
  "darling",
  "litrs",
@@ -620,14 +657,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "esp-hal-smartled"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35682f4c957d94a29e4f973a6f8461b75dac0970f4ff0ca1a618d5aec2959af"
+checksum = "d9092996f68b8553655bb36e2476b90825477dee18d32589c160c1e7e12dffe5"
 dependencies = [
  "esp-hal-common",
  "fugit",
@@ -635,16 +672,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-println"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678ad508e8e61561eccee27003a5033901fe07fe8700508c324849b3df930ef5"
-
-[[package]]
 name = "esp-riscv-rt"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7639ac03e9fe4e6d5f1c0e90b95ce9478d487335f6684c22b3515e6dc3155d8f"
+checksum = "f8c734d963f250000961ffcb6135d814a3be0456020fe54f06d71c4277769326"
 dependencies = [
  "riscv",
  "riscv-rt-macros",
@@ -661,10 +692,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp32c3"
-version = "0.18.0"
+name = "esp32c2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e5cc6c0874ae7d8ea3997eeba05bf06926b92c788b556002e2c3eea52f5882"
+checksum = "2ad287b8cbc78f61fa7c81202e8bb7b1e438715ca0dc9654fc5c326458e9ba5d"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
+name = "esp32c3"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398875eca3b0a51216110bd988bc72f79e564a0039fc93d81c10113c3e5f1a55"
 dependencies = [
  "critical-section",
  "vcell",
@@ -672,12 +713,31 @@ dependencies = [
 
 [[package]]
 name = "esp32c3-hal"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b11a787ccbf8dfb1895c1fe1207effc002061e0fc705fa1d633dd88bbf9f5c"
+checksum = "4b6bc2ca4947de92664ce7ca728fdcebedc96b1574ff3491db71d4db35491c5d"
 dependencies = [
- "cfg-if",
  "esp-hal-common",
+]
+
+[[package]]
+name = "esp32c6"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683d47088fa94123072f0d8fc6dbdad0ecd2fb013d2095170179a5bec4e09d2"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
+name = "esp32h2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cb744fe4793cf793355162551bbee5a1e07cb121004931e02847a6059b2c51"
+dependencies = [
+ "critical-section",
+ "vcell",
 ]
 
 [[package]]
@@ -717,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge_macros"
-version = "1.82.4"
+version = "1.82.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2fe4c18349a2b17b980a1214e19a4cb7888a86f70ce5a9a0fccb5611f77bdb"
+checksum = "a7fe743d921bedf4578b9472346d03a9643a01cd565ca7df7961baebad534ba5"
 
 [[package]]
 name = "fnv"
@@ -770,7 +830,6 @@ name = "frostsnap_device"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "critical-section",
  "display-interface",
  "display-interface-spi",
  "embedded-graphics",
@@ -778,14 +837,11 @@ dependencies = [
  "embedded-storage",
  "embedded-text",
  "esp-alloc",
- "esp-backtrace",
  "esp-hal-smartled",
- "esp-println",
  "esp-storage",
  "esp32c3-hal",
  "frostsnap_comms",
  "frostsnap_core",
- "fugit",
  "mipidsi",
  "nb 1.1.0",
  "rand_chacha",
@@ -820,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -831,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "hash32"
@@ -845,21 +901,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.2"
+name = "hash32"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -871,9 +946,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "379dada1584ad501b383485dd706b8afb7a70fcbc7f4da7d780638a5a6124a60"
 
 [[package]]
 name = "hex_lit"
@@ -883,9 +958,9 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.58"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -912,9 +987,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -930,16 +1005,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.9"
+name = "io-kit-sys"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -952,9 +1037,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libudev"
@@ -1017,28 +1102,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "mach"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mach2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "micromath"
@@ -1058,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -1073,8 +1149,8 @@ checksum = "46968d0e30e7753c3503248bc48b408f9cce2bfbaa522a33e13c9aafadc4ce43"
 dependencies = [
  "display-interface",
  "embedded-graphics-core",
- "embedded-hal",
- "heapless",
+ "embedded-hal 0.2.7",
+ "heapless 0.7.17",
  "nb 1.1.0",
 ]
 
@@ -1134,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -1153,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -1168,9 +1244,9 @@ checksum = "41af26158b0f5530f7b79955006c2727cd23d0d8e7c3109dc316db0a919784dd"
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "overload"
@@ -1198,7 +1274,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1215,9 +1291,15 @@ checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "ppv-lite86"
@@ -1227,10 +1309,11 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
+ "toml_datetime",
  "toml_edit",
 ]
 
@@ -1260,18 +1343,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1317,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1329,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1355,11 +1438,12 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
@@ -1369,26 +1453,19 @@ dependencies = [
 
 [[package]]
 name = "riscv"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3145d2fae3778b1e31ec2e827b228bdc6abd9b74bb5705ba46dcb82069bc4f"
+checksum = "2f5c1b8bf41ea746266cdee443d1d1e9125c86ce1447e1a2615abd34330d33a9"
 dependencies = [
- "bit_field",
  "critical-section",
- "embedded-hal",
+ "embedded-hal 1.0.0",
 ]
 
 [[package]]
-name = "riscv-atomic-emulation-trap"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7979127070e70f34c0ad6cc5a3a13f09af8dab1e9e154c396eb818f478504143"
-
-[[package]]
 name = "riscv-rt-macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38509d7b17c2f604ceab3e5ff8ac97bb8cd2f544688c512be75c715edaf4daf"
+checksum = "a8d100d466dbb76681ef6a9386f3da9abc570d57394e86da0ba5af8c4408486d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1412,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
@@ -1440,9 +1517,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "schnorr_fun"
@@ -1505,35 +1582,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -1542,19 +1619,20 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32634e2bd4311420caa504404a55fad2131292c485c97014cbed89a5899885f"
+checksum = "8f5a15d0be940df84846264b09b51b10b931fb2f275becb80934e3568a016828"
 dependencies = [
- "CoreFoundation-sys",
- "IOKit-sys",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "cfg-if",
+ "core-foundation-sys",
+ "io-kit-sys",
  "libudev",
  "mach2",
  "nix",
  "regex",
  "scopeguard",
+ "unescaper",
  "winapi",
 ]
 
@@ -1580,24 +1658,24 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smart-leds"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd45fa275f70b4110eac5f5182611ad384f88bb22b68b9a9c3cafd7015290b"
+checksum = "66df34e571fa9993fa6f99131a374d58ca3d694b75f9baac93458fe0d6057bf0"
 dependencies = [
  "smart-leds-trait",
 ]
 
 [[package]]
 name = "smart-leds-trait"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf6d833fa93f16a1c1874e62c2aebe8567e5bdd436d59bf543ed258b6f7a8e3"
+checksum = "0bc64ee02bbbf469603016df746c0ed224f263280b6ebb49b7ebadbff375c572"
 dependencies = [
  "rgb",
 ]
@@ -1621,7 +1699,7 @@ dependencies = [
  "display-interface-i2c",
  "display-interface-spi",
  "embedded-graphics-core",
- "embedded-hal",
+ "embedded-hal 0.2.7",
 ]
 
 [[package]]
@@ -1655,7 +1733,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.39",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1677,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1687,10 +1765,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.7"
+name = "thiserror"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1707,15 +1805,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1752,7 +1850,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1795,6 +1893,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unescaper"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0adf6ad32eb5b3cadff915f7b770faaac8f7ff0476633aa29eb0d9584d889d34"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1846,9 +1953,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1856,24 +1963,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.51",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1881,28 +1988,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.51",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
-version = "0.3.65"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1951,20 +2058,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -1973,13 +2080,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -1989,10 +2111,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2001,10 +2135,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2013,10 +2159,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2025,10 +2183,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "winnow"
-version = "0.5.19"
+name = "windows_x86_64_msvc"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/device/.cargo/config.toml
+++ b/device/.cargo/config.toml
@@ -3,9 +3,6 @@ runner = "espflash flash --baud 921600 --bootloader bootloader.bin"
 
 [build]
 rustflags = [
-  # enable the atomic codegen option for RISCV
-  "-C", "target-feature=+a",
-
   # Tell the `core` library that we have atomics, even though it's not
   # specified in the target definition
   "--cfg", "target_has_atomic_load_store",
@@ -13,15 +10,22 @@ rustflags = [
   "--cfg", 'target_has_atomic_load_store="16"',
   "--cfg", 'target_has_atomic_load_store="32"',
   "--cfg", 'target_has_atomic_load_store="ptr"',
-  "--cfg", "target_has_atomic",
-  "--cfg", 'target_has_atomic="8"',
-  "--cfg", 'target_has_atomic="16"',
-  "--cfg", 'target_has_atomic="32"',
-  "--cfg", 'target_has_atomic="ptr"',
+
+  # enable the atomic codegen option for RISCV
+  # LL: I disabled all this.
+  # see https://github.com/taiki-e/portable-atomic/issues/148#issuecomment-1920135639
+  #
+  # "-C", "target-feature=+a",
+  # "--cfg", "target_has_atomic",
+  # "--cfg", 'target_has_atomic="8"',
+  # "--cfg", 'target_has_atomic="16"',
+  # "--cfg", 'target_has_atomic="32"',
+  # "--cfg", 'target_has_atomic="ptr"',
 
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
-  "-C", "force-frame-pointers",
+  # LL: I turned this off because I got rid of esp-backtrace crate
+  # "-C", "force-frame-pointers",
   "-C", "link-arg=-Tlinkall.x"
 ]
 target = "riscv32imc-unknown-none-elf"

--- a/device/.cargo/config.toml
+++ b/device/.cargo/config.toml
@@ -3,30 +3,11 @@ runner = "espflash flash --baud 921600 --bootloader bootloader.bin"
 
 [build]
 rustflags = [
-  # Tell the `core` library that we have atomics, even though it's not
-  # specified in the target definition
-  "--cfg", "target_has_atomic_load_store",
-  "--cfg", 'target_has_atomic_load_store="8"',
-  "--cfg", 'target_has_atomic_load_store="16"',
-  "--cfg", 'target_has_atomic_load_store="32"',
-  "--cfg", 'target_has_atomic_load_store="ptr"',
-
-  # enable the atomic codegen option for RISCV
-  # LL: I disabled all this.
-  # see https://github.com/taiki-e/portable-atomic/issues/148#issuecomment-1920135639
-  #
-  # "-C", "target-feature=+a",
-  # "--cfg", "target_has_atomic",
-  # "--cfg", 'target_has_atomic="8"',
-  # "--cfg", 'target_has_atomic="16"',
-  # "--cfg", 'target_has_atomic="32"',
-  # "--cfg", 'target_has_atomic="ptr"',
-
+  "-C", "link-arg=-Tlinkall.x"
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
   # LL: I turned this off because I got rid of esp-backtrace crate
   # "-C", "force-frame-pointers",
-  "-C", "link-arg=-Tlinkall.x"
 ]
 target = "riscv32imc-unknown-none-elf"
 

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -20,20 +20,10 @@ mem_debug = []
 [dependencies]
 frostsnap_core = { workspace = true }
 frostsnap_comms = { workspace = true }
-hal = { package = "esp32c3-hal", version = "0.13.0" }
+hal = { package = "esp32c3-hal", version = "0.15.0" }
 esp-alloc = "0.3.0"
-esp-backtrace = { version = "0.9.0", features = [
-    "esp32c3",
-    "print-jtag-serial",
-] }
-esp-println = { version = "0.7.0", default-features = false, features = [
-    "esp32c3",
-    "jtag_serial",
-] }
-critical-section = "1.1.2"
-nb = "1.1.0"
-fugit = "0.3.7"
-embedded-storage = "0.3.0"
+nb = "1"
+embedded-storage = "0.3.1"
 esp-storage = { version = "0.3.0", features = ["esp32c3"] }
 bincode = { workspace = true }
 display-interface = { version = "0.4.1", optional = true }
@@ -43,10 +33,10 @@ mipidsi = { version = "0.7.1", features = ["batch"], optional = true }
 embedded-graphics-framebuf = { version = "0.5.0", optional = true }
 embedded-graphics = "0.8.1"
 embedded-text = "0.7.0"
-esp-hal-smartled = { version = "0.6.0", features = [
+esp-hal-smartled = { version = "0.8.0", features = [
     "esp32c3",
 ], optional = true }
-smart-leds = { version = "0.3.0", optional = true }
+smart-leds = { version = "0.4.0", optional = true }
 rand_chacha = { workspace = true }
 
 [[bin]]

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -20,7 +20,7 @@ mem_debug = []
 [dependencies]
 frostsnap_core = { workspace = true }
 frostsnap_comms = { workspace = true }
-hal = { package = "esp32c3-hal", version = "0.15.0" }
+esp-hal = { package = "esp-hal", version = "0.16.1", features = ["esp32c3"] }
 esp-alloc = "0.3.0"
 nb = "1"
 embedded-storage = "0.3.1"
@@ -33,7 +33,7 @@ mipidsi = { version = "0.7.1", features = ["batch"], optional = true }
 embedded-graphics-framebuf = { version = "0.5.0", optional = true }
 embedded-graphics = "0.8.1"
 embedded-text = "0.7.0"
-esp-hal-smartled = { version = "0.8.0", features = [
+esp-hal-smartled = { version = "0.9.0", features = [
     "esp32c3",
 ], optional = true }
 smart-leds = { version = "0.4.0", optional = true }

--- a/device/rust-toolchain.toml
+++ b/device/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly"
-components = ["rust-src"]

--- a/device/src/bin/frostypede.rs
+++ b/device/src/bin/frostypede.rs
@@ -271,14 +271,13 @@ where
                 return;
             }
             AnimationProgress::FinalTick => {
-                self.display.clear(Rgb565::BLACK).unwrap();
+                self.display.clear(Rgb565::BLACK);
             }
             AnimationProgress::Done => { /* splash is done no need to anything */ }
         }
 
         self.display
-            .header(self.device_name.as_deref().unwrap_or("New Device"))
-            .unwrap();
+            .header(self.device_name.as_deref().unwrap_or("New Device"));
 
         match &self.workflow {
             Workflow::None => {
@@ -292,12 +291,8 @@ where
             } => match existing_name {
                 Some(existing_name) => self
                     .display
-                    .print(&format!("Renaming {}:\n> {}", existing_name, current_name))
-                    .unwrap(),
-                None => self
-                    .display
-                    .print(format!("Naming:\n> {}", current_name))
-                    .unwrap(),
+                    .print(&format!("Renaming {}:\n> {}", existing_name, current_name)),
+                None => self.display.print(format!("Naming:\n> {}", current_name)),
             },
             Workflow::WaitingFor(waiting_for) => match waiting_for {
                 WaitingFor::LookingForUpstream { jtag } => {
@@ -306,18 +301,16 @@ where
                         .unwrap();
 
                     if *jtag {
-                        self.display
-                            .print("Looking for coordinator USB host")
-                            .unwrap();
+                        self.display.print("Looking for coordinator USB host");
                     } else {
-                        self.display.print("Looking for upstream device").unwrap();
+                        self.display.print("Looking for upstream device");
                     }
                 }
                 WaitingFor::CoordinatorAnnounceAck => {
                     self.led
                         .write(brightness([colors::PURPLE].iter().cloned(), 10))
                         .unwrap();
-                    self.display.print("Waiting for FrostSnap app").unwrap();
+                    self.display.print("Waiting for FrostSnap app");
                 }
                 WaitingFor::CoordinatorInstruction { completed_task: _ } => {
                     self.led
@@ -330,18 +323,16 @@ where
                             body.push_str(&format!("NAME: {}\n", label));
 
                             body.push_str("Ready..");
-                            self.display.print(body).unwrap();
+                            self.display.print(body);
                         }
                         None => {
-                            self.display.print("Press 'New Device'").unwrap();
+                            self.display.print("Press 'New Device'");
                         }
                     };
                 }
                 WaitingFor::CoordinatorResponse(response) => match response {
                     WaitingResponse::KeyGen => {
-                        self.display
-                            .print("Finished!\nWaiting for coordinator..")
-                            .unwrap();
+                        self.display.print("Finished!\nWaiting for coordinator..");
                     }
                 },
             },
@@ -352,28 +343,21 @@ where
 
                 match prompt {
                     Prompt::Signing(task) => {
-                        self.display.print(format!("Sign {}", task)).unwrap();
+                        self.display.print(format!("Sign {}", task));
                     }
                     Prompt::KeyGen(session_hash) => {
                         self.display
-                            .print(format!("Ok {}", hex::encode(session_hash)))
-                            .unwrap();
+                            .print(format!("Ok {}", hex::encode(session_hash)));
                     }
                     Prompt::NewName { old_name, new_name } => match old_name {
-                        Some(old_name) => self
-                            .display
-                            .print(format!(
-                                "Rename this device from '{}' to '{}'?",
-                                old_name, new_name
-                            ))
-                            .unwrap(),
-                        None => self
-                            .display
-                            .print(format!("Confirm name '{}'?", new_name))
-                            .unwrap(),
+                        Some(old_name) => self.display.print(format!(
+                            "Rename this device from '{}' to '{}'?",
+                            old_name, new_name
+                        )),
+                        None => self.display.print(format!("Confirm name '{}'?", new_name)),
                     },
                 }
-                self.display.confirm_bar(0.0).unwrap();
+                self.display.confirm_bar(0.0);
             }
             Workflow::BusyDoing(task) => {
                 self.led
@@ -381,14 +365,14 @@ where
                     .unwrap();
 
                 match task {
-                    BusyTask::KeyGen => self.display.print("Generating key..").unwrap(),
-                    BusyTask::Signing => self.display.print("Signing..").unwrap(),
-                    BusyTask::VerifyingShare => self.display.print("Verifying key..").unwrap(),
-                    BusyTask::Loading => self.display.print("loading..").unwrap(),
+                    BusyTask::KeyGen => self.display.print("Generating key.."),
+                    BusyTask::Signing => self.display.print("Signing.."),
+                    BusyTask::VerifyingShare => self.display.print("Verifying key.."),
+                    BusyTask::Loading => self.display.print("loading.."),
                 }
             }
             Workflow::Debug(string) => {
-                self.display.print(string).unwrap();
+                self.display.print(string);
             }
         }
 
@@ -460,7 +444,7 @@ where
                                 30,
                             ))
                             .unwrap();
-                        self.display.confirm_bar(progress).unwrap();
+                        self.display.confirm_bar(progress);
                     }
                     AnimationProgress::FinalTick => {
                         self.led
@@ -505,11 +489,11 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     // Disable the RTC and TIMG watchdog timers
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks).unwrap();
-    let rmt_buffer = smartLedBuffer!(1);
-    let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio0, rmt_buffer);
-    led.write(brightness([colors::RED].iter().cloned(), 10))
-        .unwrap();
+    if let Ok(rmt) = Rmt::new(peripherals.RMT, 80u32.MHz(), &clocks) {
+        let rmt_buffer = smartLedBuffer!(1);
+        let mut led = SmartLedsAdapter::new(rmt.channel0, io.pins.gpio0, rmt_buffer);
+        let _ = led.write(brightness([colors::RED].iter().cloned(), 10));
+    }
 
     let mut panic_buf = frostsnap_device::panic::PanicBuffer::<512>::default();
 
@@ -539,7 +523,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         &clocks,
         framebuf,
     ) {
-        let _ = display.error_print(panic_buf.as_str());
+        display.error_print(panic_buf.as_str());
     }
 
     loop {}

--- a/device/src/bin/frostypede.rs
+++ b/device/src/bin/frostypede.rs
@@ -31,7 +31,7 @@ use hal::{
     spi,
     timer::{Timer, TimerGroup},
     uart::{self, Uart},
-    Delay, Rtc, UsbSerialJtag, IO,
+    Delay, UsbSerialJtag, IO,
 };
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use smart_leds::{brightness, colors, SmartLedsWrite, RGB};
@@ -67,21 +67,12 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Disable the RTC and TIMG watchdog timers
-    let mut rtc = Rtc::new(peripherals.LPWR);
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    let mut wdt0 = timer_group0.wdt;
     let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
-    let mut wdt1 = timer_group1.wdt;
     let mut timer0 = timer_group0.timer0;
     timer0.start(1u64.secs());
     let mut timer1 = timer_group1.timer0;
     timer1.start(1u64.secs());
-
-    rtc.swd.disable();
-    rtc.rwdt.disable();
-    wdt0.disable();
-    wdt1.disable();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 

--- a/device/src/bin/frostypede.rs
+++ b/device/src/bin/frostypede.rs
@@ -18,7 +18,7 @@ use frostsnap_core::schnorr_fun::fun::hex;
 use frostsnap_device::{
     esp32_run,
     io::{set_upstream_port_mode_jtag, set_upstream_port_mode_uart},
-    st7735::{self, ST7735},
+    st7735::ST7735,
     ui::{BusyTask, Prompt, UiEvent, UserInteraction, WaitingFor, WaitingResponse, Workflow},
     ConnectionState,
 };
@@ -98,15 +98,12 @@ fn main() -> ! {
     bl.set_low().unwrap();
     let framearray = [Rgb565::WHITE; 160 * 80];
     let framebuf = FrameBuf::new(framearray, 160, 80);
-    let display = st7735::ST7735::new(
-        // &mut bl,
+    let display = ST7735::new(
         io.pins.gpio6.into_push_pull_output().into(),
         io.pins.gpio10.into_push_pull_output().into(),
         peripherals.SPI2,
         io.pins.gpio2,
-        io.pins.gpio7,
         io.pins.gpio3,
-        io.pins.gpio12,
         &clocks,
         framebuf,
     )
@@ -511,15 +508,12 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     let framearray = [Rgb565::WHITE; 160 * 80];
     let framebuf = FrameBuf::new(framearray, 160, 80);
     // let mut bl = io.pins.gpio11.into_push_pull_output();
-    if let Ok(mut display) = st7735::ST7735::new(
-        // &mut bl,
+    if let Ok(mut display) = ST7735::new(
         io.pins.gpio6.into_push_pull_output().into(),
         io.pins.gpio10.into_push_pull_output().into(),
         peripherals.SPI2,
         io.pins.gpio2,
-        io.pins.gpio7,
         io.pins.gpio3,
-        io.pins.gpio12,
         &clocks,
         framebuf,
     ) {

--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -5,6 +5,7 @@ use crate::{
     ConnectionState,
 };
 use alloc::{collections::VecDeque, string::ToString, vec::Vec};
+use esp_hal::{gpio, timer, uart, UsbSerialJtag};
 use esp_storage::FlashStorage;
 use frostsnap_comms::{CoordinatorSendBody, DeviceSendBody, DeviceSendMessage, ReceiveSerial};
 use frostsnap_comms::{CoordinatorSendMessage, Downstream, MAGIC_BYTES_PERIOD};
@@ -17,7 +18,6 @@ use frostsnap_core::{
     schnorr_fun::fun::marker::Normal,
     FrostSigner,
 };
-use hal::{gpio, uart, UsbSerialJtag};
 use rand_chacha::rand_core::RngCore;
 
 pub struct Run<'a, UpstreamUart, DownstreamUart, DownstreamDetect, Ui, T, Rng> {
@@ -26,7 +26,7 @@ pub struct Run<'a, UpstreamUart, DownstreamUart, DownstreamDetect, Ui, T, Rng> {
     pub downstream_uart: uart::Uart<'a, DownstreamUart>,
     pub rng: Rng,
     pub ui: Ui,
-    pub timer: hal::timer::Timer<T>,
+    pub timer: timer::Timer<T>,
     pub downstream_detect: DownstreamDetect,
 }
 
@@ -37,7 +37,7 @@ where
     DownstreamUart: uart::Instance,
     DownstreamDetect: gpio::InputPin,
     Ui: UserInteraction,
-    T: hal::timer::Instance,
+    T: timer::Instance,
     Rng: RngCore,
 {
     pub fn run(self) -> ! {

--- a/device/src/io.rs
+++ b/device/src/io.rs
@@ -322,12 +322,14 @@ impl<'a, T, U> UpstreamDetector<'a, T, U> {
 
 pub fn set_upstream_port_mode_jtag() {
     let usb_device = unsafe { &*USB_DEVICE::PTR };
-    usb_device.conf0.modify(|_, w| w.usb_pad_enable().set_bit());
+    usb_device
+        .conf0()
+        .modify(|_, w| w.usb_pad_enable().set_bit());
 }
 
 pub fn set_upstream_port_mode_uart() {
     let usb_device = unsafe { &*USB_DEVICE::PTR };
     usb_device
-        .conf0
+        .conf0()
         .modify(|_, w| w.usb_pad_enable().clear_bit());
 }

--- a/device/src/io.rs
+++ b/device/src/io.rs
@@ -9,11 +9,16 @@ use bincode::de::read::Reader;
 use bincode::enc::write::Writer;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
+use esp_hal::{
+    peripherals::USB_DEVICE,
+    prelude::*,
+    timer::{self, Timer},
+    uart, UsbSerialJtag,
+};
 use frostsnap_comms::Direction;
 use frostsnap_comms::MagicBytes;
 use frostsnap_comms::ReceiveSerial;
 use frostsnap_comms::Upstream;
-use hal::{peripherals::USB_DEVICE, prelude::*, timer::Timer, uart, UsbSerialJtag};
 
 const RING_BUFFER_SIZE: usize = 2_usize.pow(8); // i.e. 256 bytes
 
@@ -56,7 +61,7 @@ impl<'a, T, U> SerialInterface<'a, T, U, Upstream> {
 impl<'a, T, U, D> SerialInterface<'a, T, U, D>
 where
     U: uart::Instance,
-    T: hal::timer::Instance,
+    T: timer::Instance,
     D: Direction,
 {
     fn fill_buffer(&mut self) {
@@ -120,7 +125,7 @@ where
 impl<'a, T, U, D> Reader for SerialInterface<'a, T, U, D>
 where
     U: uart::Instance,
-    T: hal::timer::Instance,
+    T: timer::Instance,
     D: Direction,
 {
     fn read(&mut self, bytes: &mut [u8]) -> Result<(), DecodeError> {
@@ -271,7 +276,7 @@ impl<'a, T, U> UpstreamDetector<'a, T, U> {
 
     pub fn serial_interface(&mut self) -> Option<&mut SerialInterface<'a, T, U, Upstream>>
     where
-        T: hal::timer::Instance,
+        T: timer::Instance,
         U: uart::Instance,
     {
         self.poll();
@@ -283,7 +288,7 @@ impl<'a, T, U> UpstreamDetector<'a, T, U> {
 
     pub fn poll(&mut self)
     where
-        T: hal::timer::Instance,
+        T: timer::Instance,
         U: uart::Instance,
     {
         let state = core::mem::replace(&mut self.state, DetectorState::Unreachable);

--- a/device/src/st7735.rs
+++ b/device/src/st7735.rs
@@ -17,7 +17,7 @@ use embedded_text::{
 };
 use hal::{
     clock::Clocks,
-    gpio::{AnyPin, InputPin, Output, OutputPin, PushPull},
+    gpio::{AnyPin, Output, OutputPin, PushPull},
     peripheral::Peripheral,
     prelude::*,
     spi::{
@@ -36,7 +36,6 @@ pub struct ST7735<'d, SPI>
 where
     SPI: Instance,
 {
-    // pub bl: &'d mut GpioPin<Output<PushPull>, RA, IRA, InputOutputPinType, Gpio11Signals, 11>,
     pub display: Display<SpiInterface<'d, SPI>, ST7735s, AnyPin<Output<PushPull>>>,
     character_style: MonoTextStyle<'d, Rgb565>,
     textbox_style: TextBoxStyle,
@@ -48,23 +47,18 @@ where
     SPI: Instance,
 {
     #[allow(clippy::too_many_arguments)]
-    pub fn new<SCK: OutputPin, MOSI: OutputPin, MISO: InputPin, CS: OutputPin>(
-        // bl: &'d mut GpioPin<Output<PushPull>, RA, IRA, InputOutputPinType, Gpio11Signals, 11>,
+    pub fn new<SCK: OutputPin, MOSI: OutputPin>(
         dc: AnyPin<Output<PushPull>>,
         rst: AnyPin<Output<PushPull>>,
         spi: impl Peripheral<P = SPI> + 'd,
         sck: impl Peripheral<P = SCK> + 'd,
-        cs: impl Peripheral<P = CS> + 'd,
         mosi: impl Peripheral<P = MOSI> + 'd,
-        miso: impl Peripheral<P = MISO> + 'd,
         clocks: &Clocks,
         framebuf: FrameBuf<Rgb565, [Rgb565; 12800]>,
     ) -> Result<Self, mipidsi::Error> {
         let spi = Spi::new(spi, 16u32.MHz(), SpiMode::Mode0, clocks)
             .with_sck(sck)
-            .with_mosi(mosi)
-            .with_miso(miso)
-            .with_cs(cs);
+            .with_mosi(mosi);
 
         let di = SPIInterfaceNoCS::new(spi, dc);
         let mut delay = Delay::new(clocks);

--- a/device/src/st7735.rs
+++ b/device/src/st7735.rs
@@ -1,5 +1,4 @@
 // Air101 ST7735 driver
-
 use display_interface_spi::SPIInterfaceNoCS;
 use embedded_graphics::{
     mono_font::{
@@ -28,7 +27,7 @@ use hal::{
     Delay,
 };
 use mipidsi::ColorInversion;
-use mipidsi::{models::ST7735s, Display, Error};
+use mipidsi::{models::ST7735s, Display};
 
 pub type SpiInterface<'d, SPI> =
     SPIInterfaceNoCS<Spi<'d, SPI, FullDuplexMode>, AnyPin<Output<PushPull>>>;
@@ -60,7 +59,7 @@ where
         miso: impl Peripheral<P = MISO> + 'd,
         clocks: &Clocks,
         framebuf: FrameBuf<Rgb565, [Rgb565; 12800]>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, mipidsi::Error> {
         let spi = Spi::new(spi, 16u32.MHz(), SpiMode::Mode0, clocks)
             .with_sck(sck)
             .with_mosi(mosi)
@@ -89,11 +88,9 @@ where
             .with_invert_colors(INVERT_COLORS)
             .with_color_order(mipidsi::options::ColorOrder::Bgr)
             .init(&mut delay, Some(rst))
-            .unwrap();
+            .expect("infallible");
 
-        display
-            .set_orientation(mipidsi::options::Orientation::Landscape(true))
-            .unwrap();
+        display.set_orientation(mipidsi::options::Orientation::Landscape(true))?;
 
         let character_style = MonoTextStyle::new(&FONT_7X14, Rgb565::WHITE);
         let textbox_style = TextBoxStyleBuilder::new()
@@ -109,69 +106,61 @@ where
             framebuf,
         };
 
-        _self.clear(Rgb565::BLACK).unwrap();
-        _self.flush().unwrap();
+        _self.clear(Rgb565::BLACK);
+        _self.flush()?;
 
         Ok(_self)
     }
 
-    pub fn flush(&mut self) -> Result<(), Error> {
+    pub fn flush(&mut self) -> Result<(), mipidsi::Error> {
         let area = Rectangle::new(Point::new(0, 0), self.framebuf.size());
-        self.display
-            .fill_contiguous(&area, self.framebuf.data)
-            .unwrap();
+        self.display.fill_contiguous(&area, self.framebuf.data)?;
         Ok(())
     }
 
-    pub fn error_print(&mut self, error: impl AsRef<str>) -> Result<(), Error> {
+    pub fn error_print(&mut self, error: impl AsRef<str>) {
         let header_area = Rectangle::new(Point::zero(), Size::new(160, 10));
-        header_area
+        let _ = header_area
             .into_styled(PrimitiveStyleBuilder::new().fill_color(Rgb565::RED).build())
-            .draw(&mut self.framebuf)
-            .unwrap();
+            .draw(&mut self.framebuf);
 
         let header_charstyle = MonoTextStyle::new(&FONT_5X8, Rgb565::WHITE);
-        TextBox::with_textbox_style(
+        let _ = TextBox::with_textbox_style(
             "ERROR",
             Rectangle::new(Point::new(1, 1), Size::new(80, 10)),
             header_charstyle,
             self.textbox_style,
         )
-        .draw(&mut self.framebuf)
-        .unwrap();
+        .draw(&mut self.framebuf);
 
         Line::new(Point::new(0, 10), Point::new(160, 10))
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::CSS_DARK_GRAY, 1))
             .draw(&mut self.framebuf)
             .unwrap();
 
-        Rectangle::new(Point::new(0, 11), Size::new(160, 80))
+        let _ = Rectangle::new(Point::new(0, 11), Size::new(160, 80))
             .into_styled(
                 PrimitiveStyleBuilder::new()
                     .fill_color(Rgb565::BLACK)
                     .build(),
             )
-            .draw(&mut self.framebuf)
-            .unwrap();
+            .draw(&mut self.framebuf);
 
         let character_style = MonoTextStyle::new(&FONT_5X8, Rgb565::WHITE);
-        TextBox::with_textbox_style(
+        let _ = TextBox::with_textbox_style(
             error.as_ref(),
             Rectangle::new(Point::new(1, 11), Size::new(160, 80)),
             character_style,
             self.textbox_style,
         )
-        .draw(&mut self.framebuf)
-        .unwrap();
+        .draw(&mut self.framebuf);
 
-        self.flush().unwrap();
-
-        Ok(())
+        let _ = self.flush();
     }
 
-    pub fn splash_screen(&mut self, percent: f32) -> Result<(), Error> {
+    pub fn splash_screen(&mut self, percent: f32) -> Result<(), mipidsi::Error> {
         let incomplete = 1.0 - percent;
-        self.clear(Rgb565::BLACK).unwrap();
+        self.clear(Rgb565::BLACK);
 
         TextBox::with_textbox_style(
             "Frost",
@@ -204,8 +193,7 @@ where
         .draw(&mut self.framebuf)
         .unwrap();
 
-        self.flush().unwrap();
-        Ok(())
+        self.flush()
     }
 
     pub fn set_top_left_square(&mut self, color: Rgb565) {
@@ -221,7 +209,7 @@ where
             .unwrap();
     }
 
-    pub fn header(&mut self, device_label: impl AsRef<str>) -> Result<(), Error> {
+    pub fn header(&mut self, device_label: impl AsRef<str>) {
         Rectangle::new(Point::zero(), Size::new(160, 10))
             .into_styled(
                 PrimitiveStyleBuilder::new()
@@ -248,11 +236,9 @@ where
             .into_styled(PrimitiveStyle::with_stroke(Rgb565::CSS_DARK_GRAY, 1))
             .draw(&mut self.framebuf)
             .unwrap();
-
-        Ok(())
     }
 
-    pub fn print(&mut self, str: impl AsRef<str>) -> Result<(), Error> {
+    pub fn print(&mut self, str: impl AsRef<str>) {
         Rectangle::new(Point::new(0, 11), Size::new(160, 80))
             .into_styled(
                 PrimitiveStyleBuilder::new()
@@ -270,11 +256,9 @@ where
         )
         .draw(&mut self.framebuf)
         .unwrap();
-
-        Ok(())
     }
 
-    pub fn confirm_bar(&mut self, percent: f32) -> Result<(), Error> {
+    pub fn confirm_bar(&mut self, percent: f32) {
         let y = 78;
         if percent == 0.0 {
             Line::new(Point::new(0, y), Point::new(160, y))
@@ -293,17 +277,13 @@ where
                 .draw(&mut self.display)
                 .unwrap();
         }
-
-        Ok(())
     }
 
-    pub fn clear(&mut self, c: Rgb565) -> Result<(), Error> {
+    pub fn clear(&mut self, c: Rgb565) {
         Rectangle::new(Point::new(0, 0), Size::new(160, 80))
             .into_styled(PrimitiveStyleBuilder::new().fill_color(c).build())
             .draw(&mut self.framebuf)
             .unwrap();
-
-        Ok(())
     }
 
     pub fn set_mem_debug(&mut self, used: usize, free: usize) {

--- a/device/src/st7735.rs
+++ b/device/src/st7735.rs
@@ -61,16 +61,11 @@ where
         clocks: &Clocks,
         framebuf: FrameBuf<Rgb565, [Rgb565; 12800]>,
     ) -> Result<Self, Error> {
-        let spi = Spi::new(
-            spi,
-            sck,
-            mosi,
-            miso,
-            cs,
-            16u32.MHz(),
-            SpiMode::Mode0,
-            clocks,
-        );
+        let spi = Spi::new(spi, 16u32.MHz(), SpiMode::Mode0, clocks)
+            .with_sck(sck)
+            .with_mosi(mosi)
+            .with_miso(miso)
+            .with_cs(cs);
 
         let di = SPIInterfaceNoCS::new(spi, dc);
         let mut delay = Delay::new(clocks);

--- a/device/src/st7735.rs
+++ b/device/src/st7735.rs
@@ -15,7 +15,7 @@ use embedded_text::{
     style::{TextBoxStyle, TextBoxStyleBuilder},
     TextBox,
 };
-use hal::{
+use esp_hal::{
     clock::Clocks,
     gpio::{AnyPin, Output, OutputPin, PushPull},
     peripheral::Peripheral,

--- a/frostsnapp/lib/bridge_definitions.freezed.dart
+++ b/frostsnapp/lib/bridge_definitions.freezed.dart
@@ -102,26 +102,23 @@ class _$CoordinatorToUserKeyGenMessageCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWith<
-    $Res> {
-  factory _$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWith(
-          _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl value,
-          $Res Function(_$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl)
-              then) =
-      __$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWithImpl<$Res>;
+abstract class _$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWith<$Res> {
+  factory _$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWith(
+          _$CoordinatorToUserKeyGenMessage_ReceivedShares value,
+          $Res Function(_$CoordinatorToUserKeyGenMessage_ReceivedShares) then) =
+      __$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWithImpl<$Res>;
   @useResult
   $Res call({DeviceId from});
 }
 
 /// @nodoc
-class __$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWithImpl<$Res>
+class __$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWithImpl<$Res>
     extends _$CoordinatorToUserKeyGenMessageCopyWithImpl<$Res,
-        _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl>
-    implements
-        _$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWith<$Res> {
-  __$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWithImpl(
-      _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl _value,
-      $Res Function(_$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl) _then)
+        _$CoordinatorToUserKeyGenMessage_ReceivedShares>
+    implements _$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWith<$Res> {
+  __$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWithImpl(
+      _$CoordinatorToUserKeyGenMessage_ReceivedShares _value,
+      $Res Function(_$CoordinatorToUserKeyGenMessage_ReceivedShares) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -129,7 +126,7 @@ class __$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWithImpl<$Res>
   $Res call({
     Object? from = null,
   }) {
-    return _then(_$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl(
+    return _then(_$CoordinatorToUserKeyGenMessage_ReceivedShares(
       from: null == from
           ? _value.from
           : from // ignore: cast_nullable_to_non_nullable
@@ -140,10 +137,9 @@ class __$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl
+class _$CoordinatorToUserKeyGenMessage_ReceivedShares
     implements CoordinatorToUserKeyGenMessage_ReceivedShares {
-  const _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl(
-      {required this.from});
+  const _$CoordinatorToUserKeyGenMessage_ReceivedShares({required this.from});
 
   @override
   final DeviceId from;
@@ -157,7 +153,7 @@ class _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl &&
+            other is _$CoordinatorToUserKeyGenMessage_ReceivedShares &&
             (identical(other.from, from) || other.from == from));
   }
 
@@ -167,11 +163,11 @@ class _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWith<
-          _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl>
+  _$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWith<
+          _$CoordinatorToUserKeyGenMessage_ReceivedShares>
       get copyWith =>
-          __$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWithImpl<
-                  _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl>(
+          __$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWithImpl<
+                  _$CoordinatorToUserKeyGenMessage_ReceivedShares>(
               this, _$identity);
 
   @override
@@ -265,34 +261,33 @@ abstract class CoordinatorToUserKeyGenMessage_ReceivedShares
     implements CoordinatorToUserKeyGenMessage {
   const factory CoordinatorToUserKeyGenMessage_ReceivedShares(
           {required final DeviceId from}) =
-      _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl;
+      _$CoordinatorToUserKeyGenMessage_ReceivedShares;
 
   DeviceId get from;
   @JsonKey(ignore: true)
-  _$$CoordinatorToUserKeyGenMessage_ReceivedSharesImplCopyWith<
-          _$CoordinatorToUserKeyGenMessage_ReceivedSharesImpl>
+  _$$CoordinatorToUserKeyGenMessage_ReceivedSharesCopyWith<
+          _$CoordinatorToUserKeyGenMessage_ReceivedShares>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWith<$Res> {
-  factory _$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWith(
-          _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl value,
-          $Res Function(_$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl)
-              then) =
-      __$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWithImpl<$Res>;
+abstract class _$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWith<$Res> {
+  factory _$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWith(
+          _$CoordinatorToUserKeyGenMessage_CheckKeyGen value,
+          $Res Function(_$CoordinatorToUserKeyGenMessage_CheckKeyGen) then) =
+      __$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWithImpl<$Res>;
   @useResult
   $Res call({U8Array32 sessionHash});
 }
 
 /// @nodoc
-class __$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWithImpl<$Res>
+class __$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWithImpl<$Res>
     extends _$CoordinatorToUserKeyGenMessageCopyWithImpl<$Res,
-        _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl>
-    implements _$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWith<$Res> {
-  __$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWithImpl(
-      _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl _value,
-      $Res Function(_$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl) _then)
+        _$CoordinatorToUserKeyGenMessage_CheckKeyGen>
+    implements _$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWith<$Res> {
+  __$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWithImpl(
+      _$CoordinatorToUserKeyGenMessage_CheckKeyGen _value,
+      $Res Function(_$CoordinatorToUserKeyGenMessage_CheckKeyGen) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -300,7 +295,7 @@ class __$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWithImpl<$Res>
   $Res call({
     Object? sessionHash = null,
   }) {
-    return _then(_$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl(
+    return _then(_$CoordinatorToUserKeyGenMessage_CheckKeyGen(
       sessionHash: null == sessionHash
           ? _value.sessionHash
           : sessionHash // ignore: cast_nullable_to_non_nullable
@@ -311,9 +306,9 @@ class __$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl
+class _$CoordinatorToUserKeyGenMessage_CheckKeyGen
     implements CoordinatorToUserKeyGenMessage_CheckKeyGen {
-  const _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl(
+  const _$CoordinatorToUserKeyGenMessage_CheckKeyGen(
       {required this.sessionHash});
 
   @override
@@ -328,7 +323,7 @@ class _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl &&
+            other is _$CoordinatorToUserKeyGenMessage_CheckKeyGen &&
             const DeepCollectionEquality()
                 .equals(other.sessionHash, sessionHash));
   }
@@ -340,12 +335,11 @@ class _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWith<
-          _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl>
+  _$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWith<
+          _$CoordinatorToUserKeyGenMessage_CheckKeyGen>
       get copyWith =>
-          __$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWithImpl<
-                  _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl>(
-              this, _$identity);
+          __$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWithImpl<
+              _$CoordinatorToUserKeyGenMessage_CheckKeyGen>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -438,33 +432,33 @@ abstract class CoordinatorToUserKeyGenMessage_CheckKeyGen
     implements CoordinatorToUserKeyGenMessage {
   const factory CoordinatorToUserKeyGenMessage_CheckKeyGen(
           {required final U8Array32 sessionHash}) =
-      _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl;
+      _$CoordinatorToUserKeyGenMessage_CheckKeyGen;
 
   U8Array32 get sessionHash;
   @JsonKey(ignore: true)
-  _$$CoordinatorToUserKeyGenMessage_CheckKeyGenImplCopyWith<
-          _$CoordinatorToUserKeyGenMessage_CheckKeyGenImpl>
+  _$$CoordinatorToUserKeyGenMessage_CheckKeyGenCopyWith<
+          _$CoordinatorToUserKeyGenMessage_CheckKeyGen>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWith<$Res> {
-  factory _$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWith(
-          _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl value,
-          $Res Function(_$CoordinatorToUserKeyGenMessage_KeyGenAckImpl) then) =
-      __$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWithImpl<$Res>;
+abstract class _$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWith<$Res> {
+  factory _$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWith(
+          _$CoordinatorToUserKeyGenMessage_KeyGenAck value,
+          $Res Function(_$CoordinatorToUserKeyGenMessage_KeyGenAck) then) =
+      __$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWithImpl<$Res>;
   @useResult
   $Res call({DeviceId from});
 }
 
 /// @nodoc
-class __$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWithImpl<$Res>
+class __$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWithImpl<$Res>
     extends _$CoordinatorToUserKeyGenMessageCopyWithImpl<$Res,
-        _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl>
-    implements _$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWith<$Res> {
-  __$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWithImpl(
-      _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl _value,
-      $Res Function(_$CoordinatorToUserKeyGenMessage_KeyGenAckImpl) _then)
+        _$CoordinatorToUserKeyGenMessage_KeyGenAck>
+    implements _$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWith<$Res> {
+  __$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWithImpl(
+      _$CoordinatorToUserKeyGenMessage_KeyGenAck _value,
+      $Res Function(_$CoordinatorToUserKeyGenMessage_KeyGenAck) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -472,7 +466,7 @@ class __$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWithImpl<$Res>
   $Res call({
     Object? from = null,
   }) {
-    return _then(_$CoordinatorToUserKeyGenMessage_KeyGenAckImpl(
+    return _then(_$CoordinatorToUserKeyGenMessage_KeyGenAck(
       from: null == from
           ? _value.from
           : from // ignore: cast_nullable_to_non_nullable
@@ -483,9 +477,9 @@ class __$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl
+class _$CoordinatorToUserKeyGenMessage_KeyGenAck
     implements CoordinatorToUserKeyGenMessage_KeyGenAck {
-  const _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl({required this.from});
+  const _$CoordinatorToUserKeyGenMessage_KeyGenAck({required this.from});
 
   @override
   final DeviceId from;
@@ -499,7 +493,7 @@ class _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl &&
+            other is _$CoordinatorToUserKeyGenMessage_KeyGenAck &&
             (identical(other.from, from) || other.from == from));
   }
 
@@ -509,11 +503,10 @@ class _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWith<
-          _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl>
-      get copyWith =>
-          __$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWithImpl<
-              _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl>(this, _$identity);
+  _$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWith<
+          _$CoordinatorToUserKeyGenMessage_KeyGenAck>
+      get copyWith => __$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWithImpl<
+          _$CoordinatorToUserKeyGenMessage_KeyGenAck>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -606,34 +599,33 @@ abstract class CoordinatorToUserKeyGenMessage_KeyGenAck
     implements CoordinatorToUserKeyGenMessage {
   const factory CoordinatorToUserKeyGenMessage_KeyGenAck(
           {required final DeviceId from}) =
-      _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl;
+      _$CoordinatorToUserKeyGenMessage_KeyGenAck;
 
   DeviceId get from;
   @JsonKey(ignore: true)
-  _$$CoordinatorToUserKeyGenMessage_KeyGenAckImplCopyWith<
-          _$CoordinatorToUserKeyGenMessage_KeyGenAckImpl>
+  _$$CoordinatorToUserKeyGenMessage_KeyGenAckCopyWith<
+          _$CoordinatorToUserKeyGenMessage_KeyGenAck>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWith<$Res> {
-  factory _$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWith(
-          _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl value,
-          $Res Function(_$CoordinatorToUserKeyGenMessage_FinishedKeyImpl)
-              then) =
-      __$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWithImpl<$Res>;
+abstract class _$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWith<$Res> {
+  factory _$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWith(
+          _$CoordinatorToUserKeyGenMessage_FinishedKey value,
+          $Res Function(_$CoordinatorToUserKeyGenMessage_FinishedKey) then) =
+      __$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWithImpl<$Res>;
   @useResult
   $Res call({KeyId keyId});
 }
 
 /// @nodoc
-class __$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWithImpl<$Res>
+class __$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWithImpl<$Res>
     extends _$CoordinatorToUserKeyGenMessageCopyWithImpl<$Res,
-        _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl>
-    implements _$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWith<$Res> {
-  __$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWithImpl(
-      _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl _value,
-      $Res Function(_$CoordinatorToUserKeyGenMessage_FinishedKeyImpl) _then)
+        _$CoordinatorToUserKeyGenMessage_FinishedKey>
+    implements _$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWith<$Res> {
+  __$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWithImpl(
+      _$CoordinatorToUserKeyGenMessage_FinishedKey _value,
+      $Res Function(_$CoordinatorToUserKeyGenMessage_FinishedKey) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -641,7 +633,7 @@ class __$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWithImpl<$Res>
   $Res call({
     Object? keyId = null,
   }) {
-    return _then(_$CoordinatorToUserKeyGenMessage_FinishedKeyImpl(
+    return _then(_$CoordinatorToUserKeyGenMessage_FinishedKey(
       keyId: null == keyId
           ? _value.keyId
           : keyId // ignore: cast_nullable_to_non_nullable
@@ -652,9 +644,9 @@ class __$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl
+class _$CoordinatorToUserKeyGenMessage_FinishedKey
     implements CoordinatorToUserKeyGenMessage_FinishedKey {
-  const _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl({required this.keyId});
+  const _$CoordinatorToUserKeyGenMessage_FinishedKey({required this.keyId});
 
   @override
   final KeyId keyId;
@@ -668,7 +660,7 @@ class _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl &&
+            other is _$CoordinatorToUserKeyGenMessage_FinishedKey &&
             (identical(other.keyId, keyId) || other.keyId == keyId));
   }
 
@@ -678,12 +670,11 @@ class _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWith<
-          _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl>
+  _$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWith<
+          _$CoordinatorToUserKeyGenMessage_FinishedKey>
       get copyWith =>
-          __$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWithImpl<
-                  _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl>(
-              this, _$identity);
+          __$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWithImpl<
+              _$CoordinatorToUserKeyGenMessage_FinishedKey>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -776,12 +767,12 @@ abstract class CoordinatorToUserKeyGenMessage_FinishedKey
     implements CoordinatorToUserKeyGenMessage {
   const factory CoordinatorToUserKeyGenMessage_FinishedKey(
           {required final KeyId keyId}) =
-      _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl;
+      _$CoordinatorToUserKeyGenMessage_FinishedKey;
 
   KeyId get keyId;
   @JsonKey(ignore: true)
-  _$$CoordinatorToUserKeyGenMessage_FinishedKeyImplCopyWith<
-          _$CoordinatorToUserKeyGenMessage_FinishedKeyImpl>
+  _$$CoordinatorToUserKeyGenMessage_FinishedKeyCopyWith<
+          _$CoordinatorToUserKeyGenMessage_FinishedKey>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -858,20 +849,20 @@ class _$PortEventCopyWithImpl<$Res, $Val extends PortEvent>
 }
 
 /// @nodoc
-abstract class _$$PortEvent_OpenImplCopyWith<$Res> {
-  factory _$$PortEvent_OpenImplCopyWith(_$PortEvent_OpenImpl value,
-          $Res Function(_$PortEvent_OpenImpl) then) =
-      __$$PortEvent_OpenImplCopyWithImpl<$Res>;
+abstract class _$$PortEvent_OpenCopyWith<$Res> {
+  factory _$$PortEvent_OpenCopyWith(
+          _$PortEvent_Open value, $Res Function(_$PortEvent_Open) then) =
+      __$$PortEvent_OpenCopyWithImpl<$Res>;
   @useResult
   $Res call({PortOpen request});
 }
 
 /// @nodoc
-class __$$PortEvent_OpenImplCopyWithImpl<$Res>
-    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_OpenImpl>
-    implements _$$PortEvent_OpenImplCopyWith<$Res> {
-  __$$PortEvent_OpenImplCopyWithImpl(
-      _$PortEvent_OpenImpl _value, $Res Function(_$PortEvent_OpenImpl) _then)
+class __$$PortEvent_OpenCopyWithImpl<$Res>
+    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_Open>
+    implements _$$PortEvent_OpenCopyWith<$Res> {
+  __$$PortEvent_OpenCopyWithImpl(
+      _$PortEvent_Open _value, $Res Function(_$PortEvent_Open) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -879,7 +870,7 @@ class __$$PortEvent_OpenImplCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$PortEvent_OpenImpl(
+    return _then(_$PortEvent_Open(
       request: null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -890,8 +881,8 @@ class __$$PortEvent_OpenImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PortEvent_OpenImpl implements PortEvent_Open {
-  const _$PortEvent_OpenImpl({required this.request});
+class _$PortEvent_Open implements PortEvent_Open {
+  const _$PortEvent_Open({required this.request});
 
   @override
   final PortOpen request;
@@ -905,7 +896,7 @@ class _$PortEvent_OpenImpl implements PortEvent_Open {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PortEvent_OpenImpl &&
+            other is _$PortEvent_Open &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -915,9 +906,8 @@ class _$PortEvent_OpenImpl implements PortEvent_Open {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PortEvent_OpenImplCopyWith<_$PortEvent_OpenImpl> get copyWith =>
-      __$$PortEvent_OpenImplCopyWithImpl<_$PortEvent_OpenImpl>(
-          this, _$identity);
+  _$$PortEvent_OpenCopyWith<_$PortEvent_Open> get copyWith =>
+      __$$PortEvent_OpenCopyWithImpl<_$PortEvent_Open>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -996,30 +986,30 @@ class _$PortEvent_OpenImpl implements PortEvent_Open {
 
 abstract class PortEvent_Open implements PortEvent {
   const factory PortEvent_Open({required final PortOpen request}) =
-      _$PortEvent_OpenImpl;
+      _$PortEvent_Open;
 
   @override
   PortOpen get request;
   @JsonKey(ignore: true)
-  _$$PortEvent_OpenImplCopyWith<_$PortEvent_OpenImpl> get copyWith =>
+  _$$PortEvent_OpenCopyWith<_$PortEvent_Open> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$PortEvent_WriteImplCopyWith<$Res> {
-  factory _$$PortEvent_WriteImplCopyWith(_$PortEvent_WriteImpl value,
-          $Res Function(_$PortEvent_WriteImpl) then) =
-      __$$PortEvent_WriteImplCopyWithImpl<$Res>;
+abstract class _$$PortEvent_WriteCopyWith<$Res> {
+  factory _$$PortEvent_WriteCopyWith(
+          _$PortEvent_Write value, $Res Function(_$PortEvent_Write) then) =
+      __$$PortEvent_WriteCopyWithImpl<$Res>;
   @useResult
   $Res call({PortWrite request});
 }
 
 /// @nodoc
-class __$$PortEvent_WriteImplCopyWithImpl<$Res>
-    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_WriteImpl>
-    implements _$$PortEvent_WriteImplCopyWith<$Res> {
-  __$$PortEvent_WriteImplCopyWithImpl(
-      _$PortEvent_WriteImpl _value, $Res Function(_$PortEvent_WriteImpl) _then)
+class __$$PortEvent_WriteCopyWithImpl<$Res>
+    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_Write>
+    implements _$$PortEvent_WriteCopyWith<$Res> {
+  __$$PortEvent_WriteCopyWithImpl(
+      _$PortEvent_Write _value, $Res Function(_$PortEvent_Write) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1027,7 +1017,7 @@ class __$$PortEvent_WriteImplCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$PortEvent_WriteImpl(
+    return _then(_$PortEvent_Write(
       request: null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -1038,8 +1028,8 @@ class __$$PortEvent_WriteImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PortEvent_WriteImpl implements PortEvent_Write {
-  const _$PortEvent_WriteImpl({required this.request});
+class _$PortEvent_Write implements PortEvent_Write {
+  const _$PortEvent_Write({required this.request});
 
   @override
   final PortWrite request;
@@ -1053,7 +1043,7 @@ class _$PortEvent_WriteImpl implements PortEvent_Write {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PortEvent_WriteImpl &&
+            other is _$PortEvent_Write &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -1063,9 +1053,8 @@ class _$PortEvent_WriteImpl implements PortEvent_Write {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PortEvent_WriteImplCopyWith<_$PortEvent_WriteImpl> get copyWith =>
-      __$$PortEvent_WriteImplCopyWithImpl<_$PortEvent_WriteImpl>(
-          this, _$identity);
+  _$$PortEvent_WriteCopyWith<_$PortEvent_Write> get copyWith =>
+      __$$PortEvent_WriteCopyWithImpl<_$PortEvent_Write>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1144,30 +1133,30 @@ class _$PortEvent_WriteImpl implements PortEvent_Write {
 
 abstract class PortEvent_Write implements PortEvent {
   const factory PortEvent_Write({required final PortWrite request}) =
-      _$PortEvent_WriteImpl;
+      _$PortEvent_Write;
 
   @override
   PortWrite get request;
   @JsonKey(ignore: true)
-  _$$PortEvent_WriteImplCopyWith<_$PortEvent_WriteImpl> get copyWith =>
+  _$$PortEvent_WriteCopyWith<_$PortEvent_Write> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$PortEvent_ReadImplCopyWith<$Res> {
-  factory _$$PortEvent_ReadImplCopyWith(_$PortEvent_ReadImpl value,
-          $Res Function(_$PortEvent_ReadImpl) then) =
-      __$$PortEvent_ReadImplCopyWithImpl<$Res>;
+abstract class _$$PortEvent_ReadCopyWith<$Res> {
+  factory _$$PortEvent_ReadCopyWith(
+          _$PortEvent_Read value, $Res Function(_$PortEvent_Read) then) =
+      __$$PortEvent_ReadCopyWithImpl<$Res>;
   @useResult
   $Res call({PortRead request});
 }
 
 /// @nodoc
-class __$$PortEvent_ReadImplCopyWithImpl<$Res>
-    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_ReadImpl>
-    implements _$$PortEvent_ReadImplCopyWith<$Res> {
-  __$$PortEvent_ReadImplCopyWithImpl(
-      _$PortEvent_ReadImpl _value, $Res Function(_$PortEvent_ReadImpl) _then)
+class __$$PortEvent_ReadCopyWithImpl<$Res>
+    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_Read>
+    implements _$$PortEvent_ReadCopyWith<$Res> {
+  __$$PortEvent_ReadCopyWithImpl(
+      _$PortEvent_Read _value, $Res Function(_$PortEvent_Read) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1175,7 +1164,7 @@ class __$$PortEvent_ReadImplCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$PortEvent_ReadImpl(
+    return _then(_$PortEvent_Read(
       request: null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -1186,8 +1175,8 @@ class __$$PortEvent_ReadImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PortEvent_ReadImpl implements PortEvent_Read {
-  const _$PortEvent_ReadImpl({required this.request});
+class _$PortEvent_Read implements PortEvent_Read {
+  const _$PortEvent_Read({required this.request});
 
   @override
   final PortRead request;
@@ -1201,7 +1190,7 @@ class _$PortEvent_ReadImpl implements PortEvent_Read {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PortEvent_ReadImpl &&
+            other is _$PortEvent_Read &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -1211,9 +1200,8 @@ class _$PortEvent_ReadImpl implements PortEvent_Read {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PortEvent_ReadImplCopyWith<_$PortEvent_ReadImpl> get copyWith =>
-      __$$PortEvent_ReadImplCopyWithImpl<_$PortEvent_ReadImpl>(
-          this, _$identity);
+  _$$PortEvent_ReadCopyWith<_$PortEvent_Read> get copyWith =>
+      __$$PortEvent_ReadCopyWithImpl<_$PortEvent_Read>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1292,31 +1280,30 @@ class _$PortEvent_ReadImpl implements PortEvent_Read {
 
 abstract class PortEvent_Read implements PortEvent {
   const factory PortEvent_Read({required final PortRead request}) =
-      _$PortEvent_ReadImpl;
+      _$PortEvent_Read;
 
   @override
   PortRead get request;
   @JsonKey(ignore: true)
-  _$$PortEvent_ReadImplCopyWith<_$PortEvent_ReadImpl> get copyWith =>
+  _$$PortEvent_ReadCopyWith<_$PortEvent_Read> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$PortEvent_BytesToReadImplCopyWith<$Res> {
-  factory _$$PortEvent_BytesToReadImplCopyWith(
-          _$PortEvent_BytesToReadImpl value,
-          $Res Function(_$PortEvent_BytesToReadImpl) then) =
-      __$$PortEvent_BytesToReadImplCopyWithImpl<$Res>;
+abstract class _$$PortEvent_BytesToReadCopyWith<$Res> {
+  factory _$$PortEvent_BytesToReadCopyWith(_$PortEvent_BytesToRead value,
+          $Res Function(_$PortEvent_BytesToRead) then) =
+      __$$PortEvent_BytesToReadCopyWithImpl<$Res>;
   @useResult
   $Res call({PortBytesToRead request});
 }
 
 /// @nodoc
-class __$$PortEvent_BytesToReadImplCopyWithImpl<$Res>
-    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_BytesToReadImpl>
-    implements _$$PortEvent_BytesToReadImplCopyWith<$Res> {
-  __$$PortEvent_BytesToReadImplCopyWithImpl(_$PortEvent_BytesToReadImpl _value,
-      $Res Function(_$PortEvent_BytesToReadImpl) _then)
+class __$$PortEvent_BytesToReadCopyWithImpl<$Res>
+    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_BytesToRead>
+    implements _$$PortEvent_BytesToReadCopyWith<$Res> {
+  __$$PortEvent_BytesToReadCopyWithImpl(_$PortEvent_BytesToRead _value,
+      $Res Function(_$PortEvent_BytesToRead) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1324,7 +1311,7 @@ class __$$PortEvent_BytesToReadImplCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$PortEvent_BytesToReadImpl(
+    return _then(_$PortEvent_BytesToRead(
       request: null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -1335,8 +1322,8 @@ class __$$PortEvent_BytesToReadImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PortEvent_BytesToReadImpl implements PortEvent_BytesToRead {
-  const _$PortEvent_BytesToReadImpl({required this.request});
+class _$PortEvent_BytesToRead implements PortEvent_BytesToRead {
+  const _$PortEvent_BytesToRead({required this.request});
 
   @override
   final PortBytesToRead request;
@@ -1350,7 +1337,7 @@ class _$PortEvent_BytesToReadImpl implements PortEvent_BytesToRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PortEvent_BytesToReadImpl &&
+            other is _$PortEvent_BytesToRead &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -1360,9 +1347,9 @@ class _$PortEvent_BytesToReadImpl implements PortEvent_BytesToRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PortEvent_BytesToReadImplCopyWith<_$PortEvent_BytesToReadImpl>
-      get copyWith => __$$PortEvent_BytesToReadImplCopyWithImpl<
-          _$PortEvent_BytesToReadImpl>(this, _$identity);
+  _$$PortEvent_BytesToReadCopyWith<_$PortEvent_BytesToRead> get copyWith =>
+      __$$PortEvent_BytesToReadCopyWithImpl<_$PortEvent_BytesToRead>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1441,13 +1428,13 @@ class _$PortEvent_BytesToReadImpl implements PortEvent_BytesToRead {
 
 abstract class PortEvent_BytesToRead implements PortEvent {
   const factory PortEvent_BytesToRead(
-      {required final PortBytesToRead request}) = _$PortEvent_BytesToReadImpl;
+      {required final PortBytesToRead request}) = _$PortEvent_BytesToRead;
 
   @override
   PortBytesToRead get request;
   @JsonKey(ignore: true)
-  _$$PortEvent_BytesToReadImplCopyWith<_$PortEvent_BytesToReadImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$PortEvent_BytesToReadCopyWith<_$PortEvent_BytesToRead> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -1512,23 +1499,21 @@ class _$SignTaskDescriptionCopyWithImpl<$Res, $Val extends SignTaskDescription>
 }
 
 /// @nodoc
-abstract class _$$SignTaskDescription_PlainImplCopyWith<$Res> {
-  factory _$$SignTaskDescription_PlainImplCopyWith(
-          _$SignTaskDescription_PlainImpl value,
-          $Res Function(_$SignTaskDescription_PlainImpl) then) =
-      __$$SignTaskDescription_PlainImplCopyWithImpl<$Res>;
+abstract class _$$SignTaskDescription_PlainCopyWith<$Res> {
+  factory _$$SignTaskDescription_PlainCopyWith(
+          _$SignTaskDescription_Plain value,
+          $Res Function(_$SignTaskDescription_Plain) then) =
+      __$$SignTaskDescription_PlainCopyWithImpl<$Res>;
   @useResult
   $Res call({String message});
 }
 
 /// @nodoc
-class __$$SignTaskDescription_PlainImplCopyWithImpl<$Res>
-    extends _$SignTaskDescriptionCopyWithImpl<$Res,
-        _$SignTaskDescription_PlainImpl>
-    implements _$$SignTaskDescription_PlainImplCopyWith<$Res> {
-  __$$SignTaskDescription_PlainImplCopyWithImpl(
-      _$SignTaskDescription_PlainImpl _value,
-      $Res Function(_$SignTaskDescription_PlainImpl) _then)
+class __$$SignTaskDescription_PlainCopyWithImpl<$Res>
+    extends _$SignTaskDescriptionCopyWithImpl<$Res, _$SignTaskDescription_Plain>
+    implements _$$SignTaskDescription_PlainCopyWith<$Res> {
+  __$$SignTaskDescription_PlainCopyWithImpl(_$SignTaskDescription_Plain _value,
+      $Res Function(_$SignTaskDescription_Plain) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1536,7 +1521,7 @@ class __$$SignTaskDescription_PlainImplCopyWithImpl<$Res>
   $Res call({
     Object? message = null,
   }) {
-    return _then(_$SignTaskDescription_PlainImpl(
+    return _then(_$SignTaskDescription_Plain(
       message: null == message
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
@@ -1547,8 +1532,8 @@ class __$$SignTaskDescription_PlainImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$SignTaskDescription_PlainImpl implements SignTaskDescription_Plain {
-  const _$SignTaskDescription_PlainImpl({required this.message});
+class _$SignTaskDescription_Plain implements SignTaskDescription_Plain {
+  const _$SignTaskDescription_Plain({required this.message});
 
   @override
   final String message;
@@ -1562,7 +1547,7 @@ class _$SignTaskDescription_PlainImpl implements SignTaskDescription_Plain {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SignTaskDescription_PlainImpl &&
+            other is _$SignTaskDescription_Plain &&
             (identical(other.message, message) || other.message == message));
   }
 
@@ -1572,9 +1557,9 @@ class _$SignTaskDescription_PlainImpl implements SignTaskDescription_Plain {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SignTaskDescription_PlainImplCopyWith<_$SignTaskDescription_PlainImpl>
-      get copyWith => __$$SignTaskDescription_PlainImplCopyWithImpl<
-          _$SignTaskDescription_PlainImpl>(this, _$identity);
+  _$$SignTaskDescription_PlainCopyWith<_$SignTaskDescription_Plain>
+      get copyWith => __$$SignTaskDescription_PlainCopyWithImpl<
+          _$SignTaskDescription_Plain>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1642,32 +1627,32 @@ class _$SignTaskDescription_PlainImpl implements SignTaskDescription_Plain {
 
 abstract class SignTaskDescription_Plain implements SignTaskDescription {
   const factory SignTaskDescription_Plain({required final String message}) =
-      _$SignTaskDescription_PlainImpl;
+      _$SignTaskDescription_Plain;
 
   String get message;
   @JsonKey(ignore: true)
-  _$$SignTaskDescription_PlainImplCopyWith<_$SignTaskDescription_PlainImpl>
+  _$$SignTaskDescription_PlainCopyWith<_$SignTaskDescription_Plain>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$SignTaskDescription_TransactionImplCopyWith<$Res> {
-  factory _$$SignTaskDescription_TransactionImplCopyWith(
-          _$SignTaskDescription_TransactionImpl value,
-          $Res Function(_$SignTaskDescription_TransactionImpl) then) =
-      __$$SignTaskDescription_TransactionImplCopyWithImpl<$Res>;
+abstract class _$$SignTaskDescription_TransactionCopyWith<$Res> {
+  factory _$$SignTaskDescription_TransactionCopyWith(
+          _$SignTaskDescription_Transaction value,
+          $Res Function(_$SignTaskDescription_Transaction) then) =
+      __$$SignTaskDescription_TransactionCopyWithImpl<$Res>;
   @useResult
   $Res call({UnsignedTx unsignedTx});
 }
 
 /// @nodoc
-class __$$SignTaskDescription_TransactionImplCopyWithImpl<$Res>
+class __$$SignTaskDescription_TransactionCopyWithImpl<$Res>
     extends _$SignTaskDescriptionCopyWithImpl<$Res,
-        _$SignTaskDescription_TransactionImpl>
-    implements _$$SignTaskDescription_TransactionImplCopyWith<$Res> {
-  __$$SignTaskDescription_TransactionImplCopyWithImpl(
-      _$SignTaskDescription_TransactionImpl _value,
-      $Res Function(_$SignTaskDescription_TransactionImpl) _then)
+        _$SignTaskDescription_Transaction>
+    implements _$$SignTaskDescription_TransactionCopyWith<$Res> {
+  __$$SignTaskDescription_TransactionCopyWithImpl(
+      _$SignTaskDescription_Transaction _value,
+      $Res Function(_$SignTaskDescription_Transaction) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1675,7 +1660,7 @@ class __$$SignTaskDescription_TransactionImplCopyWithImpl<$Res>
   $Res call({
     Object? unsignedTx = null,
   }) {
-    return _then(_$SignTaskDescription_TransactionImpl(
+    return _then(_$SignTaskDescription_Transaction(
       unsignedTx: null == unsignedTx
           ? _value.unsignedTx
           : unsignedTx // ignore: cast_nullable_to_non_nullable
@@ -1686,9 +1671,9 @@ class __$$SignTaskDescription_TransactionImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$SignTaskDescription_TransactionImpl
+class _$SignTaskDescription_Transaction
     implements SignTaskDescription_Transaction {
-  const _$SignTaskDescription_TransactionImpl({required this.unsignedTx});
+  const _$SignTaskDescription_Transaction({required this.unsignedTx});
 
   @override
   final UnsignedTx unsignedTx;
@@ -1702,7 +1687,7 @@ class _$SignTaskDescription_TransactionImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SignTaskDescription_TransactionImpl &&
+            other is _$SignTaskDescription_Transaction &&
             (identical(other.unsignedTx, unsignedTx) ||
                 other.unsignedTx == unsignedTx));
   }
@@ -1713,10 +1698,9 @@ class _$SignTaskDescription_TransactionImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SignTaskDescription_TransactionImplCopyWith<
-          _$SignTaskDescription_TransactionImpl>
-      get copyWith => __$$SignTaskDescription_TransactionImplCopyWithImpl<
-          _$SignTaskDescription_TransactionImpl>(this, _$identity);
+  _$$SignTaskDescription_TransactionCopyWith<_$SignTaskDescription_Transaction>
+      get copyWith => __$$SignTaskDescription_TransactionCopyWithImpl<
+          _$SignTaskDescription_Transaction>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1785,11 +1769,10 @@ class _$SignTaskDescription_TransactionImpl
 abstract class SignTaskDescription_Transaction implements SignTaskDescription {
   const factory SignTaskDescription_Transaction(
           {required final UnsignedTx unsignedTx}) =
-      _$SignTaskDescription_TransactionImpl;
+      _$SignTaskDescription_Transaction;
 
   UnsignedTx get unsignedTx;
   @JsonKey(ignore: true)
-  _$$SignTaskDescription_TransactionImplCopyWith<
-          _$SignTaskDescription_TransactionImpl>
+  _$$SignTaskDescription_TransactionCopyWith<_$SignTaskDescription_Transaction>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/frostsnapp/native/src/api.rs
+++ b/frostsnapp/native/src/api.rs
@@ -275,8 +275,6 @@ pub fn get_device(id: DeviceId) -> SyncReturn<Device> {
     SyncReturn(device)
 }
 
-pub type SessionHash = [u8; 32];
-
 #[derive(Clone, Debug, Copy)]
 #[frb(mirror(EncodedSignature))]
 pub struct _EncodedSignature(pub [u8; 64]);
@@ -299,7 +297,7 @@ impl SigningState {
 #[frb(mirror(CoordinatorToUserKeyGenMessage))]
 pub enum _CoordinatorToUserKeyGenMessage {
     ReceivedShares { from: DeviceId },
-    CheckKeyGen { session_hash: SessionHash },
+    CheckKeyGen { session_hash: [u8; 32] },
     KeyGenAck { from: DeviceId },
     FinishedKey { key_id: KeyId },
 }
@@ -363,6 +361,7 @@ fn _load(db_file: String, usb_serial_manager: UsbSerialManager) -> Result<(Coord
         .read(true)
         .write(true)
         .create(true) // Creates the file if it does not exist
+        .truncate(false)
         .open(db_file.clone())?;
 
     event!(TLevel::INFO, path = db_file, "initializing database");


### PR DESCRIPTION
This allows us to drop the nightly toolchain. I deleted the toolchain.toml file.

One peculiar thing I had to do was lower the heap size to avoid some allocation failures. It would be really good to understand why this was necessary before merging.

Main benefit of this is that it seems to fix the problem of panic messages not being displayed in the panic handler. Note i'm not sure if that's to do with lowering the heap size or just the dependency upgrade.

This is on top of #117 