### PR TITLE
Update BDK to 0.15 with patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,8 +154,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_chain"
-version = "0.9.0"
-source = "git+https://github.com/LLFourn/bdk.git?rev=775dad3#775dad3aaac01efbdb6f35c7bde42c4d8a96bf71"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e879c03ebf3a64643295152a19a8b0e0a3af22e25539d2bc56ce07d07b059c33"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -169,9 +170,9 @@ source = "git+https://github.com/LLFourn/coin-select.git?rev=8eb582bc08bee173a41
 
 [[package]]
 name = "bdk_electrum"
-version = "0.7.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06513112a7cc09c36cfe14e10bfddb0d26df284597da8d67066a1b7d05eee22d"
+checksum = "fabef52d0a5137612472fce949b2ce27085a094b62bac61f6828e97c46ade231"
 dependencies = [
  "bdk_chain",
  "electrum-client",
@@ -182,6 +183,12 @@ name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.10.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bincode"
@@ -210,16 +217,26 @@ checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitcoin"
-version = "0.30.2"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1945a5048598e4189e239d3f809b19bdad4845c4b2ba400d304d2dcf26d2c462"
+checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
- "bech32",
- "bitcoin-private",
- "bitcoin_hashes",
+ "bech32 0.10.0-beta",
+ "bitcoin-internals",
+ "bitcoin_hashes 0.13.0",
  "core2",
+ "hex-conservative",
  "hex_lit",
- "secp256k1 0.27.0",
+ "secp256k1 0.28.2",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+dependencies = [
  "serde",
 ]
 
@@ -236,7 +253,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
  "core2",
+ "hex-conservative",
  "serde",
 ]
 
@@ -530,19 +557,17 @@ dependencies = [
 
 [[package]]
 name = "electrum-client"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc133f1c8d829d254f013f946653cbeb2b08674b960146361d1e9b67733ad19"
+checksum = "89008f106be6f303695522f2f4c1f28b40c3e8367ed8b3bb227f1f882cb52cc2"
 dependencies = [
  "bitcoin",
- "bitcoin-private",
  "byteorder",
  "libc",
  "log",
  "rustls",
  "serde",
  "serde_json",
- "webpki",
  "webpki-roots",
  "winapi",
 ]
@@ -1051,6 +1076,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "379dada1584ad501b383485dd706b8afb7a70fcbc7f4da7d780638a5a6124a60"
 
 [[package]]
+name = "hex-conservative"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+dependencies = [
+ "core2",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,12 +1267,13 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb102b66b2127a872dbcc73095b7b47aeb9d92f7b03c2b2298253ffc82c7594"
+checksum = "86a23dd3ad145a980e231185d114399f25a0a307d2cd918010ddda6334323df9"
 dependencies = [
+ "bech32 0.10.0-beta",
  "bitcoin",
- "bitcoin-private",
+ "bitcoin-internals",
 ]
 
 [[package]]
@@ -1647,7 +1682,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f8fbe78e3698a49208f5dd1a1d602908493ec800dd49147b1570b4eae84a1e"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "secp256kfun",
 ]
 
@@ -1673,7 +1708,6 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "bitcoin_hashes",
  "secp256k1-sys 0.8.1",
  "serde",
 ]
@@ -1684,6 +1718,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
+ "bitcoin_hashes 0.12.0",
  "secp256k1-sys 0.9.2",
  "serde",
 ]
@@ -2196,23 +2231,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,8 +155,7 @@ dependencies = [
 [[package]]
 name = "bdk_chain"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c601c4dc7e6c3efa538a0afbb43b964cefab9a9b5e8f352fa0ca38145448a5e7"
+source = "git+https://github.com/LLFourn/bdk.git?rev=a6528923ad2e48a4bf258ba35c757f5cc194cf81#a6528923ad2e48a4bf258ba35c757f5cc194cf81"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -172,8 +171,7 @@ checksum = "3c084bf76f0f67546fc814ffa82044144be1bb4618183a15016c162f8b087ad4"
 [[package]]
 name = "bdk_electrum"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28906275aeb1f71dc32045670f06c8a26fb17cc62151a99f7425d258f4bda589"
+source = "git+https://github.com/LLFourn/bdk.git?rev=a6528923ad2e48a4bf258ba35c757f5cc194cf81#a6528923ad2e48a4bf258ba35c757f5cc194cf81"
 dependencies = [
  "bdk_chain",
  "electrum-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_chain"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e879c03ebf3a64643295152a19a8b0e0a3af22e25539d2bc56ce07d07b059c33"
+checksum = "c601c4dc7e6c3efa538a0afbb43b964cefab9a9b5e8f352fa0ca38145448a5e7"
 dependencies = [
  "bitcoin",
  "miniscript",
@@ -165,14 +165,15 @@ dependencies = [
 
 [[package]]
 name = "bdk_coin_select"
-version = "0.2.0"
-source = "git+https://github.com/LLFourn/coin-select.git?rev=8eb582bc08bee173a41508a915fd2609e954f313#8eb582bc08bee173a41508a915fd2609e954f313"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c084bf76f0f67546fc814ffa82044144be1bb4618183a15016c162f8b087ad4"
 
 [[package]]
 name = "bdk_electrum"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabef52d0a5137612472fce949b2ce27085a094b62bac61f6828e97c46ade231"
+checksum = "28906275aeb1f71dc32045670f06c8a26fb17cc62151a99f7425d258f4bda589"
 dependencies = [
  "bdk_chain",
  "electrum-client",
@@ -223,7 +224,7 @@ checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "bech32 0.10.0-beta",
  "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "core2",
  "hex-conservative",
  "hex_lit",
@@ -238,21 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
 ]
 
 [[package]]
@@ -1274,6 +1260,7 @@ dependencies = [
  "bech32 0.10.0-beta",
  "bitcoin",
  "bitcoin-internals",
+ "serde",
 ]
 
 [[package]]
@@ -1718,7 +1705,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes",
  "secp256k1-sys 0.9.2",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,9 @@ tracing = { version = "0.1", default-features = false }
 llsdb = { git = "https://github.com/LLFourn/llsdb.git", rev = "b1540959897b098e7fea28799a377e210b365357" }
 rand_chacha = { version = "0.3", default-features = false }
 sha2 = { version = "0.10", default-features = false }
+
+
+[patch.crates-io]
+# bdk_chain = { path = "../bdk/crates/chain" }
+bdk_chain = { git = "https://github.com/LLFourn/bdk.git", rev = "165f06b8f78bd24f57dfbfd66da1faa189c67457" }
+bdk_electrum = { git = "https://github.com/LLFourn/bdk.git", rev = "165f06b8f78bd24f57dfbfd66da1faa189c67457" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,3 @@ frostsnap_coordinator = { path = "frostsnap_coordinator" }
 tracing = { version = "0.1", default-features = false }
 llsdb = { git = "https://github.com/LLFourn/llsdb.git", rev = "b1540959897b098e7fea28799a377e210b365357" }
 rand_chacha = { version = "0.3", default-features = false }
-
-[patch.crates-io]
-bdk_chain = { git = "https://github.com/LLFourn/bdk.git", rev = "775dad3"  , version = "0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ frostsnap_coordinator = { path = "frostsnap_coordinator" }
 tracing = { version = "0.1", default-features = false }
 llsdb = { git = "https://github.com/LLFourn/llsdb.git", rev = "b1540959897b098e7fea28799a377e210b365357" }
 rand_chacha = { version = "0.3", default-features = false }
+sha2 = { version = "0.10", default-features = false }

--- a/frostsnap_core/Cargo.toml
+++ b/frostsnap_core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 rand_core = { version = "0.6", default-features = false }
 schnorr_fun = { version = "0.10", features = ["bincode", "serde","alloc", "share_backup"], default-features = false }
 rand_chacha = { workspace = true }
-sha2 = {  version = "0.10", default-features = false }
+sha2.workspace = true
 chacha20 = { version = "0.9", default-features = false }
 serde = { workspace = true }
 bitcoin = { version = "0.31", features = ["no-std", "serde"], default-features = false }

--- a/frostsnap_core/Cargo.toml
+++ b/frostsnap_core/Cargo.toml
@@ -12,7 +12,7 @@ rand_chacha = { workspace = true }
 sha2 = {  version = "0.10", default-features = false }
 chacha20 = { version = "0.9", default-features = false }
 serde = { workspace = true }
-bitcoin = { version = "0.30", features = ["no-std", "serde"], default-features = false }
+bitcoin = { version = "0.31", features = ["no-std", "serde"], default-features = false }
 bincode = { workspace = true }
 serde_json = { version = "1", optional = true }
 tracing = { workspace = true, default-features = false, optional = true }

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -1,6 +1,5 @@
 use crate::{
-    gen_pop_message, message::*, ActionError, Error, FrostKeyExt, KeyId,
-    MessageResult, SessionHash,
+    gen_pop_message, message::*, ActionError, Error, FrostKeyExt, KeyId, MessageResult, SessionHash,
 };
 use alloc::{
     collections::{BTreeMap, BTreeSet},

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -1,5 +1,6 @@
 use crate::{
-    gen_pop_message, message::*, ActionError, Error, FrostKeyExt, KeyId, MessageResult, SessionHash,
+    gen_pop_message, message::*, ActionError, Error, FrostKeyExt, KeyId,
+    MessageResult, SessionHash,
 };
 use alloc::{
     collections::{BTreeMap, BTreeSet},
@@ -666,7 +667,7 @@ pub struct SignSessionProgress {
     sign_item: SignItem,
     sign_session: SignSession,
     signature_shares: BTreeMap<DeviceId, Scalar<Public, Zero>>,
-    key: EncodedFrostKey,
+    root_key: EncodedFrostKey,
 }
 
 impl SignSessionProgress {
@@ -676,15 +677,14 @@ impl SignSessionProgress {
         sign_item: SignItem,
         nonces: BTreeMap<frost::PartyIndex, frost::Nonce>,
     ) -> Self {
-        // FIXME: This shouldn't be raw -- plain messages should do domain separation
-        let b_message = Message::raw(&sign_item.message[..]);
         let tweaked_key = sign_item.derive_key(&root_key.into_frost_key());
-        let sign_session = frost.start_sign_session(&tweaked_key, nonces, b_message);
+        let sign_session =
+            frost.start_sign_session(&tweaked_key, nonces, sign_item.schnorr_fun_message());
         Self {
             sign_item,
             sign_session,
             signature_shares: Default::default(),
-            key: root_key,
+            root_key,
         }
     }
 
@@ -693,7 +693,7 @@ impl SignSessionProgress {
     }
 
     pub fn tweaked_frost_key(&self) -> FrostKey<EvenY> {
-        self.sign_item.derive_key(&self.key.into_frost_key())
+        self.sign_item.derive_key(&self.root_key.into_frost_key())
     }
 
     pub fn verify_final_signature<NG>(
@@ -701,12 +701,11 @@ impl SignSessionProgress {
         schnorr: &Schnorr<sha2::Sha256, NG>,
         signature: &Signature,
     ) -> bool {
-        // FIXME: This shouldn't be raw -- plain messages should do domain separation
-        let b_message = Message::<Public>::raw(&self.sign_item.message[..]);
-
-        let derived_key = self.tweaked_frost_key().public_key();
-
-        schnorr.verify(&derived_key, b_message, signature)
+        self.sign_item.verify_final_signature(
+            schnorr,
+            self.root_key.into_frost_key().public_key(),
+            signature,
+        )
     }
 }
 

--- a/frostsnap_core/src/lib.rs
+++ b/frostsnap_core/src/lib.rs
@@ -8,7 +8,7 @@ mod key_id;
 mod macros;
 pub mod message;
 pub mod nostr;
-pub mod xpub;
+pub mod tweak;
 
 pub use bincode;
 pub use key_id::*;

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -1,19 +1,14 @@
 use crate::encrypted_share::EncryptedShare;
-use crate::xpub::TweakableKey;
-use crate::CoordinatorFrostKey;
-use crate::FrostsnapSecretKey;
-use crate::Gist;
-use crate::KeyId;
-use crate::SessionHash;
-use crate::SigningSessionState;
-use crate::Vec;
+use crate::tweak::AppTweak;
+use crate::{
+    tweak::TweakableKey, CoordinatorFrostKey, FrostsnapSecretKey, Gist, KeyId, SessionHash,
+    SigningSessionState, Vec,
+};
 use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
-use schnorr_fun::fun::marker::NonZero;
-use schnorr_fun::fun::marker::Public;
-use schnorr_fun::fun::marker::Zero;
+use schnorr_fun::fun::marker::*;
 use schnorr_fun::fun::Point;
 use schnorr_fun::fun::Scalar;
 use schnorr_fun::musig::Nonce;
@@ -256,11 +251,11 @@ pub enum SignTask {
         #[bincode(with_serde)]
         event: Box<crate::nostr::UnsignedEvent>,
     }, // 1 nonce & sig
-    Transaction(TransactionSignTask),
+    BitcoinTransaction(BitcoinTransactionSignTask),
 }
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct TransactionSignTask {
+pub struct BitcoinTransactionSignTask {
     #[bincode(with_serde)]
     pub tx_template: bitcoin::Transaction,
     pub prevouts: Vec<TxInput>,
@@ -290,7 +285,7 @@ impl core::fmt::Display for SignTask {
                 write!(f, "Plain:{}", String::from_utf8_lossy(message))
             }
             SignTask::Nostr { event, .. } => write!(f, "Nostr: {}", event.content),
-            SignTask::Transaction(TransactionSignTask { tx_template, .. }) => {
+            SignTask::BitcoinTransaction(BitcoinTransactionSignTask { tx_template, .. }) => {
                 let mut lines = vec![];
                 for output in &tx_template.output {
                     let address = bitcoin::Address::from_script(
@@ -324,15 +319,13 @@ impl SignTask {
         match self {
             SignTask::Plain { message } => vec![SignItem {
                 message: message.clone(),
-                tap_tweak: false,
-                bip32_path: vec![],
+                app_tweak: AppTweak::TestMessage,
             }],
             SignTask::Nostr { event } => vec![SignItem {
                 message: event.hash_bytes.clone(),
-                tap_tweak: false,
-                bip32_path: vec![],
+                app_tweak: AppTweak::Nostr,
             }],
-            SignTask::Transaction(TransactionSignTask {
+            SignTask::BitcoinTransaction(BitcoinTransactionSignTask {
                 tx_template,
                 prevouts,
             }) => {
@@ -359,8 +352,7 @@ impl SignTask {
                         let bip32_path = input.bip32_path.clone()?;
                         Some(SignItem {
                             message: sighash.as_raw_hash().to_byte_array().to_vec(),
-                            bip32_path,
-                            tap_tweak: true,
+                            app_tweak: AppTweak::Bitcoin { bip32_path },
                         })
                     })
                     .collect();
@@ -374,31 +366,31 @@ impl SignTask {
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode)]
 pub struct SignItem {
     pub message: Vec<u8>,
-    pub tap_tweak: bool,
-    pub bip32_path: Vec<u32>,
+    pub app_tweak: AppTweak,
 }
 
 impl SignItem {
     pub fn derive_key<K: TweakableKey>(&self, root_key: &K) -> K::XOnly {
-        let derived_key = {
-            let mut xpub = crate::xpub::Xpub::new(root_key.clone());
-            xpub.derive_bip32(&self.bip32_path);
-            xpub.into_key()
-        };
+        let (app_key, extra) = root_key.app_tweak_and_expand(self.app_tweak.kind());
 
-        if self.tap_tweak {
-            let tweak = bitcoin::taproot::TapTweakHash::from_key_and_tweak(
-                derived_key.to_libsecp_xonly(),
-                None,
-            )
-            .to_scalar();
-            derived_key.into_xonly_with_tweak(
-                Scalar::<Public, _>::from_bytes_mod_order(tweak.to_be_bytes())
-                    .non_zero()
-                    .expect("computationally unreachable"),
-            )
-        } else {
-            derived_key.into_xonly()
+        match &self.app_tweak {
+            AppTweak::Bitcoin { bip32_path } => {
+                let mut xpub = crate::tweak::Xpub::new(app_key, extra);
+                xpub.derive_bip32(bip32_path);
+                let derived_key = xpub.into_key();
+                let tweak = bitcoin::taproot::TapTweakHash::from_key_and_tweak(
+                    derived_key.to_libsecp_xonly(),
+                    None,
+                )
+                .to_scalar();
+                derived_key.into_xonly_with_tweak(
+                    Scalar::<Public, _>::from_bytes_mod_order(tweak.to_be_bytes())
+                        .non_zero()
+                        .expect("computationally unreachable"),
+                )
+            }
+            AppTweak::Nostr => app_key.into_xonly(),
+            AppTweak::TestMessage => app_key.into_xonly(),
         }
     }
 

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -345,7 +345,7 @@ impl SignTask {
                     let sighash = sighash_cache
                         .taproot_key_spend_signature_hash(
                             i,
-                            &bitcoin::psbt::Prevouts::All(prevouts),
+                            &bitcoin::sighash::Prevouts::All(prevouts),
                             schnorr_sighashty,
                         )
                         .unwrap(); // TODO remove unwrap

--- a/frostsnap_core/src/tweak.rs
+++ b/frostsnap_core/src/tweak.rs
@@ -4,6 +4,40 @@ use schnorr_fun::{
     fun::{g, marker::*, Point, Scalar, G},
 };
 
+#[derive(Clone, Debug, PartialEq, bincode::Encode, bincode::Decode)]
+pub enum AppTweak {
+    TestMessage,
+    Bitcoin { bip32_path: alloc::vec::Vec<u32> },
+    Nostr,
+}
+
+impl AppTweak {
+    pub fn kind(&self) -> AppTweakKind {
+        match self {
+            AppTweak::Bitcoin { .. } => AppTweakKind::Bitcoin,
+            AppTweak::Nostr => AppTweakKind::Nostr,
+            AppTweak::TestMessage => AppTweakKind::TestMessage,
+        }
+    }
+}
+
+impl AppTweakKind {
+    pub fn app_string(&self) -> &'static str {
+        match self {
+            AppTweakKind::Bitcoin { .. } => "frostsnap/bitcoin",
+            AppTweakKind::TestMessage => "frostsnap/test-message",
+            AppTweakKind::Nostr => "frostsnap/nostr",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum AppTweakKind {
+    Bitcoin,
+    Nostr,
+    TestMessage,
+}
+
 /// Encapsulates bip32 derivations on a key
 pub struct Xpub<T> {
     key: T,
@@ -14,9 +48,22 @@ pub trait TweakableKey: Clone {
     type XOnly;
     fn to_libsecp_key(&self) -> secp256k1::PublicKey;
     fn to_libsecp_xonly(&self) -> secp256k1::XOnlyPublicKey;
-    fn tweak(self, tweak: Scalar<Public>) -> Self;
+    fn tweak(self, tweak: Scalar<Public, Zero>) -> Self;
     fn into_xonly_with_tweak(self, tweak: Scalar<Public>) -> Self::XOnly;
     fn into_xonly(self) -> Self::XOnly;
+    fn app_tweak_and_expand(&self, app: AppTweakKind) -> (Self, [u8; 32]) {
+        use bitcoin::hashes::*;
+        let mut hmac_engine = HmacEngine::<sha512::Hash>::new(app.app_string().as_bytes());
+        hmac_engine.input(self.to_libsecp_key().serialize().as_ref());
+        let result = Hmac::from_engine(hmac_engine);
+        let app_key = self
+            .clone()
+            .tweak(Scalar::from_slice_mod_order(&result[0..32]).expect("is 32 bytes long"));
+        let mut extra = [0u8; 32];
+        extra.copy_from_slice(&result[32..64]);
+
+        (app_key, extra)
+    }
 }
 
 impl TweakableKey for FrostKey<Normal> {
@@ -26,7 +73,7 @@ impl TweakableKey for FrostKey<Normal> {
         self.public_key().to_libsecp_key()
     }
 
-    fn tweak(self, tweak: Scalar<Public>) -> Self {
+    fn tweak(self, tweak: Scalar<Public, Zero>) -> Self {
         FrostKey::<Normal>::tweak(self, tweak).expect("computationally unreachable")
     }
 
@@ -52,7 +99,7 @@ impl TweakableKey for Point {
         secp256k1::PublicKey::from_slice(self.to_bytes().as_ref()).unwrap()
     }
 
-    fn tweak(self, tweak: Scalar<Public>) -> Self {
+    fn tweak(self, tweak: Scalar<Public, Zero>) -> Self {
         g!(self + tweak * G)
             .normalize()
             .non_zero()
@@ -80,15 +127,15 @@ impl TweakableKey for Point {
 }
 
 impl<T: TweakableKey> Xpub<T> {
-    pub fn new(key: T) -> Self {
-        Self {
+    pub fn new(key: T, chaincode: [u8; 32]) -> Self {
+        Xpub {
             xpub: bitcoin::bip32::Xpub {
                 network: Network::Bitcoin,
                 depth: 0,
                 child_number: ChildNumber::from(0u32),
                 parent_fingerprint: Fingerprint::default(),
                 public_key: key.to_libsecp_key(),
-                chain_code: ChainCode::from([0u8; 32]),
+                chain_code: ChainCode::from(chaincode),
             },
             key,
         }
@@ -102,12 +149,10 @@ impl<T: TweakableKey> Xpub<T> {
                 .xpub
                 .ckd_pub_tweak(child_number)
                 .expect("can only fail if you do non-hardended derivation");
-            self.key = self.key.clone().tweak(
-                Scalar::<Public, _>::from_slice(&tweak[..])
-                    .unwrap()
-                    .non_zero()
-                    .expect("sk cannot be zero"),
-            );
+            self.key = self
+                .key
+                .clone()
+                .tweak(Scalar::<Public, _>::from_slice_mod_order(&tweak[..]).expect("32 bytes"));
             self.xpub = bitcoin::bip32::Xpub {
                 network: self.xpub.network,
                 depth: self.xpub.depth + 1,
@@ -143,18 +188,19 @@ mod test {
     pub fn bip32_derivation_matches_rust_bitcoin() {
         let frost = frost::new_with_deterministic_nonces::<sha2::Sha256>();
         let (frost_key, _) = frost.simulate_keygen(3, 5, &mut rand::thread_rng());
-        let mut frost_xpub = Xpub::new(frost_key);
-        let secp = Secp256k1::verification_only();
-        let xpub = frost_xpub.xpub();
+        let (app_key, chaincode) = frost_key.app_tweak_and_expand(AppTweakKind::Bitcoin);
 
+        let mut app_xpub = Xpub::new(app_key, chaincode);
+        let secp = Secp256k1::verification_only();
+        let xpub = app_xpub.xpub();
         let path = [1337u32, 42, 0];
         let child_path = path
             .iter()
             .map(|i| ChildNumber::Normal { index: *i })
             .collect::<Vec<_>>();
         let derived_xpub = xpub.derive_pub(&secp, &child_path).unwrap();
-        frost_xpub.derive_bip32(&path);
+        app_xpub.derive_bip32(&path);
 
-        assert_eq!(frost_xpub.xpub(), &derived_xpub);
+        assert_eq!(app_xpub.xpub(), &derived_xpub);
     }
 }

--- a/frostsnap_core/src/xpub.rs
+++ b/frostsnap_core/src/xpub.rs
@@ -7,7 +7,7 @@ use schnorr_fun::{
 /// Encapsulates bip32 derivations on a key
 pub struct Xpub<T> {
     key: T,
-    xpub: ExtendedPubKey,
+    xpub: bitcoin::bip32::Xpub,
 }
 
 pub trait TweakableKey: Clone {
@@ -82,7 +82,7 @@ impl TweakableKey for Point {
 impl<T: TweakableKey> Xpub<T> {
     pub fn new(key: T) -> Self {
         Self {
-            xpub: ExtendedPubKey {
+            xpub: bitcoin::bip32::Xpub {
                 network: Network::Bitcoin,
                 depth: 0,
                 child_number: ChildNumber::from(0u32),
@@ -108,7 +108,7 @@ impl<T: TweakableKey> Xpub<T> {
                     .non_zero()
                     .expect("sk cannot be zero"),
             );
-            self.xpub = ExtendedPubKey {
+            self.xpub = bitcoin::bip32::Xpub {
                 network: self.xpub.network,
                 depth: self.xpub.depth + 1,
                 parent_fingerprint: self.xpub.fingerprint(),
@@ -127,7 +127,7 @@ impl<T: TweakableKey> Xpub<T> {
         self.key
     }
 
-    pub fn xpub(&self) -> &ExtendedPubKey {
+    pub fn xpub(&self) -> &bitcoin::bip32::Xpub {
         &self.xpub
     }
 }

--- a/frostsnapp/ios/Runner/bridge_generated.h
+++ b/frostsnapp/ios/Runner/bridge_generated.h
@@ -148,12 +148,12 @@ typedef struct wire_Coordinator {
   struct wire_FfiCoordinator field0;
 } wire_Coordinator;
 
-typedef struct wire_FrostsnapCoreMessageTransactionSignTask {
+typedef struct wire_FrostsnapCoreMessageBitcoinTransactionSignTask {
   const void *ptr;
-} wire_FrostsnapCoreMessageTransactionSignTask;
+} wire_FrostsnapCoreMessageBitcoinTransactionSignTask;
 
 typedef struct wire_UnsignedTx {
-  struct wire_FrostsnapCoreMessageTransactionSignTask task;
+  struct wire_FrostsnapCoreMessageBitcoinTransactionSignTask task;
 } wire_UnsignedTx;
 
 typedef struct wire_MutexCrateWalletWallet {
@@ -375,7 +375,7 @@ struct wire_FfiCoordinator new_FfiCoordinator(void);
 
 struct wire_FrostsnapCoreCoordinatorFrostKey new_FrostsnapCoreCoordinatorFrostKey(void);
 
-struct wire_FrostsnapCoreMessageTransactionSignTask new_FrostsnapCoreMessageTransactionSignTask(void);
+struct wire_FrostsnapCoreMessageBitcoinTransactionSignTask new_FrostsnapCoreMessageBitcoinTransactionSignTask(void);
 
 struct wire_MutexBTreeMapKeyIdStreamSinkTxState new_MutexBTreeMapKeyIdStreamSinkTxState(void);
 
@@ -451,9 +451,9 @@ void drop_opaque_FrostsnapCoreCoordinatorFrostKey(const void *ptr);
 
 const void *share_opaque_FrostsnapCoreCoordinatorFrostKey(const void *ptr);
 
-void drop_opaque_FrostsnapCoreMessageTransactionSignTask(const void *ptr);
+void drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(const void *ptr);
 
-const void *share_opaque_FrostsnapCoreMessageTransactionSignTask(const void *ptr);
+const void *share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(const void *ptr);
 
 void drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState(const void *ptr);
 
@@ -546,7 +546,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_ChainSync);
     dummy_var ^= ((int64_t) (void*) new_FfiCoordinator);
     dummy_var ^= ((int64_t) (void*) new_FrostsnapCoreCoordinatorFrostKey);
-    dummy_var ^= ((int64_t) (void*) new_FrostsnapCoreMessageTransactionSignTask);
+    dummy_var ^= ((int64_t) (void*) new_FrostsnapCoreMessageBitcoinTransactionSignTask);
     dummy_var ^= ((int64_t) (void*) new_MutexBTreeMapKeyIdStreamSinkTxState);
     dummy_var ^= ((int64_t) (void*) new_MutexCrateWalletWallet);
     dummy_var ^= ((int64_t) (void*) new_PortBytesToReadSender);
@@ -584,8 +584,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) share_opaque_FfiCoordinator);
     dummy_var ^= ((int64_t) (void*) drop_opaque_FrostsnapCoreCoordinatorFrostKey);
     dummy_var ^= ((int64_t) (void*) share_opaque_FrostsnapCoreCoordinatorFrostKey);
-    dummy_var ^= ((int64_t) (void*) drop_opaque_FrostsnapCoreMessageTransactionSignTask);
-    dummy_var ^= ((int64_t) (void*) share_opaque_FrostsnapCoreMessageTransactionSignTask);
+    dummy_var ^= ((int64_t) (void*) drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask);
+    dummy_var ^= ((int64_t) (void*) share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask);
     dummy_var ^= ((int64_t) (void*) drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState);
     dummy_var ^= ((int64_t) (void*) share_opaque_MutexBTreeMapKeyIdStreamSinkTxState);
     dummy_var ^= ((int64_t) (void*) drop_opaque_MutexCrateWalletWallet);

--- a/frostsnapp/lib/bridge_definitions.dart
+++ b/frostsnapp/lib/bridge_definitions.dart
@@ -337,9 +337,10 @@ abstract class Native {
   ShareFnType get shareOpaqueFrostsnapCoreCoordinatorFrostKey;
   OpaqueTypeFinalizer get FrostsnapCoreCoordinatorFrostKeyFinalizer;
 
-  DropFnType get dropOpaqueFrostsnapCoreMessageTransactionSignTask;
-  ShareFnType get shareOpaqueFrostsnapCoreMessageTransactionSignTask;
-  OpaqueTypeFinalizer get FrostsnapCoreMessageTransactionSignTaskFinalizer;
+  DropFnType get dropOpaqueFrostsnapCoreMessageBitcoinTransactionSignTask;
+  ShareFnType get shareOpaqueFrostsnapCoreMessageBitcoinTransactionSignTask;
+  OpaqueTypeFinalizer
+      get FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer;
 
   DropFnType get dropOpaqueMutexBTreeMapKeyIdStreamSinkTxState;
   ShareFnType get shareOpaqueMutexBTreeMapKeyIdStreamSinkTxState;
@@ -432,22 +433,22 @@ class FrostsnapCoreCoordinatorFrostKey extends FrbOpaque {
 }
 
 @sealed
-class FrostsnapCoreMessageTransactionSignTask extends FrbOpaque {
+class FrostsnapCoreMessageBitcoinTransactionSignTask extends FrbOpaque {
   final Native bridge;
-  FrostsnapCoreMessageTransactionSignTask.fromRaw(
+  FrostsnapCoreMessageBitcoinTransactionSignTask.fromRaw(
       int ptr, int size, this.bridge)
       : super.unsafe(ptr, size);
   @override
   DropFnType get dropFn =>
-      bridge.dropOpaqueFrostsnapCoreMessageTransactionSignTask;
+      bridge.dropOpaqueFrostsnapCoreMessageBitcoinTransactionSignTask;
 
   @override
   ShareFnType get shareFn =>
-      bridge.shareOpaqueFrostsnapCoreMessageTransactionSignTask;
+      bridge.shareOpaqueFrostsnapCoreMessageBitcoinTransactionSignTask;
 
   @override
   OpaqueTypeFinalizer get staticFinalizer =>
-      bridge.FrostsnapCoreMessageTransactionSignTaskFinalizer;
+      bridge.FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer;
 }
 
 @sealed
@@ -1092,7 +1093,7 @@ class U8Array64 extends NonGrowableListView<int> {
 
 class UnsignedTx {
   final Native bridge;
-  final FrostsnapCoreMessageTransactionSignTask task;
+  final FrostsnapCoreMessageBitcoinTransactionSignTask task;
 
   const UnsignedTx({
     required this.bridge,

--- a/frostsnapp/lib/bridge_generated.dart
+++ b/frostsnapp/lib/bridge_generated.dart
@@ -1219,12 +1219,15 @@ class NativeImpl implements Native {
   OpaqueTypeFinalizer get FrostsnapCoreCoordinatorFrostKeyFinalizer =>
       _platform.FrostsnapCoreCoordinatorFrostKeyFinalizer;
 
-  DropFnType get dropOpaqueFrostsnapCoreMessageTransactionSignTask =>
-      _platform.inner.drop_opaque_FrostsnapCoreMessageTransactionSignTask;
-  ShareFnType get shareOpaqueFrostsnapCoreMessageTransactionSignTask =>
-      _platform.inner.share_opaque_FrostsnapCoreMessageTransactionSignTask;
-  OpaqueTypeFinalizer get FrostsnapCoreMessageTransactionSignTaskFinalizer =>
-      _platform.FrostsnapCoreMessageTransactionSignTaskFinalizer;
+  DropFnType get dropOpaqueFrostsnapCoreMessageBitcoinTransactionSignTask =>
+      _platform
+          .inner.drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask;
+  ShareFnType get shareOpaqueFrostsnapCoreMessageBitcoinTransactionSignTask =>
+      _platform
+          .inner.share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask;
+  OpaqueTypeFinalizer
+      get FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer =>
+          _platform.FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer;
 
   DropFnType get dropOpaqueMutexBTreeMapKeyIdStreamSinkTxState =>
       _platform.inner.drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState;
@@ -1301,9 +1304,9 @@ class NativeImpl implements Native {
     return FrostsnapCoreCoordinatorFrostKey.fromRaw(raw[0], raw[1], this);
   }
 
-  FrostsnapCoreMessageTransactionSignTask
-      _wire2api_FrostsnapCoreMessageTransactionSignTask(dynamic raw) {
-    return FrostsnapCoreMessageTransactionSignTask.fromRaw(
+  FrostsnapCoreMessageBitcoinTransactionSignTask
+      _wire2api_FrostsnapCoreMessageBitcoinTransactionSignTask(dynamic raw) {
+    return FrostsnapCoreMessageBitcoinTransactionSignTask.fromRaw(
         raw[0], raw[1], this);
   }
 
@@ -1837,7 +1840,7 @@ class NativeImpl implements Native {
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return UnsignedTx(
       bridge: this,
-      task: _wire2api_FrostsnapCoreMessageTransactionSignTask(arr[0]),
+      task: _wire2api_FrostsnapCoreMessageBitcoinTransactionSignTask(arr[0]),
     );
   }
 

--- a/frostsnapp/lib/bridge_generated.io.dart
+++ b/frostsnapp/lib/bridge_generated.io.dart
@@ -49,11 +49,11 @@ class NativePlatform extends FlutterRustBridgeBase<NativeWire> {
   }
 
   @protected
-  wire_FrostsnapCoreMessageTransactionSignTask
-      api2wire_FrostsnapCoreMessageTransactionSignTask(
-          FrostsnapCoreMessageTransactionSignTask raw) {
-    final ptr = inner.new_FrostsnapCoreMessageTransactionSignTask();
-    _api_fill_to_wire_FrostsnapCoreMessageTransactionSignTask(raw, ptr);
+  wire_FrostsnapCoreMessageBitcoinTransactionSignTask
+      api2wire_FrostsnapCoreMessageBitcoinTransactionSignTask(
+          FrostsnapCoreMessageBitcoinTransactionSignTask raw) {
+    final ptr = inner.new_FrostsnapCoreMessageBitcoinTransactionSignTask();
+    _api_fill_to_wire_FrostsnapCoreMessageBitcoinTransactionSignTask(raw, ptr);
     return ptr;
   }
 
@@ -349,10 +349,12 @@ class NativePlatform extends FlutterRustBridgeBase<NativeWire> {
   OpaqueTypeFinalizer get FrostsnapCoreCoordinatorFrostKeyFinalizer =>
       _FrostsnapCoreCoordinatorFrostKeyFinalizer;
   late final OpaqueTypeFinalizer
-      _FrostsnapCoreMessageTransactionSignTaskFinalizer = OpaqueTypeFinalizer(
-          inner._drop_opaque_FrostsnapCoreMessageTransactionSignTaskPtr);
-  OpaqueTypeFinalizer get FrostsnapCoreMessageTransactionSignTaskFinalizer =>
-      _FrostsnapCoreMessageTransactionSignTaskFinalizer;
+      _FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer =
+      OpaqueTypeFinalizer(
+          inner._drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTaskPtr);
+  OpaqueTypeFinalizer
+      get FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer =>
+          _FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer;
   late final OpaqueTypeFinalizer _MutexBTreeMapKeyIdStreamSinkTxStateFinalizer =
       OpaqueTypeFinalizer(
           inner._drop_opaque_MutexBTreeMapKeyIdStreamSinkTxStatePtr);
@@ -400,9 +402,9 @@ class NativePlatform extends FlutterRustBridgeBase<NativeWire> {
     wireObj.ptr = apiObj.shareOrMove();
   }
 
-  void _api_fill_to_wire_FrostsnapCoreMessageTransactionSignTask(
-      FrostsnapCoreMessageTransactionSignTask apiObj,
-      wire_FrostsnapCoreMessageTransactionSignTask wireObj) {
+  void _api_fill_to_wire_FrostsnapCoreMessageBitcoinTransactionSignTask(
+      FrostsnapCoreMessageBitcoinTransactionSignTask apiObj,
+      wire_FrostsnapCoreMessageBitcoinTransactionSignTask wireObj) {
     wireObj.ptr = apiObj.shareOrMove();
   }
 
@@ -619,7 +621,7 @@ class NativePlatform extends FlutterRustBridgeBase<NativeWire> {
   void _api_fill_to_wire_unsigned_tx(
       UnsignedTx apiObj, wire_UnsignedTx wireObj) {
     wireObj.task =
-        api2wire_FrostsnapCoreMessageTransactionSignTask(apiObj.task);
+        api2wire_FrostsnapCoreMessageBitcoinTransactionSignTask(apiObj.task);
   }
 
   void _api_fill_to_wire_wallet(Wallet apiObj, wire_Wallet wireObj) {
@@ -1860,18 +1862,18 @@ class NativeWire implements FlutterRustBridgeWireBase {
       _new_FrostsnapCoreCoordinatorFrostKeyPtr
           .asFunction<wire_FrostsnapCoreCoordinatorFrostKey Function()>();
 
-  wire_FrostsnapCoreMessageTransactionSignTask
-      new_FrostsnapCoreMessageTransactionSignTask() {
-    return _new_FrostsnapCoreMessageTransactionSignTask();
+  wire_FrostsnapCoreMessageBitcoinTransactionSignTask
+      new_FrostsnapCoreMessageBitcoinTransactionSignTask() {
+    return _new_FrostsnapCoreMessageBitcoinTransactionSignTask();
   }
 
-  late final _new_FrostsnapCoreMessageTransactionSignTaskPtr = _lookup<
-      ffi.NativeFunction<
-          wire_FrostsnapCoreMessageTransactionSignTask
-              Function()>>('new_FrostsnapCoreMessageTransactionSignTask');
-  late final _new_FrostsnapCoreMessageTransactionSignTask =
-      _new_FrostsnapCoreMessageTransactionSignTaskPtr.asFunction<
-          wire_FrostsnapCoreMessageTransactionSignTask Function()>();
+  late final _new_FrostsnapCoreMessageBitcoinTransactionSignTaskPtr = _lookup<
+          ffi.NativeFunction<
+              wire_FrostsnapCoreMessageBitcoinTransactionSignTask Function()>>(
+      'new_FrostsnapCoreMessageBitcoinTransactionSignTask');
+  late final _new_FrostsnapCoreMessageBitcoinTransactionSignTask =
+      _new_FrostsnapCoreMessageBitcoinTransactionSignTaskPtr.asFunction<
+          wire_FrostsnapCoreMessageBitcoinTransactionSignTask Function()>();
 
   wire_MutexBTreeMapKeyIdStreamSinkTxState
       new_MutexBTreeMapKeyIdStreamSinkTxState() {
@@ -2319,35 +2321,37 @@ class NativeWire implements FlutterRustBridgeWireBase {
       _share_opaque_FrostsnapCoreCoordinatorFrostKeyPtr
           .asFunction<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>();
 
-  void drop_opaque_FrostsnapCoreMessageTransactionSignTask(
+  void drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(
     ffi.Pointer<ffi.Void> ptr,
   ) {
-    return _drop_opaque_FrostsnapCoreMessageTransactionSignTask(
+    return _drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(
       ptr,
     );
   }
 
-  late final _drop_opaque_FrostsnapCoreMessageTransactionSignTaskPtr =
+  late final _drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTaskPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'drop_opaque_FrostsnapCoreMessageTransactionSignTask');
-  late final _drop_opaque_FrostsnapCoreMessageTransactionSignTask =
-      _drop_opaque_FrostsnapCoreMessageTransactionSignTaskPtr
+          'drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask');
+  late final _drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask =
+      _drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTaskPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
-  ffi.Pointer<ffi.Void> share_opaque_FrostsnapCoreMessageTransactionSignTask(
+  ffi.Pointer<ffi.Void>
+      share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(
     ffi.Pointer<ffi.Void> ptr,
   ) {
-    return _share_opaque_FrostsnapCoreMessageTransactionSignTask(
+    return _share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(
       ptr,
     );
   }
 
-  late final _share_opaque_FrostsnapCoreMessageTransactionSignTaskPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>>(
-      'share_opaque_FrostsnapCoreMessageTransactionSignTask');
-  late final _share_opaque_FrostsnapCoreMessageTransactionSignTask =
-      _share_opaque_FrostsnapCoreMessageTransactionSignTaskPtr
+  late final _share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTaskPtr =
+      _lookup<
+              ffi.NativeFunction<
+                  ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>>(
+          'share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask');
+  late final _share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask =
+      _share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTaskPtr
           .asFunction<ffi.Pointer<ffi.Void> Function(ffi.Pointer<ffi.Void>)>();
 
   void drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState(
@@ -2747,12 +2751,13 @@ final class wire_Coordinator extends ffi.Struct {
   external wire_FfiCoordinator field0;
 }
 
-final class wire_FrostsnapCoreMessageTransactionSignTask extends ffi.Struct {
+final class wire_FrostsnapCoreMessageBitcoinTransactionSignTask
+    extends ffi.Struct {
   external ffi.Pointer<ffi.Void> ptr;
 }
 
 final class wire_UnsignedTx extends ffi.Struct {
-  external wire_FrostsnapCoreMessageTransactionSignTask task;
+  external wire_FrostsnapCoreMessageBitcoinTransactionSignTask task;
 }
 
 final class wire_MutexCrateWalletWallet extends ffi.Struct {

--- a/frostsnapp/lib/bridge_generated.web.dart
+++ b/frostsnapp/lib/bridge_generated.web.dart
@@ -42,8 +42,8 @@ class NativePlatform extends FlutterRustBridgeBase<NativeWire>
   }
 
   @protected
-  Object api2wire_FrostsnapCoreMessageTransactionSignTask(
-      FrostsnapCoreMessageTransactionSignTask raw) {
+  Object api2wire_FrostsnapCoreMessageBitcoinTransactionSignTask(
+      FrostsnapCoreMessageBitcoinTransactionSignTask raw) {
     return raw.shareOrMove();
   }
 
@@ -345,7 +345,7 @@ class NativePlatform extends FlutterRustBridgeBase<NativeWire>
 
   @protected
   List<dynamic> api2wire_unsigned_tx(UnsignedTx raw) {
-    return [api2wire_FrostsnapCoreMessageTransactionSignTask(raw.task)];
+    return [api2wire_FrostsnapCoreMessageBitcoinTransactionSignTask(raw.task)];
   }
 
   @protected
@@ -375,12 +375,12 @@ class NativePlatform extends FlutterRustBridgeBase<NativeWire>
   Finalizer<PlatformPointer> get FrostsnapCoreCoordinatorFrostKeyFinalizer =>
       _FrostsnapCoreCoordinatorFrostKeyFinalizer;
   late final Finalizer<PlatformPointer>
-      _FrostsnapCoreMessageTransactionSignTaskFinalizer =
+      _FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer =
       Finalizer<PlatformPointer>(
-          inner.drop_opaque_FrostsnapCoreMessageTransactionSignTask);
+          inner.drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask);
   Finalizer<PlatformPointer>
-      get FrostsnapCoreMessageTransactionSignTaskFinalizer =>
-          _FrostsnapCoreMessageTransactionSignTaskFinalizer;
+      get FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer =>
+          _FrostsnapCoreMessageBitcoinTransactionSignTaskFinalizer;
   late final Finalizer<PlatformPointer>
       _MutexBTreeMapKeyIdStreamSinkTxStateFinalizer =
       Finalizer<PlatformPointer>(
@@ -628,11 +628,11 @@ class NativeWasmModule implements WasmModule {
   external int /* *const c_void */
       share_opaque_FrostsnapCoreCoordinatorFrostKey(ptr);
 
-  external dynamic /*  */ drop_opaque_FrostsnapCoreMessageTransactionSignTask(
-      ptr);
+  external dynamic /*  */
+      drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(ptr);
 
   external int /* *const c_void */
-      share_opaque_FrostsnapCoreMessageTransactionSignTask(ptr);
+      share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(ptr);
 
   external dynamic /*  */ drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState(ptr);
 
@@ -928,12 +928,15 @@ class NativeWire extends FlutterRustBridgeWasmWireBase<NativeWasmModule> {
   int /* *const c_void */ share_opaque_FrostsnapCoreCoordinatorFrostKey(ptr) =>
       wasmModule.share_opaque_FrostsnapCoreCoordinatorFrostKey(ptr);
 
-  dynamic /*  */ drop_opaque_FrostsnapCoreMessageTransactionSignTask(ptr) =>
-      wasmModule.drop_opaque_FrostsnapCoreMessageTransactionSignTask(ptr);
-
-  int /* *const c_void */ share_opaque_FrostsnapCoreMessageTransactionSignTask(
+  dynamic /*  */ drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(
           ptr) =>
-      wasmModule.share_opaque_FrostsnapCoreMessageTransactionSignTask(ptr);
+      wasmModule
+          .drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(ptr);
+
+  int /* *const c_void */
+      share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(ptr) =>
+          wasmModule
+              .share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(ptr);
 
   dynamic /*  */ drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState(ptr) =>
       wasmModule.drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState(ptr);

--- a/frostsnapp/macos/Runner/bridge_generated.h
+++ b/frostsnapp/macos/Runner/bridge_generated.h
@@ -148,12 +148,12 @@ typedef struct wire_Coordinator {
   struct wire_FfiCoordinator field0;
 } wire_Coordinator;
 
-typedef struct wire_FrostsnapCoreMessageTransactionSignTask {
+typedef struct wire_FrostsnapCoreMessageBitcoinTransactionSignTask {
   const void *ptr;
-} wire_FrostsnapCoreMessageTransactionSignTask;
+} wire_FrostsnapCoreMessageBitcoinTransactionSignTask;
 
 typedef struct wire_UnsignedTx {
-  struct wire_FrostsnapCoreMessageTransactionSignTask task;
+  struct wire_FrostsnapCoreMessageBitcoinTransactionSignTask task;
 } wire_UnsignedTx;
 
 typedef struct wire_MutexCrateWalletWallet {
@@ -375,7 +375,7 @@ struct wire_FfiCoordinator new_FfiCoordinator(void);
 
 struct wire_FrostsnapCoreCoordinatorFrostKey new_FrostsnapCoreCoordinatorFrostKey(void);
 
-struct wire_FrostsnapCoreMessageTransactionSignTask new_FrostsnapCoreMessageTransactionSignTask(void);
+struct wire_FrostsnapCoreMessageBitcoinTransactionSignTask new_FrostsnapCoreMessageBitcoinTransactionSignTask(void);
 
 struct wire_MutexBTreeMapKeyIdStreamSinkTxState new_MutexBTreeMapKeyIdStreamSinkTxState(void);
 
@@ -451,9 +451,9 @@ void drop_opaque_FrostsnapCoreCoordinatorFrostKey(const void *ptr);
 
 const void *share_opaque_FrostsnapCoreCoordinatorFrostKey(const void *ptr);
 
-void drop_opaque_FrostsnapCoreMessageTransactionSignTask(const void *ptr);
+void drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(const void *ptr);
 
-const void *share_opaque_FrostsnapCoreMessageTransactionSignTask(const void *ptr);
+const void *share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(const void *ptr);
 
 void drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState(const void *ptr);
 
@@ -546,7 +546,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_ChainSync);
     dummy_var ^= ((int64_t) (void*) new_FfiCoordinator);
     dummy_var ^= ((int64_t) (void*) new_FrostsnapCoreCoordinatorFrostKey);
-    dummy_var ^= ((int64_t) (void*) new_FrostsnapCoreMessageTransactionSignTask);
+    dummy_var ^= ((int64_t) (void*) new_FrostsnapCoreMessageBitcoinTransactionSignTask);
     dummy_var ^= ((int64_t) (void*) new_MutexBTreeMapKeyIdStreamSinkTxState);
     dummy_var ^= ((int64_t) (void*) new_MutexCrateWalletWallet);
     dummy_var ^= ((int64_t) (void*) new_PortBytesToReadSender);
@@ -584,8 +584,8 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) share_opaque_FfiCoordinator);
     dummy_var ^= ((int64_t) (void*) drop_opaque_FrostsnapCoreCoordinatorFrostKey);
     dummy_var ^= ((int64_t) (void*) share_opaque_FrostsnapCoreCoordinatorFrostKey);
-    dummy_var ^= ((int64_t) (void*) drop_opaque_FrostsnapCoreMessageTransactionSignTask);
-    dummy_var ^= ((int64_t) (void*) share_opaque_FrostsnapCoreMessageTransactionSignTask);
+    dummy_var ^= ((int64_t) (void*) drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask);
+    dummy_var ^= ((int64_t) (void*) share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask);
     dummy_var ^= ((int64_t) (void*) drop_opaque_MutexBTreeMapKeyIdStreamSinkTxState);
     dummy_var ^= ((int64_t) (void*) share_opaque_MutexBTreeMapKeyIdStreamSinkTxState);
     dummy_var ^= ((int64_t) (void*) drop_opaque_MutexCrateWalletWallet);

--- a/frostsnapp/native/Cargo.toml
+++ b/frostsnapp/native/Cargo.toml
@@ -18,6 +18,6 @@ tracing = { workspace = true, features = ["std"] }
 tracing-android = "0.2"
 llsdb.workspace = true
 bincode.workspace = true
-bdk_chain = {  version = "0.9", features = ["serde"] }
-bdk_electrum = {  version = "0.7" }
+bdk_chain = {  version = "0.13", features = ["serde"] }
+bdk_electrum = {  version = "0.12" }
 bdk_coin_select = { git = "https://github.com/LLFourn/coin-select.git", rev ="8eb582bc08bee173a41508a915fd2609e954f313" }

--- a/frostsnapp/native/Cargo.toml
+++ b/frostsnapp/native/Cargo.toml
@@ -18,6 +18,6 @@ tracing = { workspace = true, features = ["std"] }
 tracing-android = "0.2"
 llsdb.workspace = true
 bincode.workspace = true
-bdk_chain = {  version = "0.13", features = ["serde"] }
-bdk_electrum = {  version = "0.12" }
-bdk_coin_select = { git = "https://github.com/LLFourn/coin-select.git", rev ="8eb582bc08bee173a41508a915fd2609e954f313" }
+bdk_chain = {  version = "0.15", features = ["serde"] }
+bdk_electrum = {  version = "0.14" }
+bdk_coin_select = { version = "0.3" }

--- a/frostsnapp/native/src/api.rs
+++ b/frostsnapp/native/src/api.rs
@@ -609,7 +609,7 @@ impl Wallet {
             let mut i = 0;
             let inspect_stream = stream.clone();
             sync_request.inspect_txids(move |_txid| {
-                inspect_stream.add((i as f64) / (total - 1) as f64);
+                inspect_stream.add(i as f64 / total as f64);
                 i += 1;
             })
         };
@@ -656,7 +656,7 @@ impl Wallet {
             let total = sync_req.spks.len();
             let mut i = 0;
             sync_req.inspect_spks(move |_spk| {
-                inspect_stream.add((i as f64) / (total - 1) as f64);
+                inspect_stream.add(i as f64 / total as f64);
                 i += 1;
             })
         };

--- a/frostsnapp/native/src/api.rs
+++ b/frostsnapp/native/src/api.rs
@@ -511,7 +511,7 @@ impl Coordinator {
         self.0.start_signing(
             key_id,
             devices.into_iter().collect(),
-            SignTask::Transaction(unsigned_tx.task.deref().clone()),
+            SignTask::BitcoinTransaction(unsigned_tx.task.deref().clone()),
             stream,
         )?;
         Ok(())
@@ -836,7 +836,7 @@ impl SignedTx {
 }
 
 pub struct UnsignedTx {
-    pub task: RustOpaque<frostsnap_core::message::TransactionSignTask>,
+    pub task: RustOpaque<frostsnap_core::message::BitcoinTransactionSignTask>,
 }
 
 impl UnsignedTx {

--- a/frostsnapp/native/src/bridge_generated.io.rs
+++ b/frostsnapp/native/src/bridge_generated.io.rs
@@ -447,9 +447,9 @@ pub extern "C" fn new_FrostsnapCoreCoordinatorFrostKey() -> wire_FrostsnapCoreCo
 }
 
 #[no_mangle]
-pub extern "C" fn new_FrostsnapCoreMessageTransactionSignTask(
-) -> wire_FrostsnapCoreMessageTransactionSignTask {
-    wire_FrostsnapCoreMessageTransactionSignTask::new_with_null_ptr()
+pub extern "C" fn new_FrostsnapCoreMessageBitcoinTransactionSignTask(
+) -> wire_FrostsnapCoreMessageBitcoinTransactionSignTask {
+    wire_FrostsnapCoreMessageBitcoinTransactionSignTask::new_with_null_ptr()
 }
 
 #[no_mangle]
@@ -687,18 +687,22 @@ pub extern "C" fn share_opaque_FrostsnapCoreCoordinatorFrostKey(
 }
 
 #[no_mangle]
-pub extern "C" fn drop_opaque_FrostsnapCoreMessageTransactionSignTask(ptr: *const c_void) {
+pub extern "C" fn drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(ptr: *const c_void) {
     unsafe {
-        Arc::<frostsnap_core::message::TransactionSignTask>::decrement_strong_count(ptr as _);
+        Arc::<frostsnap_core::message::BitcoinTransactionSignTask>::decrement_strong_count(
+            ptr as _,
+        );
     }
 }
 
 #[no_mangle]
-pub extern "C" fn share_opaque_FrostsnapCoreMessageTransactionSignTask(
+pub extern "C" fn share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(
     ptr: *const c_void,
 ) -> *const c_void {
     unsafe {
-        Arc::<frostsnap_core::message::TransactionSignTask>::increment_strong_count(ptr as _);
+        Arc::<frostsnap_core::message::BitcoinTransactionSignTask>::increment_strong_count(
+            ptr as _,
+        );
         ptr
     }
 }
@@ -834,10 +838,10 @@ impl Wire2Api<RustOpaque<frostsnap_core::CoordinatorFrostKey>>
         unsafe { support::opaque_from_dart(self.ptr as _) }
     }
 }
-impl Wire2Api<RustOpaque<frostsnap_core::message::TransactionSignTask>>
-    for wire_FrostsnapCoreMessageTransactionSignTask
+impl Wire2Api<RustOpaque<frostsnap_core::message::BitcoinTransactionSignTask>>
+    for wire_FrostsnapCoreMessageBitcoinTransactionSignTask
 {
-    fn wire2api(self) -> RustOpaque<frostsnap_core::message::TransactionSignTask> {
+    fn wire2api(self) -> RustOpaque<frostsnap_core::message::BitcoinTransactionSignTask> {
         unsafe { support::opaque_from_dart(self.ptr as _) }
     }
 }
@@ -1226,7 +1230,7 @@ pub struct wire_FrostsnapCoreCoordinatorFrostKey {
 
 #[repr(C)]
 #[derive(Clone)]
-pub struct wire_FrostsnapCoreMessageTransactionSignTask {
+pub struct wire_FrostsnapCoreMessageBitcoinTransactionSignTask {
     ptr: *const core::ffi::c_void,
 }
 
@@ -1435,7 +1439,7 @@ pub struct wire_uint_8_list {
 #[repr(C)]
 #[derive(Clone)]
 pub struct wire_UnsignedTx {
-    task: wire_FrostsnapCoreMessageTransactionSignTask,
+    task: wire_FrostsnapCoreMessageBitcoinTransactionSignTask,
 }
 
 #[repr(C)]
@@ -1486,7 +1490,7 @@ impl NewWithNullPtr for wire_FrostsnapCoreCoordinatorFrostKey {
         }
     }
 }
-impl NewWithNullPtr for wire_FrostsnapCoreMessageTransactionSignTask {
+impl NewWithNullPtr for wire_FrostsnapCoreMessageBitcoinTransactionSignTask {
     fn new_with_null_ptr() -> Self {
         Self {
             ptr: core::ptr::null(),
@@ -1800,7 +1804,7 @@ impl Default for wire_Transaction {
 impl NewWithNullPtr for wire_UnsignedTx {
     fn new_with_null_ptr() -> Self {
         Self {
-            task: wire_FrostsnapCoreMessageTransactionSignTask::new_with_null_ptr(),
+            task: wire_FrostsnapCoreMessageBitcoinTransactionSignTask::new_with_null_ptr(),
         }
     }
 }

--- a/frostsnapp/native/src/bridge_generated.web.rs
+++ b/frostsnapp/native/src/bridge_generated.web.rs
@@ -443,16 +443,22 @@ pub fn share_opaque_FrostsnapCoreCoordinatorFrostKey(ptr: *const c_void) -> *con
 }
 
 #[wasm_bindgen]
-pub fn drop_opaque_FrostsnapCoreMessageTransactionSignTask(ptr: *const c_void) {
+pub fn drop_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(ptr: *const c_void) {
     unsafe {
-        Arc::<frostsnap_core::message::TransactionSignTask>::decrement_strong_count(ptr as _);
+        Arc::<frostsnap_core::message::BitcoinTransactionSignTask>::decrement_strong_count(
+            ptr as _,
+        );
     }
 }
 
 #[wasm_bindgen]
-pub fn share_opaque_FrostsnapCoreMessageTransactionSignTask(ptr: *const c_void) -> *const c_void {
+pub fn share_opaque_FrostsnapCoreMessageBitcoinTransactionSignTask(
+    ptr: *const c_void,
+) -> *const c_void {
     unsafe {
-        Arc::<frostsnap_core::message::TransactionSignTask>::increment_strong_count(ptr as _);
+        Arc::<frostsnap_core::message::BitcoinTransactionSignTask>::increment_strong_count(
+            ptr as _,
+        );
         ptr
     }
 }
@@ -973,8 +979,8 @@ impl Wire2Api<RustOpaque<frostsnap_core::CoordinatorFrostKey>> for JsValue {
         unsafe { support::opaque_from_dart((self.as_f64().unwrap() as usize) as _) }
     }
 }
-impl Wire2Api<RustOpaque<frostsnap_core::message::TransactionSignTask>> for JsValue {
-    fn wire2api(self) -> RustOpaque<frostsnap_core::message::TransactionSignTask> {
+impl Wire2Api<RustOpaque<frostsnap_core::message::BitcoinTransactionSignTask>> for JsValue {
+    fn wire2api(self) -> RustOpaque<frostsnap_core::message::BitcoinTransactionSignTask> {
         #[cfg(target_pointer_width = "64")]
         {
             compile_error!("64-bit pointers are not supported.");

--- a/frostsnapp/native/src/chain_sync.rs
+++ b/frostsnapp/native/src/chain_sync.rs
@@ -1,16 +1,13 @@
 use anyhow::{Context, Result};
 pub use bdk_chain::spk_client::SyncRequest;
 use bdk_chain::{bitcoin, spk_client, ConfirmationTimeHeightAnchor};
-use bdk_electrum::{
-    electrum_client::{self, Client, ElectrumApi},
-    ElectrumExt,
-};
+use bdk_electrum::{electrum_client, BdkElectrumClient};
 use std::sync::Arc;
 use tracing::{event, Level};
 
 #[derive(Clone)]
 pub struct ChainSync {
-    client: Arc<Client>,
+    client: Arc<BdkElectrumClient<electrum_client::Client>>,
 }
 
 impl ChainSync {
@@ -32,8 +29,9 @@ impl ChainSync {
             url = electrum_url,
             "initializing to electrum server"
         );
-        let electrum_client = Client::from_config(electrum_url, config)
+        let electrum_client = electrum_client::Client::from_config(electrum_url, config)
             .context(format!("initializing electrum client to {}", electrum_url))?;
+        let bdk_electrum_client = BdkElectrumClient::new(electrum_client);
         event!(
             Level::INFO,
             url = electrum_url,
@@ -41,7 +39,7 @@ impl ChainSync {
         );
 
         Ok(Self {
-            client: Arc::new(electrum_client),
+            client: Arc::new(bdk_electrum_client),
         })
     }
 

--- a/frostsnapp/native/src/chain_sync.rs
+++ b/frostsnapp/native/src/chain_sync.rs
@@ -4,10 +4,7 @@ use bdk_electrum::{
     electrum_client::{self, Client, ElectrumApi},
     ElectrumExt,
 };
-use std::{
-    sync::{atomic::AtomicUsize, Arc},
-    time::UNIX_EPOCH,
-};
+use std::sync::{atomic::AtomicUsize, Arc};
 use tracing::{event, Level};
 
 #[derive(Clone)]
@@ -58,13 +55,9 @@ impl ChainSync {
         let missing = electrum_update
             .relevant_txids
             .missing_full_txs(&start_sync.existing_graph);
-        let now = std::time::SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("no a time traveler")
-            .as_secs();
         let update_graph = electrum_update
             .relevant_txids
-            .into_confirmation_time_tx_graph(&self.client, Some(now), missing)?;
+            .into_confirmation_time_tx_graph(&self.client, missing)?;
         let update_chain = electrum_update.chain_update;
         Ok(Update {
             chain: update_chain,
@@ -79,7 +72,7 @@ impl ChainSync {
 }
 
 pub struct Update {
-    pub chain: local_chain::Update,
+    pub chain: local_chain::CheckPoint,
     pub tx_graph: tx_graph::TxGraph<ConfirmationTimeHeightAnchor>,
 }
 

--- a/frostsnapp/native/src/chain_sync.rs
+++ b/frostsnapp/native/src/chain_sync.rs
@@ -1,10 +1,11 @@
 use anyhow::{Context, Result};
-use bdk_chain::{bitcoin, local_chain, tx_graph, ConfirmationTimeHeightAnchor};
+pub use bdk_chain::spk_client::SyncRequest;
+use bdk_chain::{bitcoin, spk_client, ConfirmationTimeHeightAnchor};
 use bdk_electrum::{
     electrum_client::{self, Client, ElectrumApi},
     ElectrumExt,
 };
-use std::sync::{atomic::AtomicUsize, Arc};
+use std::sync::Arc;
 use tracing::{event, Level};
 
 #[derive(Clone)]
@@ -44,173 +45,16 @@ impl ChainSync {
         })
     }
 
-    pub fn sync(&self, mut start_sync: SyncRequest) -> Result<Update> {
-        let electrum_update = self.client.sync(
-            start_sync.current_tip.clone(),
-            start_sync.take_spks(),
-            start_sync.take_txids(),
-            vec![],
-            10,
-        )?;
-        let missing = electrum_update
-            .relevant_txids
-            .missing_full_txs(&start_sync.existing_graph);
-        let update_graph = electrum_update
-            .relevant_txids
-            .into_confirmation_time_tx_graph(&self.client, missing)?;
-        let update_chain = electrum_update.chain_update;
-        Ok(Update {
-            chain: update_chain,
-            tx_graph: update_graph,
-        })
+    pub fn sync(
+        &self,
+        sync_request: SyncRequest,
+    ) -> Result<spk_client::SyncResult<ConfirmationTimeHeightAnchor>> {
+        let electrum_update = self.client.sync(sync_request, 10, true)?;
+        Ok(electrum_update.with_confirmation_time_height_anchor(self.client.as_ref())?)
     }
 
     pub fn broadcast(&self, tx: &bitcoin::Transaction) -> Result<()> {
         self.client.transaction_broadcast(tx)?;
         Ok(())
     }
-}
-
-pub struct Update {
-    pub chain: local_chain::CheckPoint,
-    pub tx_graph: tx_graph::TxGraph<ConfirmationTimeHeightAnchor>,
-}
-
-// Something like this is meant to be part of bdk soon
-pub struct SyncRequest {
-    pub current_tip: local_chain::CheckPoint,
-    spks: Vec<bitcoin::ScriptBuf>,
-    txids: Vec<bitcoin::Txid>,
-    total_items: usize,
-    #[allow(clippy::type_complexity)] // allowing because this will be in bdk eventually
-    inspect_spks: Option<Box<dyn FnMut(&bitcoin::ScriptBuf, usize, usize, usize)>>,
-    #[allow(clippy::type_complexity)]
-    inspect_txids: Option<Box<dyn FnMut(&bitcoin::Txid, usize, usize, usize)>>,
-    processed_count: Arc<AtomicUsize>,
-    /// this is not meant to be here but BDK electrum desin is a bit off
-    existing_graph: tx_graph::TxGraph<ConfirmationTimeHeightAnchor>,
-}
-
-impl SyncRequest {
-    pub fn new(
-        current_tip: local_chain::CheckPoint,
-        existing_graph: tx_graph::TxGraph<ConfirmationTimeHeightAnchor>,
-    ) -> Self {
-        Self {
-            current_tip,
-            spks: Default::default(),
-            txids: Default::default(),
-            inspect_spks: Default::default(),
-            inspect_txids: Default::default(),
-            total_items: Default::default(),
-            existing_graph,
-            processed_count: Default::default(),
-        }
-    }
-
-    pub fn add_spks(&mut self, spks: impl IntoIterator<Item = bitcoin::ScriptBuf>) {
-        self.spks
-            .extend(spks.into_iter().inspect(|_| self.total_items += 1))
-    }
-
-    pub fn spks(&self) -> &Vec<bitcoin::ScriptBuf> {
-        &self.spks
-    }
-
-    pub fn txids(&self) -> &Vec<bitcoin::Txid> {
-        &self.txids
-    }
-
-    pub fn total_items(&self) -> usize {
-        self.total_items
-    }
-
-    pub fn take_spks(&mut self) -> impl Iterator<Item = bitcoin::ScriptBuf> {
-        fn null_inspect_spks(
-            _spks: &bitcoin::ScriptBuf,
-            _i: usize,
-            _total_processed: usize,
-            _total_items: usize,
-        ) {
-        }
-        let total_items = self.total_items;
-        let spks = core::mem::take(&mut self.spks);
-        let processed_count = self.processed_count.clone();
-        let mut inspect = self
-            .inspect_spks
-            .take()
-            .unwrap_or(Box::new(null_inspect_spks));
-        spks.into_iter()
-            .enumerate()
-            .inspect(move |(i, spk)| {
-                let processed_total =
-                    processed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                inspect(spk, *i, processed_total, total_items);
-            })
-            .map(|(_, spk)| spk)
-    }
-
-    pub fn inspect_spks(
-        &mut self,
-        inspect: impl FnMut(&bitcoin::ScriptBuf, usize, usize, usize) + 'static,
-    ) {
-        self.inspect_spks = Some(Box::new(inspect))
-    }
-
-    pub fn take_txids(&mut self) -> impl Iterator<Item = bitcoin::Txid> {
-        fn null_inspect_txids(
-            _spks: &bitcoin::Txid,
-            _up_to: usize,
-            _total: usize,
-            _total_items: usize,
-        ) {
-        }
-        let total_items = self.total_items;
-        let processed_count = self.processed_count.clone();
-        let txids = core::mem::take(&mut self.txids);
-        let mut inspect = self
-            .inspect_txids
-            .take()
-            .unwrap_or(Box::new(null_inspect_txids));
-        txids
-            .into_iter()
-            .enumerate()
-            .inspect(move |(i, txid)| {
-                let processed_total =
-                    processed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                inspect(txid, *i, processed_total, total_items)
-            })
-            .map(|(_, txid)| txid)
-    }
-
-    pub fn inspect_all(
-        &mut self,
-        inspect: impl Fn(SyncItem, usize, usize, usize) + 'static + Clone,
-    ) {
-        let inspect_spks = inspect.clone();
-        self.inspect_spks(move |spk, i, total, total_items| {
-            inspect_spks(SyncItem::Spk(spk), i, total, total_items)
-        });
-        let inspect_txids = inspect.clone();
-        self.inspect_txids(move |txid, i, total, total_items| {
-            inspect_txids(SyncItem::Txid(txid), i, total, total_items)
-        });
-    }
-
-    pub fn add_txids(&mut self, txids: impl IntoIterator<Item = bitcoin::Txid>) {
-        self.txids
-            .extend(txids.into_iter().inspect(|_| self.total_items += 1));
-    }
-    pub fn inspect_txids(
-        &mut self,
-        inspect: impl FnMut(&bitcoin::Txid, usize, usize, usize) + 'static,
-    ) {
-        self.inspect_txids = Some(Box::new(inspect))
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum SyncItem<'a> {
-    Spk(&'a bitcoin::ScriptBuf),
-    Txid(&'a bitcoin::Txid),
 }

--- a/frostsnapp/native/src/coordinator.rs
+++ b/frostsnapp/native/src/coordinator.rs
@@ -458,7 +458,7 @@ impl FfiCoordinator {
                         message: String::from_utf8_lossy(&message[..]).to_string(),
                     },
                     SignTask::Nostr { .. } => todo!("nostr restoring not yet implemented"),
-                    SignTask::Transaction(task) => api::SignTaskDescription::Transaction {
+                    SignTask::BitcoinTransaction(task) => api::SignTaskDescription::Transaction {
                         unsigned_tx: api::UnsignedTx {
                             task: RustOpaque::new(task),
                         },

--- a/frostsnapp/native/src/wallet.rs
+++ b/frostsnapp/native/src/wallet.rs
@@ -208,7 +208,7 @@ impl _Wallet {
 
         [Keychain::External, Keychain::Internal]
             .into_iter()
-            .map(move |keychain| {
+            .map(|keychain| {
                 let child_xpub = root_bitcoin_xpub
                     .ckd_pub(
                         &secp,

--- a/frostsnapp/native/src/wallet.rs
+++ b/frostsnapp/native/src/wallet.rs
@@ -381,7 +381,7 @@ impl _Wallet {
         let chain_changeset = self.chain.apply_update(update.chain_update)?;
         self.db.lock().unwrap().execute(|tx| {
             let chain_list = self.chain_list_handle.api(&tx);
-            let changed = chain_changeset.is_empty() && indexed_tx_graph_changeset.is_empty();
+            let changed = !chain_changeset.is_empty() || !indexed_tx_graph_changeset.is_empty();
 
             if !chain_changeset.is_empty() {
                 chain_list.push(&bincode::serde::Compat(chain_changeset))?;
@@ -510,10 +510,10 @@ impl _Wallet {
         let mut inputs: Vec<bitcoin::TxIn> = vec![];
         let mut prevouts = vec![];
 
-        for ((_, i), selected_utxo) in selected_utxos {
+        for (((_key_id, keychain), i), selected_utxo) in selected_utxos {
             prevouts.push(frostsnap_core::message::TxInput {
                 prevout: selected_utxo.txout.clone(),
-                bip32_path: Some(vec![*i]),
+                bip32_path: Some(vec![*keychain as _, *i]),
             });
             inputs.push(bitcoin::TxIn {
                 previous_output: selected_utxo.outpoint,

--- a/justfile
+++ b/justfile
@@ -30,9 +30,9 @@ lint-device +ARGS="":
     cd device && cargo clippy {{ARGS}} --all-features --bins -- -Dwarnings
 
 fix:
-    cargo fmt --all
     cargo clippy --fix --allow-dirty --allow-staged {{non_device_packages}} --all-features --tests --bins
     ( cd device && cargo clippy --fix --allow-dirty --allow-staged --all-features --bins; )
+    cargo fmt --all
     ( cd frostsnapp && dart format .; )
 
 run:


### PR DESCRIPTION
 * Upgrades bdk to version 0.12 with minor api changes.
 * Patch keeps the keychain_txout_more_range changes from
      https://github.com/bitcoindevkit/bdk/pull/1324,
 * This bdk rev uses an updated electrum-client with upgraded rustls.
 * Frostsnapp no longer depends on ring.


https://github.com/bitcoindevkit/rust-electrum-client/pull/132

Fixes: https://github.com/frostsnap/frostsnap/issues/116