### PR TITLE
Fix Closing Check Backup Dialog

### DIFF
--- a/frostsnapp/lib/device_settings.dart
+++ b/frostsnapp/lib/device_settings.dart
@@ -455,7 +455,7 @@ class BackupSettingsPage extends StatelessWidget {
                             return null;
                           });
 
-                          final result = await showDeviceActionDialog(
+                          final result = await showDeviceActionDialog<bool>(
                             context: context,
                             complete: aborted,
                             builder: (BuildContext context) {


### PR DESCRIPTION
Oops I forgot to add this commit to #136

After a successful backup check the dialog doesn't close:
```
══╡ EXCEPTION CAUGHT BY GESTURE ╞═══════════════════════════════════════════════════════════════════
The following _TypeError was thrown while handling a gesture:
type 'bool' is not a subtype of type 'Null' of 'result'

When the exception was thrown, this was the stack:
#0      LocalHistoryRoute.didPop (package:flutter/src/widgets/routes.dart:845:18)
#1      _RouteEntry.handlePop (package:flutter/src/widgets/navigator.dart:3167:16)
#2      NavigatorState._flushHistoryUpdates (package:flutter/src/widgets/navigator.dart:4340:22)
#3      NavigatorState.pop (package:flutter/src/widgets/navigator.dart:5368:7)
#4      Navigator.pop (package:flutter/src/widgets/navigator.dart:2665:27)
#5      BackupSettingsPage.build.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:frostsnapp/device_settings.d
art:488:55)
#6      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1170:21)
#7      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:351:24)
#8      TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:656:11)
#9      BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:313:5)
#10     BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:283:7)
#11     GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:169:27)
#12     GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:505:20)
#13     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:481:22)
#14     RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:450:11)
#15     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:426:7)
#16     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:389:5)
#17     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:336:7)
#18     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:305:9)
#19     _invoke1 (dart:ui/hooks.dart:328:13)
#20     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:442:7)
#21     _dispatchPointerDataPacket (dart:ui/hooks.dart:262:31)

Handler: "onTap"
Recognizer:
  TapGestureRecognizer#9f160
════════════════════════════════════════════════════════════════════════════════════════════════════
```