### PR TITLE
Give keys names

### DIFF
--- a/device/src/bin/v2.rs
+++ b/device/src/bin/v2.rs
@@ -387,11 +387,20 @@ where
                             self.display.print(format!("Sign nostr: {message}"))
                         }
                     },
-                    Prompt::KeyGen(session_hash) => self.display.show_keygen_check(&format!(
-                        "{} {}",
-                        hex::encode(&session_hash[0..2]),
-                        hex::encode(&session_hash[2..4])
-                    )),
+                    Prompt::KeyGen {
+                        session_hash,
+                        key_name,
+                        ..
+                    } => {
+                        self.display.show_keygen_check(
+                            key_name,
+                            &format!(
+                                "{} {}",
+                                hex::encode(&session_hash[0..2]),
+                                hex::encode(&session_hash[2..4])
+                            ),
+                        );
+                    }
                     Prompt::NewName { old_name, new_name } => match old_name {
                         Some(old_name) => self.display.print(format!(
                             "Rename this device from '{}' to '{}'?",
@@ -399,9 +408,9 @@ where
                         )),
                         None => self.display.print(format!("Confirm name '{}'?", new_name)),
                     },
-                    Prompt::DisplayBackupRequest(key_id) => self
+                    Prompt::DisplayBackupRequest((key_name, _key_id)) => self
                         .display
-                        .print(format!("Display the backup for key {key_id}?")),
+                        .print(format!("Display the backup for key '{key_name}'?")),
                     Prompt::ConfirmFirmwareUpgrade {
                         firmware_digest, ..
                     } => self
@@ -528,12 +537,17 @@ where
                     }
                     AnimationProgress::FinalTick => {
                         let ui_event = match prompt {
-                            Prompt::KeyGen(_) => UiEvent::KeyGenConfirm,
+                            Prompt::KeyGen {
+                                key_name, key_id, ..
+                            } => UiEvent::KeyGenConfirm {
+                                key_name: key_name.clone(),
+                                key_id: *key_id,
+                            },
                             Prompt::Signing(_) => UiEvent::SigningConfirm,
                             Prompt::NewName { new_name, .. } => {
                                 UiEvent::NameConfirm(new_name.clone())
                             }
-                            Prompt::DisplayBackupRequest(key_id) => {
+                            Prompt::DisplayBackupRequest((_key_name, key_id)) => {
                                 UiEvent::BackupRequestConfirm(*key_id)
                             }
                             Prompt::ConfirmFirmwareUpgrade {

--- a/device/src/io.rs
+++ b/device/src/io.rs
@@ -1,15 +1,13 @@
 extern crate alloc;
-use core::convert::Infallible;
-use core::marker::PhantomData;
-
 use alloc::collections::VecDeque;
 use alloc::format;
 use alloc::vec::Vec;
-
 use bincode::de::read::Reader;
 use bincode::enc::write::Writer;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
+use core::convert::Infallible;
+use core::marker::PhantomData;
 use embedded_hal_nb::serial::{Read, Write};
 use esp_hal::clock::Clocks;
 use esp_hal::Blocking;

--- a/device/src/st7789.rs
+++ b/device/src/st7789.rs
@@ -345,11 +345,11 @@ where
         }
     }
 
-    pub fn show_keygen_check(&mut self, check: &str) {
+    pub fn show_keygen_check(&mut self, name: &str, check: &str) {
         let mut body = self.body();
-        let mut y_offset = 10;
+        let mut y_offset = 15;
         Text::with_alignment(
-            "Keygen check",
+            name,
             Point::new((body.size().width / 2) as i32, y_offset),
             U8g2TextStyle::new(FONT_MED, Rgb565::CYAN),
             Alignment::Center,

--- a/device/src/storage.rs
+++ b/device/src/storage.rs
@@ -7,7 +7,7 @@ use bincode::{
 };
 use embedded_storage::{ReadStorage, Storage};
 use esp_storage::{FlashStorage, FlashStorageError};
-use frostsnap_core::{message::DeviceToStorageMessage, schnorr_fun::fun::Scalar};
+use frostsnap_core::{message::DeviceToStorageMessage, schnorr_fun::fun::Scalar, KeyId};
 
 const NVS_PARTITION_START: u32 = 0x3D0000;
 const _NVS_PARTITION_SIZE: usize = 0x30000;
@@ -25,6 +25,7 @@ pub struct DeviceStorage {
 pub enum Change {
     Core(DeviceToStorageMessage),
     Name(String),
+    KeyNamed((KeyId, String)),
 }
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode)]

--- a/device/src/ui.rs
+++ b/device/src/ui.rs
@@ -87,13 +87,17 @@ impl Default for Workflow {
 #[derive(Clone, Debug)]
 
 pub enum Prompt {
-    KeyGen(SessionHash),
+    KeyGen {
+        session_hash: SessionHash,
+        key_name: String,
+        key_id: KeyId,
+    },
     Signing(SignPrompt),
     NewName {
         old_name: Option<String>,
         new_name: String,
     },
-    DisplayBackupRequest(KeyId),
+    DisplayBackupRequest((String, KeyId)),
     ConfirmFirmwareUpgrade {
         firmware_digest: FirmwareDigest,
         size: u32,
@@ -128,7 +132,10 @@ pub enum FirmwareUpgradeStatus {
 
 #[derive(Clone, Debug)]
 pub enum UiEvent {
-    KeyGenConfirm,
+    KeyGenConfirm {
+        key_name: String,
+        key_id: KeyId,
+    },
     SigningConfirm,
     NameConfirm(String),
     BackupRequestConfirm(KeyId),

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -124,6 +124,7 @@ pub enum CoordinatorSendBody {
     Core(frostsnap_core::message::CoordinatorToDeviceMessage),
     Naming(NameCommand),
     AnnounceAck,
+    KeyName(String),
     Cancel,
     Upgrade(CoordinatorUpgradeMessage),
 }

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -124,7 +124,6 @@ pub enum CoordinatorSendBody {
     Core(frostsnap_core::message::CoordinatorToDeviceMessage),
     Naming(NameCommand),
     AnnounceAck,
-    KeyName(String),
     Cancel,
     Upgrade(CoordinatorUpgradeMessage),
 }

--- a/frostsnap_coordinator/src/backup.rs
+++ b/frostsnap_coordinator/src/backup.rs
@@ -26,7 +26,10 @@ impl UiProtocol for BackupProtocol {
 
     fn is_complete(&self) -> Option<Completion> {
         if self.complete {
-            Some(Completion::Abort)
+            Some(Completion::Abort {
+                // get the devices to stop showing backup
+                send_cancel_to_all_devices: true,
+            })
         } else {
             None
         }

--- a/frostsnap_coordinator/src/firmware_upgrade.rs
+++ b/frostsnap_coordinator/src/firmware_upgrade.rs
@@ -48,7 +48,9 @@ impl UiProtocol for FirmwareUpgradeProtocol {
         {
             Some(Completion::Success)
         } else if self.state.abort {
-            Some(Completion::Abort)
+            Some(Completion::Abort {
+                send_cancel_to_all_devices: true,
+            })
         } else {
             None
         }

--- a/frostsnap_coordinator/src/signing.rs
+++ b/frostsnap_coordinator/src/signing.rs
@@ -112,7 +112,9 @@ impl UiProtocol for SigningDispatcher {
         if self.finished_signatures.is_some() {
             Some(Completion::Success)
         } else if self.aborted.is_some() {
-            Some(Completion::Abort)
+            Some(Completion::Abort {
+                send_cancel_to_all_devices: true,
+            })
         } else {
             None
         }

--- a/frostsnap_coordinator/src/ui_protocol.rs
+++ b/frostsnap_coordinator/src/ui_protocol.rs
@@ -38,7 +38,7 @@ pub trait Sink<M>: Send {
 #[derive(Clone, Debug)]
 pub enum Completion {
     Success,
-    Abort,
+    Abort { send_cancel_to_all_devices: bool },
 }
 
 #[derive(Clone, Debug)]

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -123,6 +123,7 @@ impl FrostCoordinator {
                     device_to_share_index,
                     responses,
                     threshold,
+                    pending_key_name,
                 })),
                 DeviceToCoordinatorMessage::KeyGenResponse(new_shares),
             ) => {
@@ -200,6 +201,7 @@ impl FrostCoordinator {
                                     .map(|id| (id, false))
                                     .collect(),
                                 session_hash,
+                                pending_key_name: pending_key_name.clone(),
                             }));
 
                         // TODO: check order
@@ -223,6 +225,7 @@ impl FrostCoordinator {
                     frost_key,
                     acks,
                     session_hash,
+                    pending_key_name,
                 })),
                 DeviceToCoordinatorMessage::KeyGenAck(acked_session_hash),
             ) => {
@@ -254,6 +257,7 @@ impl FrostCoordinator {
                     let key = CoordinatorFrostKey {
                         encoded_frost_key: frost_key.clone(),
                         device_to_share_index: device_to_share_index.clone(),
+                        key_name: pending_key_name.clone(),
                     };
                     let key_id = key.encoded_frost_key.into_frost_key().key_id();
                     self.action_state = None;
@@ -433,6 +437,7 @@ impl FrostCoordinator {
         &mut self,
         devices: &BTreeSet<DeviceId>,
         threshold: u16,
+        key_name: String,
     ) -> Result<Vec<CoordinatorSend>, ActionError> {
         if devices.len() < threshold as usize {
             panic!(
@@ -459,6 +464,7 @@ impl FrostCoordinator {
                         device_to_share_index: device_to_share_index.clone(),
                         responses: devices.iter().map(|&device_id| (device_id, None)).collect(),
                         threshold,
+                        pending_key_name: key_name,
                     }));
 
                 Ok(vec![CoordinatorSend::ToDevice {
@@ -770,12 +776,14 @@ pub enum KeyGenState {
         device_to_share_index: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
         responses: BTreeMap<DeviceId, Option<KeyGenResponse>>,
         threshold: u16,
+        pending_key_name: String,
     },
     WaitingForAcks {
         frost_key: EncodedFrostKey,
         device_to_share_index: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
         acks: BTreeMap<DeviceId, bool>,
         session_hash: SessionHash,
+        pending_key_name: String,
     },
 }
 
@@ -783,6 +791,7 @@ pub enum KeyGenState {
 pub struct CoordinatorFrostKey {
     encoded_frost_key: EncodedFrostKey,
     device_to_share_index: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
+    key_name: String,
 }
 
 impl CoordinatorFrostKey {
@@ -800,6 +809,10 @@ impl CoordinatorFrostKey {
 
     pub fn devices(&self) -> impl Iterator<Item = DeviceId> + '_ {
         self.device_to_share_index.keys().cloned()
+    }
+
+    pub fn key_name(&self) -> String {
+        self.key_name.clone()
     }
 }
 

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -464,13 +464,14 @@ impl FrostCoordinator {
                         device_to_share_index: device_to_share_index.clone(),
                         responses: devices.iter().map(|&device_id| (device_id, None)).collect(),
                         threshold,
-                        pending_key_name: key_name,
+                        pending_key_name: key_name.clone(),
                     }));
 
                 Ok(vec![CoordinatorSend::ToDevice {
                     message: CoordinatorToDeviceMessage::DoKeyGen {
                         device_to_share_index,
                         threshold,
+                        key_name,
                     },
                     destinations: devices.clone(),
                 }])

--- a/frostsnap_core/src/device.rs
+++ b/frostsnap_core/src/device.rs
@@ -260,12 +260,13 @@ impl FrostSigner {
 
                 self.action_state = Some(SignerState::KeyGenAck {
                     key: FrostsnapSecretKey {
-                        encoded_frost_key: frost_key.into(),
+                        encoded_frost_key: frost_key.clone().into(),
                         secret_share,
                     },
                 });
 
                 Ok(vec![DeviceSend::ToUser(DeviceToUserMessage::CheckKeyGen {
+                    key_id: frost_key.key_id(),
                     session_hash,
                 })])
             }

--- a/frostsnap_core/src/device.rs
+++ b/frostsnap_core/src/device.rs
@@ -4,7 +4,11 @@ use crate::{
 };
 use crate::{DeviceId, KeyId};
 use alloc::collections::BTreeSet;
-use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::iter;
 use rand_chacha::ChaCha20Rng;
 use schnorr_fun::frost::EncodedFrostKey;
@@ -120,6 +124,7 @@ impl FrostSigner {
                 DoKeyGen {
                     device_to_share_index,
                     threshold,
+                    key_name,
                 },
             ) => {
                 if !device_to_share_index.contains_key(&self.device_id()) {
@@ -135,6 +140,7 @@ impl FrostSigner {
                     scalar_poly,
                     device_to_share_index,
                     threshold,
+                    key_name,
                 });
 
                 Ok(vec![DeviceSend::ToCoordinator(
@@ -145,12 +151,14 @@ impl FrostSigner {
                 Some(SignerState::KeyGen {
                     device_to_share_index,
                     scalar_poly,
+                    key_name,
                     ..
                 }),
                 CoordinatorToDeviceMessage::FinishKeyGen {
                     ref shares_provided,
                 },
             ) => {
+                let key_name = key_name.clone();
                 if let Some((device_id, _)) = device_to_share_index
                     .iter()
                     .find(|(device_id, _)| !shares_provided.contains_key(device_id))
@@ -268,6 +276,7 @@ impl FrostSigner {
                 Ok(vec![DeviceSend::ToUser(DeviceToUserMessage::CheckKeyGen {
                     key_id: frost_key.key_id(),
                     session_hash,
+                    key_name,
                 })])
             }
             (
@@ -297,8 +306,7 @@ impl FrostSigner {
                 let my_nonces = nonces.get(&key.secret_share.index).ok_or_else(|| {
                     Error::signer_invalid_message(
                         &message,
-                        "this device was asked to sign but no nonces
-                were provided",
+                        "this device was asked to sign but no nonces were provided",
                     )
                 })?;
 
@@ -541,6 +549,7 @@ pub enum SignerState {
         scalar_poly: Vec<Scalar>,
         device_to_share_index: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
         threshold: u16,
+        key_name: String,
     },
     KeyGenAck {
         key: FrostsnapSecretKey,

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -33,6 +33,7 @@ pub enum CoordinatorToDeviceMessage {
     DoKeyGen {
         device_to_share_index: BTreeMap<DeviceId, Scalar<Public, NonZero>>,
         threshold: u16,
+        key_name: String,
     },
     FinishKeyGen {
         shares_provided: BTreeMap<DeviceId, KeyGenResponse>,
@@ -189,6 +190,7 @@ pub enum DeviceToUserMessage {
     CheckKeyGen {
         key_id: KeyId,
         session_hash: SessionHash,
+        key_name: String,
     },
     SignatureRequest {
         sign_task: CheckedSignTask,

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -187,6 +187,7 @@ pub enum CoordinatorToUserKeyGenMessage {
 #[derive(Clone, Debug)]
 pub enum DeviceToUserMessage {
     CheckKeyGen {
+        key_id: KeyId,
         session_hash: SessionHash,
     },
     SignatureRequest {

--- a/frostsnap_core/src/sqlite.rs
+++ b/frostsnap_core/src/sqlite.rs
@@ -1,4 +1,4 @@
-use crate::DeviceId;
+use crate::{DeviceId, KeyId};
 use alloc::boxed::Box;
 use alloc::str::FromStr;
 use alloc::string::ToString;
@@ -14,6 +14,18 @@ impl FromSql for DeviceId {
 }
 
 impl ToSql for DeviceId {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.to_string()))
+    }
+}
+
+impl FromSql for KeyId {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        Self::from_str(value.as_str()?).map_err(|e| FromSqlError::Other(Box::new(e)))
+    }
+}
+
+impl ToSql for KeyId {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(self.to_string()))
     }

--- a/frostsnap_core/tests/endtoend.rs
+++ b/frostsnap_core/tests/endtoend.rs
@@ -167,7 +167,10 @@ impl common::Env for TestEnv {
         message: DeviceToUserMessage,
     ) {
         match message {
-            DeviceToUserMessage::CheckKeyGen { session_hash } => {
+            DeviceToUserMessage::CheckKeyGen {
+                session_hash,
+                key_id: _,
+            } => {
                 self.keygen_checks.insert(from, session_hash);
                 let ack = run.device(from).keygen_ack().unwrap();
                 run.extend_from_device(from, ack);
@@ -220,7 +223,10 @@ fn when_we_generate_a_key_we_should_be_able_to_sign_with_it_multiple_times() {
     }
     run.run_until_finished(&mut env, &mut test_rng);
 
-    let keygen_init = run.coordinator.do_keygen(&device_set, threshold).unwrap();
+    let keygen_init = run
+        .coordinator
+        .do_keygen(&device_set, threshold, "my new key".to_string())
+        .unwrap();
     run.extend(keygen_init);
 
     run.run_until_finished(&mut env, &mut test_rng);
@@ -305,7 +311,10 @@ fn test_display_backup() {
 
     let mut run = Run::new(coordinator, devices);
 
-    let keygen_init = run.coordinator.do_keygen(&device_set, threshold).unwrap();
+    let keygen_init = run
+        .coordinator
+        .do_keygen(&device_set, threshold, "my key".to_string())
+        .unwrap();
     run.extend(keygen_init);
 
     run.run_until_finished(&mut env, &mut test_rng);
@@ -376,7 +385,10 @@ fn when_we_abandon_a_sign_request_we_should_be_able_to_start_a_new_one() {
     let mut env = TestEnv::default();
     let mut run = Run::new(coordinator, devices);
 
-    let keygen_init = run.coordinator.do_keygen(&device_set, threshold).unwrap();
+    let keygen_init = run
+        .coordinator
+        .do_keygen(&device_set, threshold, "my key".to_string())
+        .unwrap();
     run.extend(keygen_init);
 
     let request_nonces = run
@@ -484,7 +496,10 @@ fn signing_a_bitcoin_transaction_produces_valid_signatures() {
         run.extend(run.coordinator.maybe_request_nonce_replenishment(device_id));
     }
 
-    let keygen_init = run.coordinator.do_keygen(&device_set, threshold).unwrap();
+    let keygen_init = run
+        .coordinator
+        .do_keygen(&device_set, threshold, "my key".to_string())
+        .unwrap();
     run.extend(keygen_init);
 
     run.run_until_finished(&mut env, &mut test_rng);

--- a/frostsnap_core/tests/endtoend.rs
+++ b/frostsnap_core/tests/endtoend.rs
@@ -170,6 +170,7 @@ impl common::Env for TestEnv {
             DeviceToUserMessage::CheckKeyGen {
                 session_hash,
                 key_id: _,
+                ..
             } => {
                 self.keygen_checks.insert(from, session_hash);
                 let ack = run.device(from).keygen_ack().unwrap();

--- a/frostsnap_core/tests/malicious.rs
+++ b/frostsnap_core/tests/malicious.rs
@@ -102,7 +102,10 @@ fn nonce_reuse() {
     }
     run.run_until_finished(&mut TestEnv, &mut test_rng);
 
-    let keygen_init = run.coordinator.do_keygen(&device_set, threshold).unwrap();
+    let keygen_init = run
+        .coordinator
+        .do_keygen(&device_set, threshold, "my key".to_string())
+        .unwrap();
     run.extend(keygen_init);
 
     run.run_until_finished(&mut TestEnv, &mut test_rng);

--- a/frostsnap_core/tests/malicious.rs
+++ b/frostsnap_core/tests/malicious.rs
@@ -30,6 +30,7 @@ fn keygen_maliciously_replace_public_poly() {
             CoordinatorToDeviceMessage::DoKeyGen {
                 device_to_share_index: device_to_share_index.clone(),
                 threshold: 1,
+                key_name: "test".into(),
             },
             &mut test_rng,
         )

--- a/frostsnapp/ios/Runner/bridge_generated.h
+++ b/frostsnapp/ios/Runner/bridge_generated.h
@@ -264,7 +264,7 @@ WireSyncReturn wire_threshold__method__FrostKey(struct wire_FrostKey *that);
 
 WireSyncReturn wire_id__method__FrostKey(struct wire_FrostKey *that);
 
-WireSyncReturn wire_name__method__FrostKey(struct wire_FrostKey *that);
+WireSyncReturn wire_key_name__method__FrostKey(struct wire_FrostKey *that);
 
 WireSyncReturn wire_devices__method__FrostKey(struct wire_FrostKey *that);
 
@@ -358,6 +358,9 @@ void wire_sub_key_events__method__Coordinator(int64_t port_, struct wire_Coordin
 WireSyncReturn wire_get_key__method__Coordinator(struct wire_Coordinator *that,
                                                  struct wire_KeyId *key_id);
 
+WireSyncReturn wire_get_key_name__method__Coordinator(struct wire_Coordinator *that,
+                                                      struct wire_KeyId *key_id);
+
 WireSyncReturn wire_keys_for_device__method__Coordinator(struct wire_Coordinator *that,
                                                          struct wire_DeviceId *device_id);
 
@@ -382,7 +385,8 @@ WireSyncReturn wire_current_nonce__method__Coordinator(struct wire_Coordinator *
 void wire_generate_new_key__method__Coordinator(int64_t port_,
                                                 struct wire_Coordinator *that,
                                                 uintptr_t threshold,
-                                                struct wire_list_device_id *devices);
+                                                struct wire_list_device_id *devices,
+                                                struct wire_uint_8_list *key_name);
 
 WireSyncReturn wire_persisted_sign_session_description__method__Coordinator(struct wire_Coordinator *that,
                                                                             struct wire_KeyId *key_id);
@@ -615,7 +619,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_needs_firmware_upgrade__method__ConnectedDevice);
     dummy_var ^= ((int64_t) (void*) wire_threshold__method__FrostKey);
     dummy_var ^= ((int64_t) (void*) wire_id__method__FrostKey);
-    dummy_var ^= ((int64_t) (void*) wire_name__method__FrostKey);
+    dummy_var ^= ((int64_t) (void*) wire_key_name__method__FrostKey);
     dummy_var ^= ((int64_t) (void*) wire_devices__method__FrostKey);
     dummy_var ^= ((int64_t) (void*) wire_satisfy__method__PortOpen);
     dummy_var ^= ((int64_t) (void*) wire_satisfy__method__PortRead);
@@ -641,6 +645,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_key_state__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_sub_key_events__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_get_key__method__Coordinator);
+    dummy_var ^= ((int64_t) (void*) wire_get_key_name__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_keys_for_device__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_start_signing__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_start_signing_tx__method__Coordinator);

--- a/frostsnapp/ios/Runner/bridge_generated.h
+++ b/frostsnapp/ios/Runner/bridge_generated.h
@@ -384,7 +384,7 @@ WireSyncReturn wire_current_nonce__method__Coordinator(struct wire_Coordinator *
 
 void wire_generate_new_key__method__Coordinator(int64_t port_,
                                                 struct wire_Coordinator *that,
-                                                uintptr_t threshold,
+                                                uint16_t threshold,
                                                 struct wire_list_device_id *devices,
                                                 struct wire_uint_8_list *key_name);
 

--- a/frostsnapp/lib/bridge_definitions.dart
+++ b/frostsnapp/lib/bridge_definitions.dart
@@ -99,9 +99,9 @@ abstract class Native {
 
   FlutterRustBridgeTaskConstMeta get kIdMethodFrostKeyConstMeta;
 
-  String nameMethodFrostKey({required FrostKey that, dynamic hint});
+  String keyNameMethodFrostKey({required FrostKey that, dynamic hint});
 
-  FlutterRustBridgeTaskConstMeta get kNameMethodFrostKeyConstMeta;
+  FlutterRustBridgeTaskConstMeta get kKeyNameMethodFrostKeyConstMeta;
 
   List<DeviceId> devicesMethodFrostKey({required FrostKey that, dynamic hint});
 
@@ -253,6 +253,11 @@ abstract class Native {
 
   FlutterRustBridgeTaskConstMeta get kGetKeyMethodCoordinatorConstMeta;
 
+  String? getKeyNameMethodCoordinator(
+      {required Coordinator that, required KeyId keyId, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kGetKeyNameMethodCoordinatorConstMeta;
+
   List<KeyId> keysForDeviceMethodCoordinator(
       {required Coordinator that, required DeviceId deviceId, dynamic hint});
 
@@ -290,6 +295,7 @@ abstract class Native {
       {required Coordinator that,
       required int threshold,
       required List<DeviceId> devices,
+      required String keyName,
       dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kGenerateNewKeyMethodCoordinatorConstMeta;
@@ -877,6 +883,12 @@ class Coordinator {
         keyId: keyId,
       );
 
+  String? getKeyName({required KeyId keyId, dynamic hint}) =>
+      bridge.getKeyNameMethodCoordinator(
+        that: this,
+        keyId: keyId,
+      );
+
   List<KeyId> keysForDevice({required DeviceId deviceId, dynamic hint}) =>
       bridge.keysForDeviceMethodCoordinator(
         that: this,
@@ -922,11 +934,13 @@ class Coordinator {
   Stream<KeyGenState> generateNewKey(
           {required int threshold,
           required List<DeviceId> devices,
+          required String keyName,
           dynamic hint}) =>
       bridge.generateNewKeyMethodCoordinator(
         that: this,
         threshold: threshold,
         devices: devices,
+        keyName: keyName,
       );
 
   SignTaskDescription? persistedSignSessionDescription(
@@ -1106,7 +1120,7 @@ class FrostKey {
         that: this,
       );
 
-  String name({dynamic hint}) => bridge.nameMethodFrostKey(
+  String keyName({dynamic hint}) => bridge.keyNameMethodFrostKey(
         that: this,
       );
 

--- a/frostsnapp/lib/bridge_definitions.freezed.dart
+++ b/frostsnapp/lib/bridge_definitions.freezed.dart
@@ -12,7 +12,7 @@ part of 'bridge_definitions.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$PortEvent {
@@ -87,20 +87,20 @@ class _$PortEventCopyWithImpl<$Res, $Val extends PortEvent>
 }
 
 /// @nodoc
-abstract class _$$PortEvent_OpenCopyWith<$Res> {
-  factory _$$PortEvent_OpenCopyWith(
-          _$PortEvent_Open value, $Res Function(_$PortEvent_Open) then) =
-      __$$PortEvent_OpenCopyWithImpl<$Res>;
+abstract class _$$PortEvent_OpenImplCopyWith<$Res> {
+  factory _$$PortEvent_OpenImplCopyWith(_$PortEvent_OpenImpl value,
+          $Res Function(_$PortEvent_OpenImpl) then) =
+      __$$PortEvent_OpenImplCopyWithImpl<$Res>;
   @useResult
   $Res call({PortOpen request});
 }
 
 /// @nodoc
-class __$$PortEvent_OpenCopyWithImpl<$Res>
-    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_Open>
-    implements _$$PortEvent_OpenCopyWith<$Res> {
-  __$$PortEvent_OpenCopyWithImpl(
-      _$PortEvent_Open _value, $Res Function(_$PortEvent_Open) _then)
+class __$$PortEvent_OpenImplCopyWithImpl<$Res>
+    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_OpenImpl>
+    implements _$$PortEvent_OpenImplCopyWith<$Res> {
+  __$$PortEvent_OpenImplCopyWithImpl(
+      _$PortEvent_OpenImpl _value, $Res Function(_$PortEvent_OpenImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -108,7 +108,7 @@ class __$$PortEvent_OpenCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$PortEvent_Open(
+    return _then(_$PortEvent_OpenImpl(
       request: null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -119,8 +119,8 @@ class __$$PortEvent_OpenCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PortEvent_Open implements PortEvent_Open {
-  const _$PortEvent_Open({required this.request});
+class _$PortEvent_OpenImpl implements PortEvent_Open {
+  const _$PortEvent_OpenImpl({required this.request});
 
   @override
   final PortOpen request;
@@ -131,10 +131,10 @@ class _$PortEvent_Open implements PortEvent_Open {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PortEvent_Open &&
+            other is _$PortEvent_OpenImpl &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -144,8 +144,9 @@ class _$PortEvent_Open implements PortEvent_Open {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PortEvent_OpenCopyWith<_$PortEvent_Open> get copyWith =>
-      __$$PortEvent_OpenCopyWithImpl<_$PortEvent_Open>(this, _$identity);
+  _$$PortEvent_OpenImplCopyWith<_$PortEvent_OpenImpl> get copyWith =>
+      __$$PortEvent_OpenImplCopyWithImpl<_$PortEvent_OpenImpl>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -224,30 +225,30 @@ class _$PortEvent_Open implements PortEvent_Open {
 
 abstract class PortEvent_Open implements PortEvent {
   const factory PortEvent_Open({required final PortOpen request}) =
-      _$PortEvent_Open;
+      _$PortEvent_OpenImpl;
 
   @override
   PortOpen get request;
   @JsonKey(ignore: true)
-  _$$PortEvent_OpenCopyWith<_$PortEvent_Open> get copyWith =>
+  _$$PortEvent_OpenImplCopyWith<_$PortEvent_OpenImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$PortEvent_WriteCopyWith<$Res> {
-  factory _$$PortEvent_WriteCopyWith(
-          _$PortEvent_Write value, $Res Function(_$PortEvent_Write) then) =
-      __$$PortEvent_WriteCopyWithImpl<$Res>;
+abstract class _$$PortEvent_WriteImplCopyWith<$Res> {
+  factory _$$PortEvent_WriteImplCopyWith(_$PortEvent_WriteImpl value,
+          $Res Function(_$PortEvent_WriteImpl) then) =
+      __$$PortEvent_WriteImplCopyWithImpl<$Res>;
   @useResult
   $Res call({PortWrite request});
 }
 
 /// @nodoc
-class __$$PortEvent_WriteCopyWithImpl<$Res>
-    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_Write>
-    implements _$$PortEvent_WriteCopyWith<$Res> {
-  __$$PortEvent_WriteCopyWithImpl(
-      _$PortEvent_Write _value, $Res Function(_$PortEvent_Write) _then)
+class __$$PortEvent_WriteImplCopyWithImpl<$Res>
+    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_WriteImpl>
+    implements _$$PortEvent_WriteImplCopyWith<$Res> {
+  __$$PortEvent_WriteImplCopyWithImpl(
+      _$PortEvent_WriteImpl _value, $Res Function(_$PortEvent_WriteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -255,7 +256,7 @@ class __$$PortEvent_WriteCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$PortEvent_Write(
+    return _then(_$PortEvent_WriteImpl(
       request: null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -266,8 +267,8 @@ class __$$PortEvent_WriteCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PortEvent_Write implements PortEvent_Write {
-  const _$PortEvent_Write({required this.request});
+class _$PortEvent_WriteImpl implements PortEvent_Write {
+  const _$PortEvent_WriteImpl({required this.request});
 
   @override
   final PortWrite request;
@@ -278,10 +279,10 @@ class _$PortEvent_Write implements PortEvent_Write {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PortEvent_Write &&
+            other is _$PortEvent_WriteImpl &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -291,8 +292,9 @@ class _$PortEvent_Write implements PortEvent_Write {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PortEvent_WriteCopyWith<_$PortEvent_Write> get copyWith =>
-      __$$PortEvent_WriteCopyWithImpl<_$PortEvent_Write>(this, _$identity);
+  _$$PortEvent_WriteImplCopyWith<_$PortEvent_WriteImpl> get copyWith =>
+      __$$PortEvent_WriteImplCopyWithImpl<_$PortEvent_WriteImpl>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -371,30 +373,30 @@ class _$PortEvent_Write implements PortEvent_Write {
 
 abstract class PortEvent_Write implements PortEvent {
   const factory PortEvent_Write({required final PortWrite request}) =
-      _$PortEvent_Write;
+      _$PortEvent_WriteImpl;
 
   @override
   PortWrite get request;
   @JsonKey(ignore: true)
-  _$$PortEvent_WriteCopyWith<_$PortEvent_Write> get copyWith =>
+  _$$PortEvent_WriteImplCopyWith<_$PortEvent_WriteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$PortEvent_ReadCopyWith<$Res> {
-  factory _$$PortEvent_ReadCopyWith(
-          _$PortEvent_Read value, $Res Function(_$PortEvent_Read) then) =
-      __$$PortEvent_ReadCopyWithImpl<$Res>;
+abstract class _$$PortEvent_ReadImplCopyWith<$Res> {
+  factory _$$PortEvent_ReadImplCopyWith(_$PortEvent_ReadImpl value,
+          $Res Function(_$PortEvent_ReadImpl) then) =
+      __$$PortEvent_ReadImplCopyWithImpl<$Res>;
   @useResult
   $Res call({PortRead request});
 }
 
 /// @nodoc
-class __$$PortEvent_ReadCopyWithImpl<$Res>
-    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_Read>
-    implements _$$PortEvent_ReadCopyWith<$Res> {
-  __$$PortEvent_ReadCopyWithImpl(
-      _$PortEvent_Read _value, $Res Function(_$PortEvent_Read) _then)
+class __$$PortEvent_ReadImplCopyWithImpl<$Res>
+    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_ReadImpl>
+    implements _$$PortEvent_ReadImplCopyWith<$Res> {
+  __$$PortEvent_ReadImplCopyWithImpl(
+      _$PortEvent_ReadImpl _value, $Res Function(_$PortEvent_ReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -402,7 +404,7 @@ class __$$PortEvent_ReadCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$PortEvent_Read(
+    return _then(_$PortEvent_ReadImpl(
       request: null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -413,8 +415,8 @@ class __$$PortEvent_ReadCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PortEvent_Read implements PortEvent_Read {
-  const _$PortEvent_Read({required this.request});
+class _$PortEvent_ReadImpl implements PortEvent_Read {
+  const _$PortEvent_ReadImpl({required this.request});
 
   @override
   final PortRead request;
@@ -425,10 +427,10 @@ class _$PortEvent_Read implements PortEvent_Read {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PortEvent_Read &&
+            other is _$PortEvent_ReadImpl &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -438,8 +440,9 @@ class _$PortEvent_Read implements PortEvent_Read {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PortEvent_ReadCopyWith<_$PortEvent_Read> get copyWith =>
-      __$$PortEvent_ReadCopyWithImpl<_$PortEvent_Read>(this, _$identity);
+  _$$PortEvent_ReadImplCopyWith<_$PortEvent_ReadImpl> get copyWith =>
+      __$$PortEvent_ReadImplCopyWithImpl<_$PortEvent_ReadImpl>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -518,30 +521,31 @@ class _$PortEvent_Read implements PortEvent_Read {
 
 abstract class PortEvent_Read implements PortEvent {
   const factory PortEvent_Read({required final PortRead request}) =
-      _$PortEvent_Read;
+      _$PortEvent_ReadImpl;
 
   @override
   PortRead get request;
   @JsonKey(ignore: true)
-  _$$PortEvent_ReadCopyWith<_$PortEvent_Read> get copyWith =>
+  _$$PortEvent_ReadImplCopyWith<_$PortEvent_ReadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$PortEvent_BytesToReadCopyWith<$Res> {
-  factory _$$PortEvent_BytesToReadCopyWith(_$PortEvent_BytesToRead value,
-          $Res Function(_$PortEvent_BytesToRead) then) =
-      __$$PortEvent_BytesToReadCopyWithImpl<$Res>;
+abstract class _$$PortEvent_BytesToReadImplCopyWith<$Res> {
+  factory _$$PortEvent_BytesToReadImplCopyWith(
+          _$PortEvent_BytesToReadImpl value,
+          $Res Function(_$PortEvent_BytesToReadImpl) then) =
+      __$$PortEvent_BytesToReadImplCopyWithImpl<$Res>;
   @useResult
   $Res call({PortBytesToRead request});
 }
 
 /// @nodoc
-class __$$PortEvent_BytesToReadCopyWithImpl<$Res>
-    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_BytesToRead>
-    implements _$$PortEvent_BytesToReadCopyWith<$Res> {
-  __$$PortEvent_BytesToReadCopyWithImpl(_$PortEvent_BytesToRead _value,
-      $Res Function(_$PortEvent_BytesToRead) _then)
+class __$$PortEvent_BytesToReadImplCopyWithImpl<$Res>
+    extends _$PortEventCopyWithImpl<$Res, _$PortEvent_BytesToReadImpl>
+    implements _$$PortEvent_BytesToReadImplCopyWith<$Res> {
+  __$$PortEvent_BytesToReadImplCopyWithImpl(_$PortEvent_BytesToReadImpl _value,
+      $Res Function(_$PortEvent_BytesToReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -549,7 +553,7 @@ class __$$PortEvent_BytesToReadCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$PortEvent_BytesToRead(
+    return _then(_$PortEvent_BytesToReadImpl(
       request: null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -560,8 +564,8 @@ class __$$PortEvent_BytesToReadCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$PortEvent_BytesToRead implements PortEvent_BytesToRead {
-  const _$PortEvent_BytesToRead({required this.request});
+class _$PortEvent_BytesToReadImpl implements PortEvent_BytesToRead {
+  const _$PortEvent_BytesToReadImpl({required this.request});
 
   @override
   final PortBytesToRead request;
@@ -572,10 +576,10 @@ class _$PortEvent_BytesToRead implements PortEvent_BytesToRead {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PortEvent_BytesToRead &&
+            other is _$PortEvent_BytesToReadImpl &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -585,9 +589,9 @@ class _$PortEvent_BytesToRead implements PortEvent_BytesToRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PortEvent_BytesToReadCopyWith<_$PortEvent_BytesToRead> get copyWith =>
-      __$$PortEvent_BytesToReadCopyWithImpl<_$PortEvent_BytesToRead>(
-          this, _$identity);
+  _$$PortEvent_BytesToReadImplCopyWith<_$PortEvent_BytesToReadImpl>
+      get copyWith => __$$PortEvent_BytesToReadImplCopyWithImpl<
+          _$PortEvent_BytesToReadImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -666,13 +670,13 @@ class _$PortEvent_BytesToRead implements PortEvent_BytesToRead {
 
 abstract class PortEvent_BytesToRead implements PortEvent {
   const factory PortEvent_BytesToRead(
-      {required final PortBytesToRead request}) = _$PortEvent_BytesToRead;
+      {required final PortBytesToRead request}) = _$PortEvent_BytesToReadImpl;
 
   @override
   PortBytesToRead get request;
   @JsonKey(ignore: true)
-  _$$PortEvent_BytesToReadCopyWith<_$PortEvent_BytesToRead> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$PortEvent_BytesToReadImplCopyWith<_$PortEvent_BytesToReadImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -743,20 +747,22 @@ class _$QrDecoderStatusCopyWithImpl<$Res, $Val extends QrDecoderStatus>
 }
 
 /// @nodoc
-abstract class _$$QrDecoderStatus_ProgressCopyWith<$Res> {
-  factory _$$QrDecoderStatus_ProgressCopyWith(_$QrDecoderStatus_Progress value,
-          $Res Function(_$QrDecoderStatus_Progress) then) =
-      __$$QrDecoderStatus_ProgressCopyWithImpl<$Res>;
+abstract class _$$QrDecoderStatus_ProgressImplCopyWith<$Res> {
+  factory _$$QrDecoderStatus_ProgressImplCopyWith(
+          _$QrDecoderStatus_ProgressImpl value,
+          $Res Function(_$QrDecoderStatus_ProgressImpl) then) =
+      __$$QrDecoderStatus_ProgressImplCopyWithImpl<$Res>;
   @useResult
   $Res call({DecodingProgress field0});
 }
 
 /// @nodoc
-class __$$QrDecoderStatus_ProgressCopyWithImpl<$Res>
-    extends _$QrDecoderStatusCopyWithImpl<$Res, _$QrDecoderStatus_Progress>
-    implements _$$QrDecoderStatus_ProgressCopyWith<$Res> {
-  __$$QrDecoderStatus_ProgressCopyWithImpl(_$QrDecoderStatus_Progress _value,
-      $Res Function(_$QrDecoderStatus_Progress) _then)
+class __$$QrDecoderStatus_ProgressImplCopyWithImpl<$Res>
+    extends _$QrDecoderStatusCopyWithImpl<$Res, _$QrDecoderStatus_ProgressImpl>
+    implements _$$QrDecoderStatus_ProgressImplCopyWith<$Res> {
+  __$$QrDecoderStatus_ProgressImplCopyWithImpl(
+      _$QrDecoderStatus_ProgressImpl _value,
+      $Res Function(_$QrDecoderStatus_ProgressImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -764,7 +770,7 @@ class __$$QrDecoderStatus_ProgressCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$QrDecoderStatus_Progress(
+    return _then(_$QrDecoderStatus_ProgressImpl(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -775,8 +781,8 @@ class __$$QrDecoderStatus_ProgressCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$QrDecoderStatus_Progress implements QrDecoderStatus_Progress {
-  const _$QrDecoderStatus_Progress(this.field0);
+class _$QrDecoderStatus_ProgressImpl implements QrDecoderStatus_Progress {
+  const _$QrDecoderStatus_ProgressImpl(this.field0);
 
   @override
   final DecodingProgress field0;
@@ -787,10 +793,10 @@ class _$QrDecoderStatus_Progress implements QrDecoderStatus_Progress {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$QrDecoderStatus_Progress &&
+            other is _$QrDecoderStatus_ProgressImpl &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -800,10 +806,9 @@ class _$QrDecoderStatus_Progress implements QrDecoderStatus_Progress {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$QrDecoderStatus_ProgressCopyWith<_$QrDecoderStatus_Progress>
-      get copyWith =>
-          __$$QrDecoderStatus_ProgressCopyWithImpl<_$QrDecoderStatus_Progress>(
-              this, _$identity);
+  _$$QrDecoderStatus_ProgressImplCopyWith<_$QrDecoderStatus_ProgressImpl>
+      get copyWith => __$$QrDecoderStatus_ProgressImplCopyWithImpl<
+          _$QrDecoderStatus_ProgressImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -876,30 +881,32 @@ class _$QrDecoderStatus_Progress implements QrDecoderStatus_Progress {
 
 abstract class QrDecoderStatus_Progress implements QrDecoderStatus {
   const factory QrDecoderStatus_Progress(final DecodingProgress field0) =
-      _$QrDecoderStatus_Progress;
+      _$QrDecoderStatus_ProgressImpl;
 
   @override
   DecodingProgress get field0;
   @JsonKey(ignore: true)
-  _$$QrDecoderStatus_ProgressCopyWith<_$QrDecoderStatus_Progress>
+  _$$QrDecoderStatus_ProgressImplCopyWith<_$QrDecoderStatus_ProgressImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$QrDecoderStatus_DecodedCopyWith<$Res> {
-  factory _$$QrDecoderStatus_DecodedCopyWith(_$QrDecoderStatus_Decoded value,
-          $Res Function(_$QrDecoderStatus_Decoded) then) =
-      __$$QrDecoderStatus_DecodedCopyWithImpl<$Res>;
+abstract class _$$QrDecoderStatus_DecodedImplCopyWith<$Res> {
+  factory _$$QrDecoderStatus_DecodedImplCopyWith(
+          _$QrDecoderStatus_DecodedImpl value,
+          $Res Function(_$QrDecoderStatus_DecodedImpl) then) =
+      __$$QrDecoderStatus_DecodedImplCopyWithImpl<$Res>;
   @useResult
   $Res call({Uint8List field0});
 }
 
 /// @nodoc
-class __$$QrDecoderStatus_DecodedCopyWithImpl<$Res>
-    extends _$QrDecoderStatusCopyWithImpl<$Res, _$QrDecoderStatus_Decoded>
-    implements _$$QrDecoderStatus_DecodedCopyWith<$Res> {
-  __$$QrDecoderStatus_DecodedCopyWithImpl(_$QrDecoderStatus_Decoded _value,
-      $Res Function(_$QrDecoderStatus_Decoded) _then)
+class __$$QrDecoderStatus_DecodedImplCopyWithImpl<$Res>
+    extends _$QrDecoderStatusCopyWithImpl<$Res, _$QrDecoderStatus_DecodedImpl>
+    implements _$$QrDecoderStatus_DecodedImplCopyWith<$Res> {
+  __$$QrDecoderStatus_DecodedImplCopyWithImpl(
+      _$QrDecoderStatus_DecodedImpl _value,
+      $Res Function(_$QrDecoderStatus_DecodedImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -907,7 +914,7 @@ class __$$QrDecoderStatus_DecodedCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$QrDecoderStatus_Decoded(
+    return _then(_$QrDecoderStatus_DecodedImpl(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -918,8 +925,8 @@ class __$$QrDecoderStatus_DecodedCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$QrDecoderStatus_Decoded implements QrDecoderStatus_Decoded {
-  const _$QrDecoderStatus_Decoded(this.field0);
+class _$QrDecoderStatus_DecodedImpl implements QrDecoderStatus_Decoded {
+  const _$QrDecoderStatus_DecodedImpl(this.field0);
 
   @override
   final Uint8List field0;
@@ -930,10 +937,10 @@ class _$QrDecoderStatus_Decoded implements QrDecoderStatus_Decoded {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$QrDecoderStatus_Decoded &&
+            other is _$QrDecoderStatus_DecodedImpl &&
             const DeepCollectionEquality().equals(other.field0, field0));
   }
 
@@ -944,9 +951,9 @@ class _$QrDecoderStatus_Decoded implements QrDecoderStatus_Decoded {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$QrDecoderStatus_DecodedCopyWith<_$QrDecoderStatus_Decoded> get copyWith =>
-      __$$QrDecoderStatus_DecodedCopyWithImpl<_$QrDecoderStatus_Decoded>(
-          this, _$identity);
+  _$$QrDecoderStatus_DecodedImplCopyWith<_$QrDecoderStatus_DecodedImpl>
+      get copyWith => __$$QrDecoderStatus_DecodedImplCopyWithImpl<
+          _$QrDecoderStatus_DecodedImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1019,30 +1026,32 @@ class _$QrDecoderStatus_Decoded implements QrDecoderStatus_Decoded {
 
 abstract class QrDecoderStatus_Decoded implements QrDecoderStatus {
   const factory QrDecoderStatus_Decoded(final Uint8List field0) =
-      _$QrDecoderStatus_Decoded;
+      _$QrDecoderStatus_DecodedImpl;
 
   @override
   Uint8List get field0;
   @JsonKey(ignore: true)
-  _$$QrDecoderStatus_DecodedCopyWith<_$QrDecoderStatus_Decoded> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$QrDecoderStatus_DecodedImplCopyWith<_$QrDecoderStatus_DecodedImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$QrDecoderStatus_FailedCopyWith<$Res> {
-  factory _$$QrDecoderStatus_FailedCopyWith(_$QrDecoderStatus_Failed value,
-          $Res Function(_$QrDecoderStatus_Failed) then) =
-      __$$QrDecoderStatus_FailedCopyWithImpl<$Res>;
+abstract class _$$QrDecoderStatus_FailedImplCopyWith<$Res> {
+  factory _$$QrDecoderStatus_FailedImplCopyWith(
+          _$QrDecoderStatus_FailedImpl value,
+          $Res Function(_$QrDecoderStatus_FailedImpl) then) =
+      __$$QrDecoderStatus_FailedImplCopyWithImpl<$Res>;
   @useResult
   $Res call({String field0});
 }
 
 /// @nodoc
-class __$$QrDecoderStatus_FailedCopyWithImpl<$Res>
-    extends _$QrDecoderStatusCopyWithImpl<$Res, _$QrDecoderStatus_Failed>
-    implements _$$QrDecoderStatus_FailedCopyWith<$Res> {
-  __$$QrDecoderStatus_FailedCopyWithImpl(_$QrDecoderStatus_Failed _value,
-      $Res Function(_$QrDecoderStatus_Failed) _then)
+class __$$QrDecoderStatus_FailedImplCopyWithImpl<$Res>
+    extends _$QrDecoderStatusCopyWithImpl<$Res, _$QrDecoderStatus_FailedImpl>
+    implements _$$QrDecoderStatus_FailedImplCopyWith<$Res> {
+  __$$QrDecoderStatus_FailedImplCopyWithImpl(
+      _$QrDecoderStatus_FailedImpl _value,
+      $Res Function(_$QrDecoderStatus_FailedImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1050,7 +1059,7 @@ class __$$QrDecoderStatus_FailedCopyWithImpl<$Res>
   $Res call({
     Object? field0 = null,
   }) {
-    return _then(_$QrDecoderStatus_Failed(
+    return _then(_$QrDecoderStatus_FailedImpl(
       null == field0
           ? _value.field0
           : field0 // ignore: cast_nullable_to_non_nullable
@@ -1061,8 +1070,8 @@ class __$$QrDecoderStatus_FailedCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$QrDecoderStatus_Failed implements QrDecoderStatus_Failed {
-  const _$QrDecoderStatus_Failed(this.field0);
+class _$QrDecoderStatus_FailedImpl implements QrDecoderStatus_Failed {
+  const _$QrDecoderStatus_FailedImpl(this.field0);
 
   @override
   final String field0;
@@ -1073,10 +1082,10 @@ class _$QrDecoderStatus_Failed implements QrDecoderStatus_Failed {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$QrDecoderStatus_Failed &&
+            other is _$QrDecoderStatus_FailedImpl &&
             (identical(other.field0, field0) || other.field0 == field0));
   }
 
@@ -1086,9 +1095,9 @@ class _$QrDecoderStatus_Failed implements QrDecoderStatus_Failed {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$QrDecoderStatus_FailedCopyWith<_$QrDecoderStatus_Failed> get copyWith =>
-      __$$QrDecoderStatus_FailedCopyWithImpl<_$QrDecoderStatus_Failed>(
-          this, _$identity);
+  _$$QrDecoderStatus_FailedImplCopyWith<_$QrDecoderStatus_FailedImpl>
+      get copyWith => __$$QrDecoderStatus_FailedImplCopyWithImpl<
+          _$QrDecoderStatus_FailedImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1161,13 +1170,13 @@ class _$QrDecoderStatus_Failed implements QrDecoderStatus_Failed {
 
 abstract class QrDecoderStatus_Failed implements QrDecoderStatus {
   const factory QrDecoderStatus_Failed(final String field0) =
-      _$QrDecoderStatus_Failed;
+      _$QrDecoderStatus_FailedImpl;
 
   @override
   String get field0;
   @JsonKey(ignore: true)
-  _$$QrDecoderStatus_FailedCopyWith<_$QrDecoderStatus_Failed> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$QrDecoderStatus_FailedImplCopyWith<_$QrDecoderStatus_FailedImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -1232,21 +1241,23 @@ class _$SignTaskDescriptionCopyWithImpl<$Res, $Val extends SignTaskDescription>
 }
 
 /// @nodoc
-abstract class _$$SignTaskDescription_PlainCopyWith<$Res> {
-  factory _$$SignTaskDescription_PlainCopyWith(
-          _$SignTaskDescription_Plain value,
-          $Res Function(_$SignTaskDescription_Plain) then) =
-      __$$SignTaskDescription_PlainCopyWithImpl<$Res>;
+abstract class _$$SignTaskDescription_PlainImplCopyWith<$Res> {
+  factory _$$SignTaskDescription_PlainImplCopyWith(
+          _$SignTaskDescription_PlainImpl value,
+          $Res Function(_$SignTaskDescription_PlainImpl) then) =
+      __$$SignTaskDescription_PlainImplCopyWithImpl<$Res>;
   @useResult
   $Res call({String message});
 }
 
 /// @nodoc
-class __$$SignTaskDescription_PlainCopyWithImpl<$Res>
-    extends _$SignTaskDescriptionCopyWithImpl<$Res, _$SignTaskDescription_Plain>
-    implements _$$SignTaskDescription_PlainCopyWith<$Res> {
-  __$$SignTaskDescription_PlainCopyWithImpl(_$SignTaskDescription_Plain _value,
-      $Res Function(_$SignTaskDescription_Plain) _then)
+class __$$SignTaskDescription_PlainImplCopyWithImpl<$Res>
+    extends _$SignTaskDescriptionCopyWithImpl<$Res,
+        _$SignTaskDescription_PlainImpl>
+    implements _$$SignTaskDescription_PlainImplCopyWith<$Res> {
+  __$$SignTaskDescription_PlainImplCopyWithImpl(
+      _$SignTaskDescription_PlainImpl _value,
+      $Res Function(_$SignTaskDescription_PlainImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1254,7 +1265,7 @@ class __$$SignTaskDescription_PlainCopyWithImpl<$Res>
   $Res call({
     Object? message = null,
   }) {
-    return _then(_$SignTaskDescription_Plain(
+    return _then(_$SignTaskDescription_PlainImpl(
       message: null == message
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
@@ -1265,8 +1276,8 @@ class __$$SignTaskDescription_PlainCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$SignTaskDescription_Plain implements SignTaskDescription_Plain {
-  const _$SignTaskDescription_Plain({required this.message});
+class _$SignTaskDescription_PlainImpl implements SignTaskDescription_Plain {
+  const _$SignTaskDescription_PlainImpl({required this.message});
 
   @override
   final String message;
@@ -1277,10 +1288,10 @@ class _$SignTaskDescription_Plain implements SignTaskDescription_Plain {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SignTaskDescription_Plain &&
+            other is _$SignTaskDescription_PlainImpl &&
             (identical(other.message, message) || other.message == message));
   }
 
@@ -1290,9 +1301,9 @@ class _$SignTaskDescription_Plain implements SignTaskDescription_Plain {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SignTaskDescription_PlainCopyWith<_$SignTaskDescription_Plain>
-      get copyWith => __$$SignTaskDescription_PlainCopyWithImpl<
-          _$SignTaskDescription_Plain>(this, _$identity);
+  _$$SignTaskDescription_PlainImplCopyWith<_$SignTaskDescription_PlainImpl>
+      get copyWith => __$$SignTaskDescription_PlainImplCopyWithImpl<
+          _$SignTaskDescription_PlainImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1360,32 +1371,32 @@ class _$SignTaskDescription_Plain implements SignTaskDescription_Plain {
 
 abstract class SignTaskDescription_Plain implements SignTaskDescription {
   const factory SignTaskDescription_Plain({required final String message}) =
-      _$SignTaskDescription_Plain;
+      _$SignTaskDescription_PlainImpl;
 
   String get message;
   @JsonKey(ignore: true)
-  _$$SignTaskDescription_PlainCopyWith<_$SignTaskDescription_Plain>
+  _$$SignTaskDescription_PlainImplCopyWith<_$SignTaskDescription_PlainImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$SignTaskDescription_TransactionCopyWith<$Res> {
-  factory _$$SignTaskDescription_TransactionCopyWith(
-          _$SignTaskDescription_Transaction value,
-          $Res Function(_$SignTaskDescription_Transaction) then) =
-      __$$SignTaskDescription_TransactionCopyWithImpl<$Res>;
+abstract class _$$SignTaskDescription_TransactionImplCopyWith<$Res> {
+  factory _$$SignTaskDescription_TransactionImplCopyWith(
+          _$SignTaskDescription_TransactionImpl value,
+          $Res Function(_$SignTaskDescription_TransactionImpl) then) =
+      __$$SignTaskDescription_TransactionImplCopyWithImpl<$Res>;
   @useResult
   $Res call({UnsignedTx unsignedTx});
 }
 
 /// @nodoc
-class __$$SignTaskDescription_TransactionCopyWithImpl<$Res>
+class __$$SignTaskDescription_TransactionImplCopyWithImpl<$Res>
     extends _$SignTaskDescriptionCopyWithImpl<$Res,
-        _$SignTaskDescription_Transaction>
-    implements _$$SignTaskDescription_TransactionCopyWith<$Res> {
-  __$$SignTaskDescription_TransactionCopyWithImpl(
-      _$SignTaskDescription_Transaction _value,
-      $Res Function(_$SignTaskDescription_Transaction) _then)
+        _$SignTaskDescription_TransactionImpl>
+    implements _$$SignTaskDescription_TransactionImplCopyWith<$Res> {
+  __$$SignTaskDescription_TransactionImplCopyWithImpl(
+      _$SignTaskDescription_TransactionImpl _value,
+      $Res Function(_$SignTaskDescription_TransactionImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1393,7 +1404,7 @@ class __$$SignTaskDescription_TransactionCopyWithImpl<$Res>
   $Res call({
     Object? unsignedTx = null,
   }) {
-    return _then(_$SignTaskDescription_Transaction(
+    return _then(_$SignTaskDescription_TransactionImpl(
       unsignedTx: null == unsignedTx
           ? _value.unsignedTx
           : unsignedTx // ignore: cast_nullable_to_non_nullable
@@ -1404,9 +1415,9 @@ class __$$SignTaskDescription_TransactionCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$SignTaskDescription_Transaction
+class _$SignTaskDescription_TransactionImpl
     implements SignTaskDescription_Transaction {
-  const _$SignTaskDescription_Transaction({required this.unsignedTx});
+  const _$SignTaskDescription_TransactionImpl({required this.unsignedTx});
 
   @override
   final UnsignedTx unsignedTx;
@@ -1417,10 +1428,10 @@ class _$SignTaskDescription_Transaction
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SignTaskDescription_Transaction &&
+            other is _$SignTaskDescription_TransactionImpl &&
             (identical(other.unsignedTx, unsignedTx) ||
                 other.unsignedTx == unsignedTx));
   }
@@ -1431,9 +1442,10 @@ class _$SignTaskDescription_Transaction
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SignTaskDescription_TransactionCopyWith<_$SignTaskDescription_Transaction>
-      get copyWith => __$$SignTaskDescription_TransactionCopyWithImpl<
-          _$SignTaskDescription_Transaction>(this, _$identity);
+  _$$SignTaskDescription_TransactionImplCopyWith<
+          _$SignTaskDescription_TransactionImpl>
+      get copyWith => __$$SignTaskDescription_TransactionImplCopyWithImpl<
+          _$SignTaskDescription_TransactionImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1502,10 +1514,11 @@ class _$SignTaskDescription_Transaction
 abstract class SignTaskDescription_Transaction implements SignTaskDescription {
   const factory SignTaskDescription_Transaction(
           {required final UnsignedTx unsignedTx}) =
-      _$SignTaskDescription_Transaction;
+      _$SignTaskDescription_TransactionImpl;
 
   UnsignedTx get unsignedTx;
   @JsonKey(ignore: true)
-  _$$SignTaskDescription_TransactionCopyWith<_$SignTaskDescription_Transaction>
+  _$$SignTaskDescription_TransactionImplCopyWith<
+          _$SignTaskDescription_TransactionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/frostsnapp/lib/bridge_generated.dart
+++ b/frostsnapp/lib/bridge_generated.dart
@@ -368,21 +368,21 @@ class NativeImpl implements Native {
         argNames: ["that"],
       );
 
-  String nameMethodFrostKey({required FrostKey that, dynamic hint}) {
+  String keyNameMethodFrostKey({required FrostKey that, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_frost_key(that);
     return _platform.executeSync(FlutterRustBridgeSyncTask(
-      callFfi: () => _platform.inner.wire_name__method__FrostKey(arg0),
+      callFfi: () => _platform.inner.wire_key_name__method__FrostKey(arg0),
       parseSuccessData: _wire2api_String,
       parseErrorData: null,
-      constMeta: kNameMethodFrostKeyConstMeta,
+      constMeta: kKeyNameMethodFrostKeyConstMeta,
       argValues: [that],
       hint: hint,
     ));
   }
 
-  FlutterRustBridgeTaskConstMeta get kNameMethodFrostKeyConstMeta =>
+  FlutterRustBridgeTaskConstMeta get kKeyNameMethodFrostKeyConstMeta =>
       const FlutterRustBridgeTaskConstMeta(
-        debugName: "name__method__FrostKey",
+        debugName: "key_name__method__FrostKey",
         argNames: ["that"],
       );
 
@@ -941,6 +941,27 @@ class NativeImpl implements Native {
         argNames: ["that", "keyId"],
       );
 
+  String? getKeyNameMethodCoordinator(
+      {required Coordinator that, required KeyId keyId, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_coordinator(that);
+    var arg1 = _platform.api2wire_box_autoadd_key_id(keyId);
+    return _platform.executeSync(FlutterRustBridgeSyncTask(
+      callFfi: () =>
+          _platform.inner.wire_get_key_name__method__Coordinator(arg0, arg1),
+      parseSuccessData: _wire2api_opt_String,
+      parseErrorData: null,
+      constMeta: kGetKeyNameMethodCoordinatorConstMeta,
+      argValues: [that, keyId],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kGetKeyNameMethodCoordinatorConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "get_key_name__method__Coordinator",
+        argNames: ["that", "keyId"],
+      );
+
   List<KeyId> keysForDeviceMethodCoordinator(
       {required Coordinator that, required DeviceId deviceId, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_coordinator(that);
@@ -1066,17 +1087,20 @@ class NativeImpl implements Native {
       {required Coordinator that,
       required int threshold,
       required List<DeviceId> devices,
+      required String keyName,
       dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_coordinator(that);
     var arg1 = api2wire_usize(threshold);
     var arg2 = _platform.api2wire_list_device_id(devices);
+    var arg3 = _platform.api2wire_String(keyName);
     return _platform.executeStream(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner
-          .wire_generate_new_key__method__Coordinator(port_, arg0, arg1, arg2),
+          .wire_generate_new_key__method__Coordinator(
+              port_, arg0, arg1, arg2, arg3),
       parseSuccessData: _wire2api_key_gen_state,
       parseErrorData: _wire2api_FrbAnyhowException,
       constMeta: kGenerateNewKeyMethodCoordinatorConstMeta,
-      argValues: [that, threshold, devices],
+      argValues: [that, threshold, devices, keyName],
       hint: hint,
     ));
   }
@@ -1085,7 +1109,7 @@ class NativeImpl implements Native {
       get kGenerateNewKeyMethodCoordinatorConstMeta =>
           const FlutterRustBridgeTaskConstMeta(
             debugName: "generate_new_key__method__Coordinator",
-            argNames: ["that", "threshold", "devices"],
+            argNames: ["that", "threshold", "devices", "keyName"],
           );
 
   SignTaskDescription? persistedSignSessionDescriptionMethodCoordinator(

--- a/frostsnapp/lib/bridge_generated.dart
+++ b/frostsnapp/lib/bridge_generated.dart
@@ -1090,7 +1090,7 @@ class NativeImpl implements Native {
       required String keyName,
       dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_coordinator(that);
-    var arg1 = api2wire_usize(threshold);
+    var arg1 = api2wire_u16(threshold);
     var arg2 = _platform.api2wire_list_device_id(devices);
     var arg3 = _platform.api2wire_String(keyName);
     return _platform.executeStream(FlutterRustBridgeTask(

--- a/frostsnapp/lib/bridge_generated.io.dart
+++ b/frostsnapp/lib/bridge_generated.io.dart
@@ -1154,20 +1154,21 @@ class NativeWire implements FlutterRustBridgeWireBase {
   late final _wire_id__method__FrostKey = _wire_id__method__FrostKeyPtr
       .asFunction<WireSyncReturn Function(ffi.Pointer<wire_FrostKey>)>();
 
-  WireSyncReturn wire_name__method__FrostKey(
+  WireSyncReturn wire_key_name__method__FrostKey(
     ffi.Pointer<wire_FrostKey> that,
   ) {
-    return _wire_name__method__FrostKey(
+    return _wire_key_name__method__FrostKey(
       that,
     );
   }
 
-  late final _wire_name__method__FrostKeyPtr = _lookup<
+  late final _wire_key_name__method__FrostKeyPtr = _lookup<
           ffi
           .NativeFunction<WireSyncReturn Function(ffi.Pointer<wire_FrostKey>)>>(
-      'wire_name__method__FrostKey');
-  late final _wire_name__method__FrostKey = _wire_name__method__FrostKeyPtr
-      .asFunction<WireSyncReturn Function(ffi.Pointer<wire_FrostKey>)>();
+      'wire_key_name__method__FrostKey');
+  late final _wire_key_name__method__FrostKey =
+      _wire_key_name__method__FrostKeyPtr
+          .asFunction<WireSyncReturn Function(ffi.Pointer<wire_FrostKey>)>();
 
   WireSyncReturn wire_devices__method__FrostKey(
     ffi.Pointer<wire_FrostKey> that,
@@ -1705,6 +1706,26 @@ class NativeWire implements FlutterRustBridgeWireBase {
           WireSyncReturn Function(
               ffi.Pointer<wire_Coordinator>, ffi.Pointer<wire_KeyId>)>();
 
+  WireSyncReturn wire_get_key_name__method__Coordinator(
+    ffi.Pointer<wire_Coordinator> that,
+    ffi.Pointer<wire_KeyId> key_id,
+  ) {
+    return _wire_get_key_name__method__Coordinator(
+      that,
+      key_id,
+    );
+  }
+
+  late final _wire_get_key_name__method__CoordinatorPtr = _lookup<
+          ffi.NativeFunction<
+              WireSyncReturn Function(
+                  ffi.Pointer<wire_Coordinator>, ffi.Pointer<wire_KeyId>)>>(
+      'wire_get_key_name__method__Coordinator');
+  late final _wire_get_key_name__method__Coordinator =
+      _wire_get_key_name__method__CoordinatorPtr.asFunction<
+          WireSyncReturn Function(
+              ffi.Pointer<wire_Coordinator>, ffi.Pointer<wire_KeyId>)>();
+
   WireSyncReturn wire_keys_for_device__method__Coordinator(
     ffi.Pointer<wire_Coordinator> that,
     ffi.Pointer<wire_DeviceId> device_id,
@@ -1838,24 +1859,34 @@ class NativeWire implements FlutterRustBridgeWireBase {
     ffi.Pointer<wire_Coordinator> that,
     int threshold,
     ffi.Pointer<wire_list_device_id> devices,
+    ffi.Pointer<wire_uint_8_list> key_name,
   ) {
     return _wire_generate_new_key__method__Coordinator(
       port_,
       that,
       threshold,
       devices,
+      key_name,
     );
   }
 
   late final _wire_generate_new_key__method__CoordinatorPtr = _lookup<
           ffi.NativeFunction<
-              ffi.Void Function(ffi.Int64, ffi.Pointer<wire_Coordinator>,
-                  ffi.UintPtr, ffi.Pointer<wire_list_device_id>)>>(
+              ffi.Void Function(
+                  ffi.Int64,
+                  ffi.Pointer<wire_Coordinator>,
+                  ffi.UintPtr,
+                  ffi.Pointer<wire_list_device_id>,
+                  ffi.Pointer<wire_uint_8_list>)>>(
       'wire_generate_new_key__method__Coordinator');
   late final _wire_generate_new_key__method__Coordinator =
       _wire_generate_new_key__method__CoordinatorPtr.asFunction<
-          void Function(int, ffi.Pointer<wire_Coordinator>, int,
-              ffi.Pointer<wire_list_device_id>)>();
+          void Function(
+              int,
+              ffi.Pointer<wire_Coordinator>,
+              int,
+              ffi.Pointer<wire_list_device_id>,
+              ffi.Pointer<wire_uint_8_list>)>();
 
   WireSyncReturn wire_persisted_sign_session_description__method__Coordinator(
     ffi.Pointer<wire_Coordinator> that,

--- a/frostsnapp/lib/bridge_generated.io.dart
+++ b/frostsnapp/lib/bridge_generated.io.dart
@@ -1875,7 +1875,7 @@ class NativeWire implements FlutterRustBridgeWireBase {
               ffi.Void Function(
                   ffi.Int64,
                   ffi.Pointer<wire_Coordinator>,
-                  ffi.UintPtr,
+                  ffi.Uint16,
                   ffi.Pointer<wire_list_device_id>,
                   ffi.Pointer<wire_uint_8_list>)>>(
       'wire_generate_new_key__method__Coordinator');

--- a/frostsnapp/lib/bridge_generated.web.dart
+++ b/frostsnapp/lib/bridge_generated.web.dart
@@ -559,7 +559,8 @@ class NativeWasmModule implements WasmModule {
   external dynamic /* List<dynamic> */ wire_id__method__FrostKey(
       List<dynamic> that);
 
-  external dynamic /* String */ wire_name__method__FrostKey(List<dynamic> that);
+  external dynamic /* String */ wire_key_name__method__FrostKey(
+      List<dynamic> that);
 
   external dynamic /* List<dynamic> */ wire_devices__method__FrostKey(
       List<dynamic> that);
@@ -651,6 +652,9 @@ class NativeWasmModule implements WasmModule {
   external dynamic /* List<dynamic>? */ wire_get_key__method__Coordinator(
       List<dynamic> that, List<dynamic> key_id);
 
+  external dynamic /* String? */ wire_get_key_name__method__Coordinator(
+      List<dynamic> that, List<dynamic> key_id);
+
   external dynamic /* List<dynamic> */
       wire_keys_for_device__method__Coordinator(
           List<dynamic> that, List<dynamic> device_id);
@@ -679,7 +683,8 @@ class NativeWasmModule implements WasmModule {
       NativePortType port_,
       List<dynamic> that,
       int threshold,
-      List<dynamic> devices);
+      List<dynamic> devices,
+      String key_name);
 
   external dynamic /* List<dynamic>? */
       wire_persisted_sign_session_description__method__Coordinator(
@@ -875,8 +880,8 @@ class NativeWire extends FlutterRustBridgeWasmWireBase<NativeWasmModule> {
   dynamic /* List<dynamic> */ wire_id__method__FrostKey(List<dynamic> that) =>
       wasmModule.wire_id__method__FrostKey(that);
 
-  dynamic /* String */ wire_name__method__FrostKey(List<dynamic> that) =>
-      wasmModule.wire_name__method__FrostKey(that);
+  dynamic /* String */ wire_key_name__method__FrostKey(List<dynamic> that) =>
+      wasmModule.wire_key_name__method__FrostKey(that);
 
   dynamic /* List<dynamic> */ wire_devices__method__FrostKey(
           List<dynamic> that) =>
@@ -988,6 +993,10 @@ class NativeWire extends FlutterRustBridgeWasmWireBase<NativeWasmModule> {
           List<dynamic> that, List<dynamic> key_id) =>
       wasmModule.wire_get_key__method__Coordinator(that, key_id);
 
+  dynamic /* String? */ wire_get_key_name__method__Coordinator(
+          List<dynamic> that, List<dynamic> key_id) =>
+      wasmModule.wire_get_key_name__method__Coordinator(that, key_id);
+
   dynamic /* List<dynamic> */ wire_keys_for_device__method__Coordinator(
           List<dynamic> that, List<dynamic> device_id) =>
       wasmModule.wire_keys_for_device__method__Coordinator(that, device_id);
@@ -1018,10 +1027,14 @@ class NativeWire extends FlutterRustBridgeWasmWireBase<NativeWasmModule> {
           List<dynamic> that, List<dynamic> id) =>
       wasmModule.wire_current_nonce__method__Coordinator(that, id);
 
-  void wire_generate_new_key__method__Coordinator(NativePortType port_,
-          List<dynamic> that, int threshold, List<dynamic> devices) =>
+  void wire_generate_new_key__method__Coordinator(
+          NativePortType port_,
+          List<dynamic> that,
+          int threshold,
+          List<dynamic> devices,
+          String key_name) =>
       wasmModule.wire_generate_new_key__method__Coordinator(
-          port_, that, threshold, devices);
+          port_, that, threshold, devices, key_name);
 
   dynamic /* List<dynamic>? */
       wire_persisted_sign_session_description__method__Coordinator(

--- a/frostsnapp/lib/device_list.dart
+++ b/frostsnapp/lib/device_list.dart
@@ -258,14 +258,15 @@ Widget buildInteractiveDevice(BuildContext context, ConnectedDevice device,
 
   if (upToDate) {
     if (device.name == null) {
-      children.add(IconButton.outlined(
-          onPressed: () async {
-            await Navigator.push(context, MaterialPageRoute(builder: (context) {
-              return DeviceSetup(id: device.id);
-            }));
-          },
-          color: Colors.blue,
-          icon: Icon(Icons.phonelink_setup)));
+      children.add(ElevatedButton.icon(
+        onPressed: () async {
+          await Navigator.push(context, MaterialPageRoute(builder: (context) {
+            return DeviceSetup(id: device.id);
+          }));
+        },
+        icon: Icon(Icons.phonelink_setup),
+        label: Text('New device'),
+      ));
     } else {
       children.add(IconButton(
         icon: Icon(Icons.settings),

--- a/frostsnapp/lib/device_settings.dart
+++ b/frostsnapp/lib/device_settings.dart
@@ -85,19 +85,26 @@ class _DeviceSettingsState extends State<DeviceSettings> {
         itemCount: deviceKeys.length,
         itemBuilder: (context, index) {
           final keyId = deviceKeys[index];
+          final keyName = coord.getKeyName(keyId: keyId)!;
           return ListTile(
             title: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
-                Text(
-                  toHex(Uint8List.fromList(keyId.field0)),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontFamily: 'Monospace',
+                Column(children: [
+                  Text(
+                    keyName,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
                   ),
-                ),
+                  Text(
+                    toHex(Uint8List.fromList(keyId.field0)),
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 1,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontFamily: 'Monospace',
+                    ),
+                  )
+                ]),
                 SizedBox(width: 10),
                 ElevatedButton(
                   onPressed: () async {

--- a/frostsnapp/lib/device_settings.dart
+++ b/frostsnapp/lib/device_settings.dart
@@ -93,17 +93,8 @@ class _DeviceSettingsState extends State<DeviceSettings> {
                 Column(children: [
                   Text(
                     keyName,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
+                    style: const TextStyle(fontSize: 20.0),
                   ),
-                  Text(
-                    toHex(Uint8List.fromList(keyId.field0)),
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 1,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      fontFamily: 'Monospace',
-                    ),
-                  )
                 ]),
                 SizedBox(width: 10),
                 ElevatedButton(
@@ -161,7 +152,7 @@ class _DeviceSettingsState extends State<DeviceSettings> {
                               });
                         },
                         onCancel: () {
-                          coord.cancelAll();
+                          coord.cancelProtocol();
                         });
                   },
                   child: Text("Backup"),

--- a/frostsnapp/lib/key_list.dart
+++ b/frostsnapp/lib/key_list.dart
@@ -158,7 +158,7 @@ class _KeyCard extends State<KeyCard> {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Text(
-              toHex(Uint8List.fromList(widget.frostKey.id().field0)),
+              widget.frostKey.keyName(),
               textAlign: TextAlign.center,
               style: const TextStyle(
                   fontSize: 18,

--- a/frostsnapp/lib/key_list.dart
+++ b/frostsnapp/lib/key_list.dart
@@ -1,4 +1,3 @@
-import 'dart:typed_data';
 import 'package:frostsnapp/global.dart';
 import 'package:frostsnapp/device_settings.dart';
 import 'package:frostsnapp/keygen.dart';
@@ -7,7 +6,6 @@ import 'package:frostsnapp/wallet.dart';
 
 import 'ffi.dart' if (dart.library.html) 'ffi_web.dart';
 import 'package:flutter/material.dart';
-import 'package:frostsnapp/hex.dart';
 import 'package:confetti/confetti.dart';
 
 import 'sign_message.dart';
@@ -60,7 +58,7 @@ class KeyList extends StatelessWidget {
                       onPressed: () async {
                         final newId = await Navigator.push(context,
                             MaterialPageRoute(builder: (context) {
-                          return const KeyGenPage();
+                          return KeyNamePage();
                         }));
                         if (newId != null) {
                           onNewKey?.call(newId);

--- a/frostsnapp/lib/keygen.dart
+++ b/frostsnapp/lib/keygen.dart
@@ -40,6 +40,7 @@ class DoKeyGenButton extends StatefulWidget {
 
 class _DoKeyGenButtonState extends State<DoKeyGenButton> {
   int? thresholdSlider;
+  final _messageController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -62,6 +63,16 @@ class _DoKeyGenButtonState extends State<DoKeyGenButton> {
     }
 
     return Column(children: [
+      SizedBox(
+          width: MediaQuery.of(context).size.width * 0.5,
+          child: TextField(
+            controller: _messageController,
+            onChanged: (_) {
+              setState(() {});
+            },
+            decoration: InputDecoration(labelText: 'Key Name'),
+          )),
+      SizedBox(height: 8),
       Text(
         prompt,
         style: const TextStyle(fontSize: 18.0),
@@ -84,7 +95,7 @@ class _DoKeyGenButtonState extends State<DoKeyGenButton> {
             max: max(readyDevices.length.toDouble(), 1)),
       ),
       ElevatedButton(
-          onPressed: readyDevices.isEmpty
+          onPressed: (readyDevices.isEmpty || _messageController.text.isEmpty)
               ? null
               : () async {
                   final keyId = await Navigator.push(context,
@@ -92,10 +103,12 @@ class _DoKeyGenButtonState extends State<DoKeyGenButton> {
                     final stream = coord
                         .generateNewKey(
                             threshold: selectedThreshold,
-                            devices: readyDevices.map((e) => e.id).toList())
+                            devices: readyDevices.map((e) => e.id).toList(),
+                            keyName: _messageController.text)
                         .toBehaviorSubject();
                     return DoKeyGenScreen(
                       stream: stream,
+                      keyName: _messageController.text,
                     );
                   }));
                   if (keyId != null) {
@@ -115,7 +128,9 @@ typedef OnSuccess = Function(KeyId);
 
 class DoKeyGenScreen extends StatefulWidget {
   final Stream<KeyGenState> stream;
-  const DoKeyGenScreen({super.key, required this.stream});
+  final String keyName;
+  const DoKeyGenScreen(
+      {super.key, required this.stream, required this.keyName});
 
   @override
   State<DoKeyGenScreen> createState() => _DoKeyGenScreenState();

--- a/frostsnapp/lib/main.dart
+++ b/frostsnapp/lib/main.dart
@@ -76,26 +76,33 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
         title: 'Frostsnapp',
         theme: ThemeData(
-          colorScheme: ColorScheme.fromSwatch(
-            primarySwatch: Colors.blue,
-            backgroundColor: Colors.white,
-            errorColor: Colors.red,
-          ).copyWith(
-            secondary: Colors.blueAccent,
-          ),
-          textButtonTheme: TextButtonThemeData(
-            style: TextButton.styleFrom(backgroundColor: Colors.blueAccent),
-          ),
-          elevatedButtonTheme: ElevatedButtonThemeData(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.blue,
-              foregroundColor: Colors.white,
+            colorScheme: ColorScheme.fromSwatch(
+              primarySwatch: Colors.blue,
+              backgroundColor: Colors.white,
+              errorColor: Colors.red,
+            ).copyWith(
+              secondary: Colors.blueAccent,
             ),
-          ),
-          outlinedButtonTheme: OutlinedButtonThemeData(
-            style: OutlinedButton.styleFrom(),
-          ),
-        ),
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(
+                  backgroundColor: Colors.blueAccent,
+                  foregroundColor: Colors.white),
+            ),
+            elevatedButtonTheme: ElevatedButtonThemeData(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blue,
+                foregroundColor: Colors.white,
+              ),
+            ),
+            inputDecorationTheme: InputDecorationTheme(
+              border: OutlineInputBorder(), // Apply border globally
+              enabledBorder: OutlineInputBorder(
+                borderSide: BorderSide(color: Colors.grey),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderSide: BorderSide(color: Colors.blue),
+              ),
+            )),
         home: startupError == null
             ? const MyHomePage(title: 'Frostsnapp')
             : StartupErrorWidget(error: startupError!));

--- a/frostsnapp/macos/Runner/bridge_generated.h
+++ b/frostsnapp/macos/Runner/bridge_generated.h
@@ -264,7 +264,7 @@ WireSyncReturn wire_threshold__method__FrostKey(struct wire_FrostKey *that);
 
 WireSyncReturn wire_id__method__FrostKey(struct wire_FrostKey *that);
 
-WireSyncReturn wire_name__method__FrostKey(struct wire_FrostKey *that);
+WireSyncReturn wire_key_name__method__FrostKey(struct wire_FrostKey *that);
 
 WireSyncReturn wire_devices__method__FrostKey(struct wire_FrostKey *that);
 
@@ -358,6 +358,9 @@ void wire_sub_key_events__method__Coordinator(int64_t port_, struct wire_Coordin
 WireSyncReturn wire_get_key__method__Coordinator(struct wire_Coordinator *that,
                                                  struct wire_KeyId *key_id);
 
+WireSyncReturn wire_get_key_name__method__Coordinator(struct wire_Coordinator *that,
+                                                      struct wire_KeyId *key_id);
+
 WireSyncReturn wire_keys_for_device__method__Coordinator(struct wire_Coordinator *that,
                                                          struct wire_DeviceId *device_id);
 
@@ -382,7 +385,8 @@ WireSyncReturn wire_current_nonce__method__Coordinator(struct wire_Coordinator *
 void wire_generate_new_key__method__Coordinator(int64_t port_,
                                                 struct wire_Coordinator *that,
                                                 uintptr_t threshold,
-                                                struct wire_list_device_id *devices);
+                                                struct wire_list_device_id *devices,
+                                                struct wire_uint_8_list *key_name);
 
 WireSyncReturn wire_persisted_sign_session_description__method__Coordinator(struct wire_Coordinator *that,
                                                                             struct wire_KeyId *key_id);
@@ -615,7 +619,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_needs_firmware_upgrade__method__ConnectedDevice);
     dummy_var ^= ((int64_t) (void*) wire_threshold__method__FrostKey);
     dummy_var ^= ((int64_t) (void*) wire_id__method__FrostKey);
-    dummy_var ^= ((int64_t) (void*) wire_name__method__FrostKey);
+    dummy_var ^= ((int64_t) (void*) wire_key_name__method__FrostKey);
     dummy_var ^= ((int64_t) (void*) wire_devices__method__FrostKey);
     dummy_var ^= ((int64_t) (void*) wire_satisfy__method__PortOpen);
     dummy_var ^= ((int64_t) (void*) wire_satisfy__method__PortRead);
@@ -641,6 +645,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_key_state__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_sub_key_events__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_get_key__method__Coordinator);
+    dummy_var ^= ((int64_t) (void*) wire_get_key_name__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_keys_for_device__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_start_signing__method__Coordinator);
     dummy_var ^= ((int64_t) (void*) wire_start_signing_tx__method__Coordinator);

--- a/frostsnapp/macos/Runner/bridge_generated.h
+++ b/frostsnapp/macos/Runner/bridge_generated.h
@@ -384,7 +384,7 @@ WireSyncReturn wire_current_nonce__method__Coordinator(struct wire_Coordinator *
 
 void wire_generate_new_key__method__Coordinator(int64_t port_,
                                                 struct wire_Coordinator *that,
-                                                uintptr_t threshold,
+                                                uint16_t threshold,
                                                 struct wire_list_device_id *devices,
                                                 struct wire_uint_8_list *key_name);
 

--- a/frostsnapp/native/src/api.rs
+++ b/frostsnapp/native/src/api.rs
@@ -132,6 +132,7 @@ impl ConnectedDevice {
 #[derive(Clone, Debug)]
 pub struct KeyState {
     pub keys: Vec<FrostKey>,
+    // pub key_names: BTreeMap<KeyId, String>,
 }
 
 #[derive(Clone, Debug)]
@@ -146,8 +147,8 @@ impl FrostKey {
         SyncReturn(self.0.frost_key().key_id())
     }
 
-    pub fn name(&self) -> SyncReturn<String> {
-        SyncReturn("KEY NAMES NOT IMPLEMENTED".into())
+    pub fn key_name(&self) -> SyncReturn<String> {
+        SyncReturn(self.0.key_name())
     }
 
     pub fn devices(&self) -> SyncReturn<Vec<DeviceId>> {
@@ -682,6 +683,16 @@ impl Coordinator {
         )
     }
 
+    pub fn get_key_name(&self, key_id: KeyId) -> SyncReturn<Option<String>> {
+        SyncReturn(
+            self.0
+                .frost_keys()
+                .into_iter()
+                .find(|frost_key| frost_key.id().0 == key_id)
+                .map(|frost_key| frost_key.0.key_name()),
+        )
+    }
+
     pub fn keys_for_device(&self, device_id: DeviceId) -> SyncReturn<Vec<KeyId>> {
         SyncReturn(
             self.0
@@ -742,10 +753,15 @@ impl Coordinator {
         &self,
         threshold: usize,
         devices: Vec<DeviceId>,
+        key_name: String,
         event_stream: StreamSink<KeyGenState>,
     ) -> anyhow::Result<()> {
-        self.0
-            .generate_new_key(devices.into_iter().collect(), threshold, event_stream)
+        self.0.generate_new_key(
+            devices.into_iter().collect(),
+            threshold,
+            key_name,
+            event_stream,
+        )
     }
 
     pub fn persisted_sign_session_description(

--- a/frostsnapp/native/src/api.rs
+++ b/frostsnapp/native/src/api.rs
@@ -751,7 +751,7 @@ impl Coordinator {
 
     pub fn generate_new_key(
         &self,
-        threshold: usize,
+        threshold: u16,
         devices: Vec<DeviceId>,
         key_name: String,
         event_stream: StreamSink<KeyGenState>,

--- a/frostsnapp/native/src/bridge_generated.io.rs
+++ b/frostsnapp/native/src/bridge_generated.io.rs
@@ -109,8 +109,10 @@ pub extern "C" fn wire_id__method__FrostKey(that: *mut wire_FrostKey) -> support
 }
 
 #[no_mangle]
-pub extern "C" fn wire_name__method__FrostKey(that: *mut wire_FrostKey) -> support::WireSyncReturn {
-    wire_name__method__FrostKey_impl(that)
+pub extern "C" fn wire_key_name__method__FrostKey(
+    that: *mut wire_FrostKey,
+) -> support::WireSyncReturn {
+    wire_key_name__method__FrostKey_impl(that)
 }
 
 #[no_mangle]
@@ -331,6 +333,14 @@ pub extern "C" fn wire_get_key__method__Coordinator(
 }
 
 #[no_mangle]
+pub extern "C" fn wire_get_key_name__method__Coordinator(
+    that: *mut wire_Coordinator,
+    key_id: *mut wire_KeyId,
+) -> support::WireSyncReturn {
+    wire_get_key_name__method__Coordinator_impl(that, key_id)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_keys_for_device__method__Coordinator(
     that: *mut wire_Coordinator,
     device_id: *mut wire_DeviceId,
@@ -382,8 +392,9 @@ pub extern "C" fn wire_generate_new_key__method__Coordinator(
     that: *mut wire_Coordinator,
     threshold: usize,
     devices: *mut wire_list_device_id,
+    key_name: *mut wire_uint_8_list,
 ) {
-    wire_generate_new_key__method__Coordinator_impl(port_, that, threshold, devices)
+    wire_generate_new_key__method__Coordinator_impl(port_, that, threshold, devices, key_name)
 }
 
 #[no_mangle]

--- a/frostsnapp/native/src/bridge_generated.io.rs
+++ b/frostsnapp/native/src/bridge_generated.io.rs
@@ -390,7 +390,7 @@ pub extern "C" fn wire_current_nonce__method__Coordinator(
 pub extern "C" fn wire_generate_new_key__method__Coordinator(
     port_: i64,
     that: *mut wire_Coordinator,
-    threshold: usize,
+    threshold: u16,
     devices: *mut wire_list_device_id,
     key_name: *mut wire_uint_8_list,
 ) {

--- a/frostsnapp/native/src/bridge_generated.rs
+++ b/frostsnapp/native/src/bridge_generated.rs
@@ -296,18 +296,18 @@ fn wire_id__method__FrostKey_impl(
         },
     )
 }
-fn wire_name__method__FrostKey_impl(
+fn wire_key_name__method__FrostKey_impl(
     that: impl Wire2Api<FrostKey> + UnwindSafe,
 ) -> support::WireSyncReturn {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
         WrapInfo {
-            debug_name: "name__method__FrostKey",
+            debug_name: "key_name__method__FrostKey",
             port: None,
             mode: FfiCallMode::Sync,
         },
         move || {
             let api_that = that.wire2api();
-            Result::<_, ()>::Ok(FrostKey::name(&api_that))
+            Result::<_, ()>::Ok(FrostKey::key_name(&api_that))
         },
     )
 }
@@ -808,6 +808,23 @@ fn wire_get_key__method__Coordinator_impl(
         },
     )
 }
+fn wire_get_key_name__method__Coordinator_impl(
+    that: impl Wire2Api<Coordinator> + UnwindSafe,
+    key_id: impl Wire2Api<KeyId> + UnwindSafe,
+) -> support::WireSyncReturn {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync(
+        WrapInfo {
+            debug_name: "get_key_name__method__Coordinator",
+            port: None,
+            mode: FfiCallMode::Sync,
+        },
+        move || {
+            let api_that = that.wire2api();
+            let api_key_id = key_id.wire2api();
+            Result::<_, ()>::Ok(Coordinator::get_key_name(&api_that, api_key_id))
+        },
+    )
+}
 fn wire_keys_for_device__method__Coordinator_impl(
     that: impl Wire2Api<Coordinator> + UnwindSafe,
     device_id: impl Wire2Api<DeviceId> + UnwindSafe,
@@ -924,6 +941,7 @@ fn wire_generate_new_key__method__Coordinator_impl(
     that: impl Wire2Api<Coordinator> + UnwindSafe,
     threshold: impl Wire2Api<usize> + UnwindSafe,
     devices: impl Wire2Api<Vec<DeviceId>> + UnwindSafe,
+    key_name: impl Wire2Api<String> + UnwindSafe,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, (), _>(
         WrapInfo {
@@ -935,11 +953,13 @@ fn wire_generate_new_key__method__Coordinator_impl(
             let api_that = that.wire2api();
             let api_threshold = threshold.wire2api();
             let api_devices = devices.wire2api();
+            let api_key_name = key_name.wire2api();
             move |task_callback| {
                 Coordinator::generate_new_key(
                     &api_that,
                     api_threshold,
                     api_devices,
+                    api_key_name,
                     task_callback.stream_sink::<_, mirror_KeyGenState>(),
                 )
             }

--- a/frostsnapp/native/src/bridge_generated.rs
+++ b/frostsnapp/native/src/bridge_generated.rs
@@ -939,7 +939,7 @@ fn wire_current_nonce__method__Coordinator_impl(
 fn wire_generate_new_key__method__Coordinator_impl(
     port_: MessagePort,
     that: impl Wire2Api<Coordinator> + UnwindSafe,
-    threshold: impl Wire2Api<usize> + UnwindSafe,
+    threshold: impl Wire2Api<u16> + UnwindSafe,
     devices: impl Wire2Api<Vec<DeviceId>> + UnwindSafe,
     key_name: impl Wire2Api<String> + UnwindSafe,
 ) {

--- a/frostsnapp/native/src/bridge_generated.web.rs
+++ b/frostsnapp/native/src/bridge_generated.web.rs
@@ -344,7 +344,7 @@ pub fn wire_current_nonce__method__Coordinator(
 pub fn wire_generate_new_key__method__Coordinator(
     port_: MessagePort,
     that: JsValue,
-    threshold: usize,
+    threshold: u16,
     devices: JsValue,
     key_name: String,
 ) {

--- a/frostsnapp/native/src/bridge_generated.web.rs
+++ b/frostsnapp/native/src/bridge_generated.web.rs
@@ -99,8 +99,8 @@ pub fn wire_id__method__FrostKey(that: JsValue) -> support::WireSyncReturn {
 }
 
 #[wasm_bindgen]
-pub fn wire_name__method__FrostKey(that: JsValue) -> support::WireSyncReturn {
-    wire_name__method__FrostKey_impl(that)
+pub fn wire_key_name__method__FrostKey(that: JsValue) -> support::WireSyncReturn {
+    wire_key_name__method__FrostKey_impl(that)
 }
 
 #[wasm_bindgen]
@@ -287,6 +287,14 @@ pub fn wire_get_key__method__Coordinator(
 }
 
 #[wasm_bindgen]
+pub fn wire_get_key_name__method__Coordinator(
+    that: JsValue,
+    key_id: JsValue,
+) -> support::WireSyncReturn {
+    wire_get_key_name__method__Coordinator_impl(that, key_id)
+}
+
+#[wasm_bindgen]
 pub fn wire_keys_for_device__method__Coordinator(
     that: JsValue,
     device_id: JsValue,
@@ -338,8 +346,9 @@ pub fn wire_generate_new_key__method__Coordinator(
     that: JsValue,
     threshold: usize,
     devices: JsValue,
+    key_name: String,
 ) {
-    wire_generate_new_key__method__Coordinator_impl(port_, that, threshold, devices)
+    wire_generate_new_key__method__Coordinator_impl(port_, that, threshold, devices, key_name)
 }
 
 #[wasm_bindgen]

--- a/frostsnapp/native/src/coordinator.rs
+++ b/frostsnapp/native/src/coordinator.rs
@@ -247,10 +247,15 @@ impl FfiCoordinator {
                                 completion
                             );
                             *ui_protocol_loop = None;
-                            if let Completion::Abort = completion {
-                                event!(Level::DEBUG, "canceling protocol due to abort");
+                            if let Completion::Abort {
+                                send_cancel_to_all_devices,
+                            } = completion
+                            {
                                 coordinator.MUTATE_NO_PERSIST().cancel();
-                                usb_sender.send_cancel_all();
+                                event!(Level::DEBUG, "canceling protocol due to abort");
+                                if send_cancel_to_all_devices {
+                                    usb_sender.send_cancel_all();
+                                }
                             }
                         }
                     }
@@ -376,37 +381,30 @@ impl FfiCoordinator {
             .unwrap()
             .MUTATE_NO_PERSIST()
             .cancel();
-        self.usb_sender.send_cancel_all()
+        self.usb_sender.send_cancel_all();
     }
 
     pub fn generate_new_key(
         &self,
         devices: BTreeSet<DeviceId>,
-        threshold: usize,
+        threshold: u16,
         key_name: String,
         sink: StreamSink<frostsnap_coordinator::keygen::KeyGenState>,
     ) -> anyhow::Result<()> {
-        let ui_protocol =
-            frostsnap_coordinator::keygen::KeyGen::new(SinkWrap(sink), devices.clone(), threshold);
-
-        let keygen_messages = {
-            let mut coordinator = self.coordinator.lock().unwrap();
-            coordinator.staged_mutate(&mut *self.db.lock().unwrap(), |coordinator| {
-                Ok(coordinator.do_keygen(&devices, threshold as u16, key_name.clone())?)
-            })?
-        };
-
-        self.pending_for_outbox
-            .lock()
-            .unwrap()
-            .extend(keygen_messages);
-
-        // Send device pending key name
-        let send_message = CoordinatorSendMessage {
-            target_destinations: Destination::from(devices),
-            message_body: CoordinatorSendBody::KeyName(key_name),
-        };
-        self.usb_sender.send(send_message);
+        let currently_connected = api::device_list_state()
+            .0
+            .devices
+            .into_iter()
+            .map(|device| device.id)
+            .collect();
+        let ui_protocol = frostsnap_coordinator::keygen::KeyGen::new(
+            SinkWrap(sink),
+            self.coordinator.lock().unwrap().MUTATE_NO_PERSIST(),
+            devices.clone(),
+            currently_connected,
+            threshold,
+            key_name,
+        );
 
         ui_protocol.emit_state();
         self.start_protocol(ui_protocol);
@@ -570,7 +568,14 @@ impl FfiCoordinator {
         for device in api::device_list_state().0.devices {
             protocol.connected(device.id);
         }
+        let new_name = protocol.name();
         if let Some(mut prev) = self.ui_protocol.lock().unwrap().replace(Box::new(protocol)) {
+            event!(
+                Level::WARN,
+                prev = prev.name(),
+                new = new_name,
+                "previous protocol wasn't shut down cleanly"
+            );
             prev.cancel();
         }
     }


### PR DESCRIPTION
- When initiating keygen, the coordinator sends over a `CoordinatorSendBody::KeyName(key_name)` to the device
- Currently the names are stored inside each `CoordinatorFrostKey`
- Devices receive this name and store it as a change after confirming keygen
- The device panics if it receives a new `Change::KeyName` message for a key.

Still not super happy with the mix of where key names are involved. With recent changes i've put it more inside frostsnap_core, no longer carrying around some `pending_key_name` inside the coordinator state.

I think we should either:
* Go all out into making a separate sql table for key names, removing it as much as possible from frostsnap_core
* Go all out into putting key names into keygen messages (might be the nicer solution). FinishKeyGen would tell the device the name, rather than storing some pending one while awaiting keygen.