### PR TITLE
Better device dialogs

### DIFF
--- a/frostsnapp/lib/device_setup.dart
+++ b/frostsnapp/lib/device_setup.dart
@@ -77,27 +77,30 @@ class _DeviceNameField extends State<DeviceNameField> {
           coord.finishNaming(id: widget.id, name: name);
           await showDeviceActionDialog(
               context: context,
-              content: Column(children: [
-                Text("Confirm name '$name' on device"),
-                Divider(),
-                MaybeExpandedVertical(child: DeviceListContainer(child:
-                    DeviceListWithIcons(iconAssigner: (context, deviceId) {
-                  if (deviceIdEquals(deviceId, widget.id)) {
-                    final label = LabeledDeviceText("'$name'?");
-                    const icon = Row(mainAxisSize: MainAxisSize.min, children: [
-                      Icon(Icons.visibility, color: Colors.orange),
-                      SizedBox(width: 4),
-                      Text("Confirm"),
-                    ]);
-                    return (label, icon);
-                  } else {
-                    return (null, null);
-                  }
-                })))
-              ]),
               complete: completeWhen,
               onCancel: () async {
                 await coord.sendCancel(id: widget.id);
+              },
+              builder: (context) {
+                return Column(children: [
+                  Text("Confirm name '$name' on device"),
+                  Divider(),
+                  MaybeExpandedVertical(child: DeviceListContainer(child:
+                      DeviceListWithIcons(iconAssigner: (context, deviceId) {
+                    if (deviceIdEquals(deviceId, widget.id)) {
+                      final label = LabeledDeviceText("'$name'?");
+                      const icon =
+                          Row(mainAxisSize: MainAxisSize.min, children: [
+                        Icon(Icons.visibility, color: Colors.orange),
+                        SizedBox(width: 4),
+                        Text("Confirm"),
+                      ]);
+                      return (label, icon);
+                    } else {
+                      return (null, null);
+                    }
+                  })))
+                ]);
               });
         },
         onChanged: (value) async {

--- a/frostsnapp/lib/hex.dart
+++ b/frostsnapp/lib/hex.dart
@@ -43,7 +43,7 @@ Widget toHexBox(Uint8List bytes, {int chunkSize = 2}) {
   // Widget to dynamically layout the chunks
   return LayoutBuilder(
     builder: (BuildContext context, BoxConstraints constraints) {
-      int maxChunksPerRow = (constraints.maxWidth / (chunkSize * 30)).floor();
+      int maxChunksPerRow = (constraints.maxWidth / (chunkSize * 40)).floor();
       maxChunksPerRow =
           math.max(1, maxChunksPerRow); // Ensure at least one chunk per row
 

--- a/frostsnapp/lib/main.dart
+++ b/frostsnapp/lib/main.dart
@@ -93,10 +93,7 @@ class MyApp extends StatelessWidget {
             ),
           ),
           outlinedButtonTheme: OutlinedButtonThemeData(
-            style: OutlinedButton.styleFrom(
-              backgroundColor: Colors.blue,
-              side: BorderSide(color: Colors.blue),
-            ),
+            style: OutlinedButton.styleFrom(),
           ),
         ),
         home: startupError == null

--- a/frostsnapp/lib/sign_message.dart
+++ b/frostsnapp/lib/sign_message.dart
@@ -198,12 +198,14 @@ Future<List<EncodedSignature>?> showSigningProgressDialog(
         coord.cancelProtocol();
       },
       complete: finishedSigning,
-      content: Column(children: [
-        description,
-        Divider(),
-        Text("Plug in each device"),
-        Expanded(child: DeviceSigningProgress(stream: stream)),
-      ]));
+      builder: (context) {
+        return Column(children: [
+          description,
+          Divider(),
+          Text("Plug in each device"),
+          Expanded(child: DeviceSigningProgress(stream: stream)),
+        ]);
+      });
 }
 
 Future<void> _showSignatureDialog(


### PR DESCRIPTION
I changed the dialog that comes up for device actions to a https://api.flutter.dev/flutter/widgets/DraggableScrollableSheet-class.html. To me this is much nicer because:

1. More space. Much less cramped on screen.
2. Natural way of closing it.
3. Let's you drag it down to see what's behind it and then resume.

This is on top of the PSBT PR #129 