### PR TITLE
Fix: restart after topmost instance pop

### DIFF
--- a/frostsnapp/lib/main.dart
+++ b/frostsnapp/lib/main.dart
@@ -119,7 +119,7 @@ class MyHomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: FsAppBar(title: Text("Key List")),
+        appBar: FsAppBar(title: Text("Wallets")),
         body: Center(child: KeyListWithConfetti()));
   }
 }

--- a/frostsnapp/native/src/api.rs
+++ b/frostsnapp/native/src/api.rs
@@ -332,14 +332,16 @@ impl From<LogLevel> for tracing::Level {
 }
 
 pub fn turn_stderr_logging_on(level: LogLevel, log_stream: StreamSink<String>) -> Result<()> {
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::from(level))
-        .without_time()
-        .pretty()
-        .finish()
-        .with(crate::logger::dart_logger(log_stream));
-
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    // Global default subscriber must only be set once.
+    if crate::logger::set_dart_logger(log_stream) {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::from(level))
+            .without_time()
+            .pretty()
+            .finish()
+            .with(crate::logger::dart_logger());
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    }
     event!(Level::INFO, "logging to stderr and Dart logger");
 
     Ok(())
@@ -352,23 +354,26 @@ pub fn turn_logcat_logging_on(level: LogLevel, log_stream: StreamSink<String>) -
 
     #[cfg(target_os = "android")]
     {
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(match level {
-                LogLevel::Info => tracing::Level::INFO,
-                LogLevel::Debug => tracing::Level::DEBUG,
-            })
-            .without_time()
-            .pretty()
-            .finish();
+        // Global default subscriber must only be set once.
+        if crate::logger::set_dart_logger(log_stream) {
+            let subscriber = tracing_subscriber::fmt()
+                .with_max_level(match level {
+                    LogLevel::Info => tracing::Level::INFO,
+                    LogLevel::Debug => tracing::Level::DEBUG,
+                })
+                .without_time()
+                .pretty()
+                .finish();
 
-        let subscriber = {
-            use tracing_subscriber::layer::SubscriberExt;
-            subscriber
-                .with(tracing_android::layer("rust-frostsnapp").unwrap())
-                .with(crate::logger::dart_logger(log_stream))
-        };
+            let subscriber = {
+                use tracing_subscriber::layer::SubscriberExt;
+                subscriber
+                    .with(tracing_android::layer("rust-frostsnapp").unwrap())
+                    .with(crate::logger::dart_logger())
+            };
 
-        tracing::subscriber::set_global_default(subscriber)?;
+            tracing::subscriber::set_global_default(subscriber)?;
+        }
         event!(Level::INFO, "frostsnap logging to logcat and Dart logger");
     }
 


### PR DESCRIPTION
Previously, if the topmost flutter instance got popped, the app will end
up hanging at the startup screen. The culprit is
`tracing::subscriber::set_global_default` being called multiple times
(it should only be called once).

This commit changes the behavior so that future calls only replaces the
`StreamSink` (which is now a global variable).