### PR TITLE
WIP fix continue signing

### DIFF
--- a/frostsnap_core/tests/common/mod.rs
+++ b/frostsnap_core/tests/common/mod.rs
@@ -31,7 +31,6 @@ pub enum Send {
         destinations: BTreeSet<DeviceId>,
         message: CoordinatorToDeviceMessage,
     },
-    CoordinatorSigningSession(SigningSessionState),
 }
 
 impl From<CoordinatorSend> for Send {
@@ -45,9 +44,6 @@ impl From<CoordinatorSend> for Send {
                 message,
             },
             CoordinatorSend::ToUser(v) => v.into(),
-            CoordinatorSend::SigningSessionStore(session_state) => {
-                Send::CoordinatorSigningSession(session_state)
-            }
         }
     }
 }
@@ -263,9 +259,6 @@ impl Run {
                                 .map(|v| Send::device_send(destination, v)),
                         );
                     }
-                }
-                Send::CoordinatorSigningSession(signing_session_state) => {
-                    env.sign_session_state_react_to_coordinator(self, signing_session_state);
                 }
             }
         }


### PR DESCRIPTION
*Almost* works - there's a bug sometimes where a device doesn't react to a `SignRequest`, wild guess is that this has something to do with `HeldShares` computation when being plugged in (need conch??). Will investigate.

---


Also documenting some general thoughts on signing sessions:

## Mutation Design
The way we're making append-only mutations means that storing the entire signing session multiple times is very bloated.

We might want to separate signing session mutations into: `Mutation::SigningSession`, `Mutation::SignatureShare`, `Mutation::FinishedSession` (complete or cancelled).

## Signing Order
Due to our nonce-counter design, if there are multiple sessions for a key then they must be acted upon in order **by each device**.

I think this means that "Continue Signing" is linked to a particular device, not the relevant key. "Continue signing" button could presents a series of "Sign or cancel" tasks.

Device X can't continue signing on Key B before it has dealt with Key A.
But maybe Device Y only cares about continue signing on Key A.

Users will want multiple parallel signing sessions because of geographic separation of devices.

Later, we will want bitcoin double spend logic that cancels/skips earlier signing sessions in favor of more recent ones.

## Signing Session ID?

If we split up our SigningSession mutations, then this could necessitate a `SigningSessionID` - if so, how should it be constructed? Needs to be unique for at minimum each challenge and participants. If the same quorum wants to sign the same thing again then the coordinator will choose different nonces, resulting in a different challenge and `SigningSessionID`.