### PR TITLE
[coord+app] Remove verify_address/sent_to_devices

### DIFF
--- a/frostsnap_coordinator/src/verify_address.rs
+++ b/frostsnap_coordinator/src/verify_address.rs
@@ -10,8 +10,7 @@ use crate::{Completion, Sink, UiProtocol, UiToStorageMessage};
 
 #[derive(Clone, Debug, Default)]
 pub struct VerifyAddressProtocolState {
-    pub target_devices: Vec<DeviceId>,  // not a set for frb compat
-    pub sent_to_devices: Vec<DeviceId>, // not a set for frb compat
+    pub target_devices: Vec<DeviceId>, // not a set for frb compat
 }
 
 pub struct VerifyAddressProtocol {
@@ -31,7 +30,6 @@ impl VerifyAddressProtocol {
         Self {
             state: VerifyAddressProtocolState {
                 target_devices: verify_address_message.target_devices.into_iter().collect(),
-                sent_to_devices: Default::default(),
             },
             master_appkey: verify_address_message.master_appkey,
             derivation_index: verify_address_message.derivation_index,
@@ -96,9 +94,6 @@ impl UiProtocol for VerifyAddressProtocol {
                 ),
             });
         }
-        self.state
-            .sent_to_devices
-            .extend(self.need_to_send_to.iter().cloned());
 
         (messages, vec![])
     }

--- a/frostsnapp/lib/address.dart
+++ b/frostsnapp/lib/address.dart
@@ -183,12 +183,6 @@ Future<void> _showVerificationDialog(
             builder: (context, snapshot) {
               return ElevatedButton(
                 onPressed: () {
-                  if (snapshot.hasData &&
-                      snapshot.data?.sentToDevices != null &&
-                      snapshot.data!.sentToDevices.isNotEmpty) {
-                    // go back an extra window
-                    Navigator.of(context).pop();
-                  }
                   Navigator.of(context).pop();
                 },
                 child: Text('Done'),

--- a/frostsnapp/native/src/api.rs
+++ b/frostsnapp/native/src/api.rs
@@ -1527,7 +1527,6 @@ pub enum _ChainStatusState {
 #[frb(mirror(VerifyAddressProtocolState))]
 pub struct _VerifyAddressProtocolState {
     pub target_devices: Vec<DeviceId>,
-    pub sent_to_devices: Vec<DeviceId>,
 }
 
 // XXX: bugs in flutter_rust_bridge mean that sometimes the right code doesn't get emitted unless


### PR DESCRIPTION
I broke it before and it is only used to pop an extra scope and I'm not even sure we want to do that.