### PR TITLE
Nonce streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -1407,6 +1408,7 @@ dependencies = [
  "bitcoin",
  "chacha20",
  "chacha20poly1305",
+ "cipher",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -2583,7 +2585,7 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 [[package]]
 name = "schnorr_fun"
 version = "0.10.0"
-source = "git+https://github.com/LLFourn/secp256kfun.git?rev=8132fbe806d9f306a9fb646f2147e5971bfea88d#8132fbe806d9f306a9fb646f2147e5971bfea88d"
+source = "git+https://github.com/LLFourn/secp256kfun.git?rev=35b5c12fd6ca730dfe74b95255a64997e26a369b#35b5c12fd6ca730dfe74b95255a64997e26a369b"
 dependencies = [
  "bech32",
  "secp256kfun",
@@ -2627,6 +2629,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "secp256k1-sys 0.10.0",
+ "serde",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "secp256kfun"
 version = "0.10.0"
-source = "git+https://github.com/LLFourn/secp256kfun.git?rev=8132fbe806d9f306a9fb646f2147e5971bfea88d#8132fbe806d9f306a9fb646f2147e5971bfea88d"
+source = "git+https://github.com/LLFourn/secp256kfun.git?rev=35b5c12fd6ca730dfe74b95255a64997e26a369b#35b5c12fd6ca730dfe74b95255a64997e26a369b"
 dependencies = [
  "bincode",
  "digest",
@@ -2664,6 +2676,7 @@ dependencies = [
  "secp256k1 0.27.0",
  "secp256k1 0.28.2",
  "secp256k1 0.29.0",
+ "secp256k1 0.30.0",
  "secp256kfun_arithmetic_macros",
  "serde",
  "subtle-ng",
@@ -2672,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "secp256kfun_arithmetic_macros"
 version = "0.1.0"
-source = "git+https://github.com/LLFourn/secp256kfun.git?rev=8132fbe806d9f306a9fb646f2147e5971bfea88d#8132fbe806d9f306a9fb646f2147e5971bfea88d"
+source = "git+https://github.com/LLFourn/secp256kfun.git?rev=35b5c12fd6ca730dfe74b95255a64997e26a369b#35b5c12fd6ca730dfe74b95255a64997e26a369b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rand_core = "0.6"
 futures = "0.3.31"
 
 [patch.crates-io]
-schnorr_fun = { git = "https://github.com/LLFourn/secp256kfun.git", rev = "8132fbe806d9f306a9fb646f2147e5971bfea88d" }
+schnorr_fun = { git = "https://github.com/LLFourn/secp256kfun.git", rev = "35b5c12fd6ca730dfe74b95255a64997e26a369b" }
 
 [profile.dev]
 # Rust debug is too slow.

--- a/device/src/flash_nonce_slot.rs
+++ b/device/src/flash_nonce_slot.rs
@@ -1,0 +1,131 @@
+use crate::storage::APP_STORAGE_END;
+use alloc::{rc::Rc, vec::Vec};
+use core::cell::RefCell;
+use embedded_storage::{ReadStorage, Storage};
+use esp_storage::FlashStorage;
+use frostsnap_core::device_nonces::*;
+
+pub const FLASH_NONCE_SLOTS: usize = 16;
+const SECTOR_SIZE: usize = 4096;
+pub const FLASH_NONCE_SLOTS_SIZE: u32 = FLASH_NONCE_SLOTS as u32 * SECTOR_SIZE as u32 * 2;
+const NONCE_FLASH_BINCODE_CONFIG: bincode::config::Configuration<
+    bincode::config::LittleEndian,
+    bincode::config::Fixint,
+    bincode::config::NoLimit,
+> = bincode::config::standard().with_fixed_int_encoding();
+
+#[derive(Debug)]
+pub struct FlashNonceSlot {
+    flash: Rc<RefCell<FlashStorage>>,
+    offset: u32,
+    /// A single write buf shared by all slots
+    write_buf: Rc<RefCell<Vec<u8>>>,
+}
+
+impl NonceStreamSlot for FlashNonceSlot {
+    fn read_index(&mut self) -> Option<u32> {
+        let index = bincode::decode_from_reader::<u32, _, _>(
+            BincodeFlashReader {
+                flash: &mut self.flash.borrow_mut(),
+                pos: self.offset,
+            },
+            NONCE_FLASH_BINCODE_CONFIG,
+        )
+        .expect("should always be able to read an int");
+
+        if index == u32::MAX {
+            None
+        } else {
+            Some(index)
+        }
+    }
+
+    fn read_slot(&mut self) -> Option<SecretNonceSlot> {
+        let value = bincode::decode_from_reader::<SecretNonceSlot, _, _>(
+            BincodeFlashReader {
+                flash: &mut self.flash.borrow_mut(),
+                pos: self.offset,
+            },
+            NONCE_FLASH_BINCODE_CONFIG,
+        )
+        .ok()?;
+
+        if value.index == u32::MAX {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
+    fn write_slot(&mut self, value: &SecretNonceSlot) {
+        let mut write_buf = self.write_buf.borrow_mut();
+        write_buf.clear();
+        bincode::encode_into_writer(value, BufWriter(&mut write_buf), NONCE_FLASH_BINCODE_CONFIG)
+            .expect("will encode");
+        assert!(write_buf.len() <= SECTOR_SIZE);
+        assert!(value.index < u32::MAX, "u32::MAX is reserved to mean empty");
+        self.flash
+            .borrow_mut()
+            .write(self.offset, &write_buf[..])
+            .expect("must not fail to write");
+
+        drop(write_buf);
+
+        // slightly paranoid but we really gotta make sure the write happened
+        assert_eq!(
+            self.read_slot().as_ref(),
+            Some(value),
+            "flash failed to write correctly"
+        );
+    }
+}
+
+pub fn flash_nonce_slots(flash: Rc<RefCell<FlashStorage>>) -> ABSlots<FlashNonceSlot> {
+    let mut slots = vec![];
+    let write_buf = Rc::new(RefCell::new(vec![]));
+    let mut curr = APP_STORAGE_END;
+    for _ in 0..FLASH_NONCE_SLOTS {
+        let offset1 = curr;
+        curr += SECTOR_SIZE as u32;
+        let offset2 = curr;
+        curr += SECTOR_SIZE as u32;
+        slots.push(ABSlot::new(
+            FlashNonceSlot {
+                flash: flash.clone(),
+                offset: offset1,
+                write_buf: write_buf.clone(),
+            },
+            FlashNonceSlot {
+                flash: flash.clone(),
+                offset: offset2,
+                write_buf: write_buf.clone(),
+            },
+        ));
+    }
+
+    ABSlots::new(slots)
+}
+
+struct BufWriter<'a>(&'a mut Vec<u8>);
+
+impl bincode::enc::write::Writer for BufWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), bincode::error::EncodeError> {
+        self.0.extend(bytes);
+        Ok(())
+    }
+}
+
+struct BincodeFlashReader<'a> {
+    flash: &'a mut FlashStorage,
+    pos: u32,
+}
+
+impl bincode::de::read::Reader for BincodeFlashReader<'_> {
+    fn read(&mut self, bytes: &mut [u8]) -> Result<(), bincode::error::DecodeError> {
+        self.flash.read(self.pos, bytes).map_err(|e| {
+            bincode::error::DecodeError::OtherString(format!("Flash read error {:?}", e))
+        })?;
+        self.pos += bytes.len() as u32;
+        Ok(())
+    }
+}

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -13,6 +13,7 @@ extern crate alloc;
 pub mod device_config;
 pub mod efuse;
 pub mod esp32_run;
+mod flash_nonce_slot;
 #[cfg(feature = "v2")]
 pub mod graphics;
 pub mod io;

--- a/frostsnap_coordinator/src/check_share.rs
+++ b/frostsnap_coordinator/src/check_share.rs
@@ -7,7 +7,7 @@ use frostsnap_core::{
 };
 use tracing::{event, Level};
 
-use crate::{Completion, Sink, UiProtocol, UiToStorageMessage};
+use crate::{Completion, Sink, UiProtocol};
 
 pub struct CheckShareProtocol {
     state: CheckShareState,
@@ -114,8 +114,8 @@ impl UiProtocol for CheckShareProtocol {
         }
     }
 
-    fn poll(&mut self) -> (Vec<CoordinatorSendMessage>, Vec<UiToStorageMessage>) {
-        (core::mem::take(&mut self.check_share_messages), vec![])
+    fn poll(&mut self) -> Vec<CoordinatorSendMessage> {
+        core::mem::take(&mut self.check_share_messages)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/frostsnap_coordinator/src/display_backup.rs
+++ b/frostsnap_coordinator/src/display_backup.rs
@@ -4,7 +4,7 @@ use frostsnap_core::{
     SymmetricKey,
 };
 
-use crate::{Completion, Sink, UiProtocol, UiToStorageMessage};
+use crate::{Completion, Sink, UiProtocol};
 
 pub struct DisplayBackupProtocol {
     device_id: DeviceId,
@@ -82,8 +82,8 @@ impl UiProtocol for DisplayBackupProtocol {
         }
     }
 
-    fn poll(&mut self) -> (Vec<CoordinatorSendMessage>, Vec<UiToStorageMessage>) {
-        (core::mem::take(&mut self.messages), vec![])
+    fn poll(&mut self) -> Vec<CoordinatorSendMessage> {
+        core::mem::take(&mut self.messages)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/frostsnap_coordinator/src/firmware_upgrade.rs
+++ b/frostsnap_coordinator/src/firmware_upgrade.rs
@@ -1,4 +1,4 @@
-use crate::{Completion, FirmwareBin, Sink, UiProtocol, UiToStorageMessage};
+use crate::{Completion, FirmwareBin, Sink, UiProtocol};
 use frostsnap_comms::{CoordinatorSendBody, CoordinatorSendMessage, CoordinatorUpgradeMessage};
 use frostsnap_core::DeviceId;
 use std::collections::BTreeSet;
@@ -71,7 +71,7 @@ impl UiProtocol for FirmwareUpgradeProtocol {
         }
     }
 
-    fn poll(&mut self) -> (Vec<CoordinatorSendMessage>, Vec<UiToStorageMessage>) {
+    fn poll(&mut self) -> Vec<CoordinatorSendMessage> {
         let mut to_devices = vec![];
         if !self.sent_first_message {
             to_devices.push(CoordinatorSendMessage {
@@ -93,7 +93,7 @@ impl UiProtocol for FirmwareUpgradeProtocol {
             self.emit_state()
         }
 
-        (to_devices, vec![])
+        to_devices
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/frostsnap_coordinator/src/frostsnap_persist.rs
+++ b/frostsnap_coordinator/src/frostsnap_persist.rs
@@ -1,7 +1,7 @@
 use crate::{
     frostsnap_core::{
         self,
-        coordinator::{FrostCoordinator, SigningSessionState},
+        coordinator::{ActiveSignSession, FrostCoordinator},
     },
     persist::{BincodeWrapper, Persist, TakeStaged},
 };
@@ -88,7 +88,7 @@ impl TakeStaged<VecDeque<coordinator::Mutation>> for FrostCoordinator {
     }
 }
 
-impl Persist<rusqlite::Connection> for Option<SigningSessionState> {
+impl Persist<rusqlite::Connection> for Option<ActiveSignSession> {
     type Update = Self;
     type InitParams = ();
 
@@ -105,7 +105,7 @@ impl Persist<rusqlite::Connection> for Option<SigningSessionState> {
 
         let signing_session_state =
             conn.query_row("SELECT state FROM fs_signing_session_state", [], |row| {
-                Ok(row.get::<_, BincodeWrapper<SigningSessionState>>(0)?.0)
+                Ok(row.get::<_, BincodeWrapper<ActiveSignSession>>(0)?.0)
             });
 
         let state = match signing_session_state {
@@ -133,8 +133,8 @@ impl Persist<rusqlite::Connection> for Option<SigningSessionState> {
     }
 }
 
-impl TakeStaged<Option<SigningSessionState>> for Option<SigningSessionState> {
-    fn take_staged_update(&mut self) -> Option<Option<SigningSessionState>> {
+impl TakeStaged<Option<ActiveSignSession>> for Option<ActiveSignSession> {
+    fn take_staged_update(&mut self) -> Option<Option<ActiveSignSession>> {
         Some(self.clone())
     }
 }

--- a/frostsnap_coordinator/src/keygen.rs
+++ b/frostsnap_coordinator/src/keygen.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use crate::{Completion, Sink, UiProtocol, UiToStorageMessage};
+use crate::{Completion, Sink, UiProtocol};
 use frostsnap_comms::CoordinatorSendMessage;
 use frostsnap_core::{
     coordinator::FrostCoordinator,
@@ -109,12 +109,12 @@ impl UiProtocol for KeyGen {
         }
     }
 
-    fn poll(&mut self) -> (Vec<CoordinatorSendMessage>, Vec<UiToStorageMessage>) {
+    fn poll(&mut self) -> Vec<CoordinatorSendMessage> {
         if self.is_complete().is_some() {
-            return (vec![], vec![]);
+            return vec![];
         }
 
-        (core::mem::take(&mut self.keygen_messages), vec![])
+        core::mem::take(&mut self.keygen_messages)
     }
 
     fn connected(&mut self, _id: frostsnap_core::DeviceId) {

--- a/frostsnap_coordinator/src/lib.rs
+++ b/frostsnap_coordinator/src/lib.rs
@@ -20,7 +20,7 @@ pub use bdk_chain;
 pub mod frostsnap_persist;
 pub mod persist;
 
-pub trait Sink<M>: Send {
+pub trait Sink<M>: Send + 'static {
     fn send(&self, state: M);
     fn close(&self);
 }

--- a/frostsnap_coordinator/src/ui_protocol.rs
+++ b/frostsnap_coordinator/src/ui_protocol.rs
@@ -25,7 +25,7 @@ pub trait UiProtocol: Send + Any + 'static {
     /// connected. The UI protocol is currently the point that manages the effect of device
     /// connections and disconnections on the protocol so it is able to violate boundries here a bit
     /// and send out core messages.
-    fn poll(&mut self) -> (Vec<CoordinatorSendMessage>, Vec<UiToStorageMessage>);
+    fn poll(&mut self) -> Vec<CoordinatorSendMessage>;
 
     fn as_any(&self) -> &dyn Any;
     fn as_mut_any(&mut self) -> &mut dyn Any;
@@ -35,11 +35,4 @@ pub trait UiProtocol: Send + Any + 'static {
 pub enum Completion {
     Success,
     Abort { send_cancel_to_all_devices: bool },
-}
-
-#[derive(Clone, Debug)]
-pub enum UiToStorageMessage {
-    /// Clear the signing session. Note that the signing session is stored by core but the
-    /// application is left to decide when to clear it.
-    ClearSigningSession,
 }

--- a/frostsnap_coordinator/src/verify_address.rs
+++ b/frostsnap_coordinator/src/verify_address.rs
@@ -6,7 +6,7 @@ use frostsnap_core::{
 };
 use tracing::{event, Level};
 
-use crate::{Completion, Sink, UiProtocol, UiToStorageMessage};
+use crate::{Completion, Sink, UiProtocol};
 
 #[derive(Clone, Debug, Default)]
 pub struct VerifyAddressProtocolState {
@@ -79,7 +79,7 @@ impl UiProtocol for VerifyAddressProtocol {
         );
     }
 
-    fn poll(&mut self) -> (Vec<CoordinatorSendMessage>, Vec<UiToStorageMessage>) {
+    fn poll(&mut self) -> Vec<CoordinatorSendMessage> {
         let mut messages = vec![];
         if !self.need_to_send_to.is_empty() {
             messages.push(CoordinatorSendMessage {
@@ -95,7 +95,7 @@ impl UiProtocol for VerifyAddressProtocol {
             });
         }
 
-        (messages, vec![])
+        messages
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/frostsnap_core/Cargo.toml
+++ b/frostsnap_core/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2021"
 
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
-schnorr_fun = {version = "0.10", features = ["bincode", "serde","alloc", "share_backup", "libsecp_compat"], default-features = false}
+schnorr_fun = {version = "0.10", features = ["bincode", "serde","alloc", "share_backup", "libsecp_compat_0_29"], default-features = false}
 rand_chacha = { workspace = true }
 sha2.workspace = true
 chacha20 = { version = "0.9", default-features = false }
+cipher = { version = "0.4", features = [ "rand_core" ], default-features = false }
 chacha20poly1305 = { version = "0.10", default-features = false }
 serde = { workspace = true }
 bitcoin = { workspace = true }

--- a/frostsnap_core/src/coord_nonces.rs
+++ b/frostsnap_core/src/coord_nonces.rs
@@ -1,0 +1,169 @@
+use crate::{nonce_stream::*, DeviceId};
+use alloc::collections::*;
+
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct NonceCache {
+    by_device: BTreeMap<DeviceId, BTreeMap<NonceStreamId, NonceStreamSegment>>,
+}
+
+impl NonceCache {
+    pub fn extend_segment(
+        &mut self,
+        device_id: DeviceId,
+        new_segment: NonceStreamSegment,
+    ) -> Result<bool, NonceSegmentIncompatible> {
+        let nonce_segments = self.by_device.entry(device_id).or_default();
+
+        let segment = nonce_segments
+            .entry(new_segment.stream_id)
+            .or_insert(NonceStreamSegment {
+                stream_id: new_segment.stream_id,
+                nonces: Default::default(),
+                index: 0,
+            });
+
+        segment.extend(new_segment)
+    }
+
+    pub fn check_can_extend(
+        &self,
+        device_id: DeviceId,
+        new_segment: &NonceStreamSegment,
+    ) -> Result<(), NonceSegmentIncompatible> {
+        match self.by_device.get(&device_id) {
+            Some(device_segments) => match device_segments.get(&new_segment.stream_id) {
+                Some(segment) => segment.check_can_extend(new_segment),
+                None => Ok(()),
+            },
+            None => Ok(()),
+        }
+    }
+
+    pub fn new_signing_session(
+        &mut self,
+        devices: &BTreeSet<DeviceId>,
+        n_nonces: usize,
+        used_streams: &BTreeSet<NonceStreamId>,
+    ) -> Result<BTreeMap<DeviceId, SigningReqSubSegment>, NotEnoughNonces> {
+        let mut nonces_chosen: BTreeMap<DeviceId, SigningReqSubSegment> = BTreeMap::default();
+
+        for &device in devices {
+            let by_device = self.by_device.entry(device).or_default();
+            let mut nonces_available = 0;
+            for (stream_id, stream_segment) in by_device {
+                if used_streams.contains(stream_id) {
+                    continue;
+                }
+                if stream_segment.index_after_last().is_none() {
+                    continue;
+                }
+                if let Some(sub_segment) = stream_segment.signing_req_sub_segment(n_nonces) {
+                    nonces_chosen.insert(device, sub_segment);
+                    break;
+                } else {
+                    nonces_available = nonces_available.max(stream_segment.nonces.len());
+                }
+            }
+
+            if !nonces_chosen.contains_key(&device) {
+                return Err(NotEnoughNonces {
+                    device_id: device,
+                    available: nonces_available,
+                    need: n_nonces,
+                });
+            }
+        }
+
+        Ok(nonces_chosen)
+    }
+
+    pub fn consume(
+        &mut self,
+        device_id: DeviceId,
+        stream_id: NonceStreamId,
+        up_to_but_not_including: u32,
+    ) -> bool {
+        if let Some(device_streams) = self.by_device.get_mut(&device_id) {
+            if let Some(local_segment) = device_streams.get_mut(&stream_id) {
+                assert!(
+                    local_segment.index <= up_to_but_not_including,
+                    "tried to consume no nonces since counter {} was greater than consumption point {}",
+                    local_segment.index,
+                    up_to_but_not_including
+                );
+
+                return local_segment.delete_up_to(up_to_but_not_including);
+            }
+        }
+        false
+    }
+
+    pub fn nonces_available(
+        &self,
+        device_id: DeviceId,
+        used_streams: &BTreeSet<NonceStreamId>,
+    ) -> BTreeMap<NonceStreamId, u32> {
+        let mut available = BTreeMap::default();
+        if let Some(streams) = self.by_device.get(&device_id) {
+            for (stream_id, stream) in streams {
+                if used_streams.contains(stream_id) {
+                    continue;
+                }
+                if !stream.nonces.is_empty() {
+                    available.insert(*stream_id, stream.nonces.len() as u32);
+                }
+            }
+        }
+
+        available
+    }
+
+    pub fn generate_nonce_stream_opening_requests(
+        &self,
+        device_id: DeviceId,
+        min_streams: usize,
+        rng: &mut impl rand_core::RngCore,
+    ) -> impl IntoIterator<Item = CoordNonceStreamState> {
+        let mut stream_ids = vec![];
+        let streams = self.by_device.get(&device_id).cloned().unwrap_or_default();
+        let new_streams_needed = min_streams.saturating_sub(streams.len());
+        for _ in 0..new_streams_needed {
+            stream_ids.push(CoordNonceStreamState {
+                stream_id: NonceStreamId::random(rng),
+                index: 0,
+                remaining: 0,
+            });
+        }
+
+        for (stream_id, stream) in streams {
+            stream_ids.push(CoordNonceStreamState {
+                stream_id,
+                index: stream.index,
+                remaining: stream.nonces.len().try_into().unwrap(),
+            })
+        }
+
+        stream_ids
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NotEnoughNonces {
+    device_id: DeviceId,
+    available: usize,
+    need: usize,
+}
+
+impl core::fmt::Display for NotEnoughNonces {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let NotEnoughNonces {
+            device_id,
+            available,
+            need,
+        } = self;
+        write!(f, "coordinator doesn't have enough nonces for {device_id}. It only has {available} but needs {need}")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NotEnoughNonces {}

--- a/frostsnap_core/src/device_nonces.rs
+++ b/frostsnap_core/src/device_nonces.rs
@@ -1,0 +1,379 @@
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+use chacha20::{
+    cipher::{KeyIvInit, StreamCipher},
+    ChaCha20,
+};
+use rand_core::RngCore;
+use schnorr_fun::{
+    binonce,
+    frost::{NonceKeyPair, PairedSecretShare, PartySignSession, SignatureShare},
+    fun::prelude::*,
+};
+
+use crate::{
+    nonce_stream::{CoordNonceStreamState, NonceStreamId, NonceStreamSegment},
+    SignSessionId, NONCE_BATCH_SIZE,
+};
+
+type ChaChaSeed = [u8; 32];
+
+#[derive(Clone, Debug, PartialEq, bincode::Encode, bincode::Decode)]
+pub struct SecretNonceSlot {
+    //XXX: index must be first so we can decode it easily without decoding the whole thing
+    //XXX: index == u32::MAX is invalid because we use it to represent "uninitialized"
+    pub index: u32,
+    pub nonce_stream_id: NonceStreamId,
+    pub ratchet_prg_seed: ChaChaSeed,
+    pub signing_state: Option<SigningState>,
+}
+
+#[derive(Clone, Debug, PartialEq, bincode::Encode, bincode::Decode)]
+pub struct SigningState {
+    pub session_id: SignSessionId,
+    pub signature_shares: Vec<SignatureShare>,
+}
+
+pub trait NonceStreamSlot {
+    fn read_index(&mut self) -> Option<u32>;
+    fn read_slot(&mut self) -> Option<SecretNonceSlot>;
+    fn write_slot(&mut self, value: &SecretNonceSlot);
+}
+
+/// Manages two writable sectors of persistent storage such that we make sure the state of the system we're managing is never lost.
+/// The new state is first written, if that succeeds we finally write over the previous state.
+/// In this case we're managing the secret seed needed to produce nonces for signatures.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ABSlot<S> {
+    slots: [S; 2],
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ABSlots<S> {
+    slots: Vec<ABSlot<S>>,
+}
+
+impl<S: NonceStreamSlot> ABSlots<S> {
+    pub fn new(ab_slots: impl IntoIterator<Item = ABSlot<S>>) -> Self {
+        Self {
+            slots: ab_slots.into_iter().collect(),
+        }
+    }
+
+    pub fn get_or_create(
+        &mut self,
+        stream_id: NonceStreamId,
+        rng: &mut impl RngCore,
+    ) -> &mut ABSlot<S> {
+        let mut i = 0;
+        let found = loop {
+            let ab_slot = &mut self.slots[i];
+            match ab_slot.nonce_stream_id() {
+                Some(slot_nsid) => {
+                    if slot_nsid == stream_id {
+                        break Some(i);
+                    }
+                }
+                None => {
+                    ab_slot.initialize(stream_id, rng);
+                    break Some(i);
+                }
+            }
+            i += 1;
+            if i >= self.slots.len() {
+                break None;
+            }
+        };
+
+        match found {
+            Some(i) => &mut self.slots[i],
+            None => {
+                let random_overwrite_idx = rng.next_u32() as usize % self.slots.len();
+                let ab_slot = &mut self.slots[random_overwrite_idx];
+                ab_slot.initialize(stream_id, rng);
+                ab_slot
+            }
+        }
+    }
+
+    pub fn get(&mut self, stream_id: NonceStreamId) -> Option<&mut ABSlot<S>> {
+        //XXX: clippy is wrong about this
+        #[allow(clippy::manual_find)]
+        for slot in &mut self.slots {
+            if slot.nonce_stream_id() == Some(stream_id) {
+                return Some(slot);
+            }
+        }
+        None
+    }
+
+    pub fn all_stream_ids(&mut self) -> impl Iterator<Item = NonceStreamId> + '_ {
+        self.slots
+            .iter_mut()
+            .filter_map(|slot| slot.nonce_stream_id())
+    }
+}
+
+impl<S: NonceStreamSlot> ABSlot<S> {
+    pub fn new(a: S, b: S) -> Self {
+        Self { slots: [a, b] }
+    }
+
+    pub fn initialize(&mut self, stream_id: NonceStreamId, rng: &mut impl RngCore) {
+        let mut ratchet_prg_seed = ChaChaSeed::default();
+        rng.fill_bytes(&mut ratchet_prg_seed[..]);
+        let value = SecretNonceSlot {
+            index: 0,
+            nonce_stream_id: stream_id,
+            ratchet_prg_seed,
+            signing_state: None,
+        };
+        for slot in &mut self.slots {
+            slot.write_slot(&value);
+        }
+    }
+
+    fn iter_pub_nonces(&mut self) -> impl Iterator<Item = (u32, binonce::Nonce)> {
+        let current_slot = &mut self.slots[self.current_slot()];
+        let slot_value = current_slot
+            .read_slot()
+            .expect("can't iter nonces of unintialized nonce slot");
+        slot_value
+            .iter_secret_nonces()
+            .map(|(index, secret_nonce, _)| {
+                (index, NonceKeyPair::from_secret(secret_nonce).public())
+            })
+    }
+
+    pub fn reconcile_coord_nonce_stream_state(
+        &mut self,
+        state: CoordNonceStreamState,
+    ) -> Option<NonceStreamSegment> {
+        let our_index = self.current_index();
+        if our_index > state.index || state.remaining < NONCE_BATCH_SIZE {
+            Some(self.nonce_segment(None, NONCE_BATCH_SIZE as usize))
+        } else if our_index == state.index {
+            None
+        } else {
+            Some(self.nonce_segment(None, (state.index - our_index) as usize))
+        }
+    }
+
+    pub fn nonce_segment(&mut self, start: Option<u32>, length: usize) -> NonceStreamSegment {
+        let current_slot = &mut self.slots[self.current_slot()];
+        let slot_value = current_slot
+            .read_slot()
+            .expect("can't iter nonces of unintialized nonce slot");
+        let start = start.unwrap_or(slot_value.index);
+
+        if start < slot_value.index {
+            panic!("can't iterate erased nonces");
+        }
+        let last = start.saturating_add(length.try_into().expect("length not too big"));
+
+        if last == u32::MAX {
+            panic!("cannot have an index at u32::MAX");
+        }
+
+        let nonces = self
+            .iter_pub_nonces()
+            .skip((start - slot_value.index) as _)
+            .map(|(_, nonce)| nonce)
+            .take(length)
+            .collect::<VecDeque<_>>();
+
+        assert_eq!(nonces.len(), length, "there weren't enough noces for that");
+
+        NonceStreamSegment {
+            stream_id: slot_value.nonce_stream_id,
+            index: start,
+            nonces,
+        }
+    }
+
+    pub fn are_nonces_available(&mut self, index: u32, n: u32) -> Result<(), NoncesUnavaillable> {
+        let current_slot_value = self.slots[self.current_slot()]
+            .read_slot()
+            .expect("signing on a nonce stream that hasn't been initialized");
+
+        let current = current_slot_value.index;
+        let requested = index;
+
+        if requested < current {
+            return Err(NoncesUnavaillable::IndexUsed { current, requested });
+        }
+
+        if index.saturating_add(n) == u32::MAX {
+            return Err(NoncesUnavaillable::Overflow);
+        }
+
+        Ok(())
+    }
+
+    pub fn sign_guaranteeing_nonces_destroyed(
+        &mut self,
+        session_id: SignSessionId,
+        coord_nonce_state: CoordNonceStreamState,
+        sessions: impl IntoIterator<Item = (PairedSecretShare<EvenY>, PartySignSession)>,
+    ) -> (Vec<SignatureShare>, Option<NonceStreamSegment>) {
+        let current_slot = self.current_slot();
+        let current_slot_value = self.slots[current_slot]
+            .read_slot()
+            .expect("signing on a nonce stream that hasn't been initialized");
+
+        if coord_nonce_state.index < current_slot_value.index {
+            panic!("trying to sign with old nonce");
+        }
+
+        let (slot_with_sigs, slot_value) = match &current_slot_value.signing_state {
+            Some(last_session) if last_session.session_id == session_id => {
+                (current_slot, current_slot_value)
+            }
+            _ => {
+                let next_slot = (current_slot + 1) % 2;
+                let mut nonce_iter = current_slot_value
+                    .iter_secret_nonces()
+                    .skip((coord_nonce_state.index - current_slot_value.index) as usize);
+
+                let mut signature_shares = vec![];
+                let mut next_prg_state: Option<(u32, ChaChaSeed)> = None;
+
+                for (secret_share, session) in sessions.into_iter() {
+                    let (current_index, secret_nonce, next_seed) = nonce_iter
+                        .next()
+                        .expect("tried to sign with nonces out of range");
+                    let next_index = current_index + 1;
+                    next_prg_state = Some((next_index, next_seed));
+                    let signature_share = session.sign(&secret_share, secret_nonce);
+                    // TODO: verify the signature share as a sanity check
+                    signature_shares.push(signature_share);
+                }
+
+                if signature_shares.is_empty() {
+                    panic!("sign sessions must not be empty");
+                }
+
+                let (next_index, next_prg_seed) = next_prg_state.unwrap();
+
+                let next_slot_value = SecretNonceSlot {
+                    nonce_stream_id: current_slot_value.nonce_stream_id,
+                    index: next_index,
+                    ratchet_prg_seed: next_prg_seed,
+                    signing_state: Some(SigningState {
+                        session_id,
+                        signature_shares,
+                    }),
+                };
+
+                self.slots[next_slot].write_slot(&next_slot_value);
+                (next_slot, next_slot_value)
+            }
+        };
+
+        let other_slot = (slot_with_sigs + 1) % 2;
+        self.slots[other_slot].write_slot(&slot_value);
+        let signature_shares = slot_value
+            .signing_state
+            .expect("guaranteed")
+            .signature_shares;
+
+        let implied_coord_nonce_state = coord_nonce_state.after_signing(signature_shares.len());
+        let replenishment = self.reconcile_coord_nonce_stream_state(implied_coord_nonce_state);
+
+        (signature_shares, replenishment)
+    }
+
+    fn current_slot(&mut self) -> usize {
+        if self.slots[1].read_index() > self.slots[0].read_index() {
+            1
+        } else {
+            0
+        }
+    }
+
+    pub fn current_index(&mut self) -> u32 {
+        self.slots[0]
+            .read_index()
+            .max(self.slots[1].read_index())
+            .unwrap_or(0)
+    }
+
+    pub fn nonce_stream_id(&mut self) -> Option<NonceStreamId> {
+        self.slots[self.current_slot()]
+            .read_slot()
+            .map(|value| value.nonce_stream_id)
+    }
+}
+
+impl SecretNonceSlot {
+    fn iter_secret_nonces(&self) -> impl Iterator<Item = (u32, binonce::SecretNonce, ChaChaSeed)> {
+        let mut prg_seed = self.ratchet_prg_seed;
+        let mut index = self.index;
+
+        core::iter::from_fn(move || {
+            if index == u32::MAX {
+                return None;
+            }
+            let mut chacha_nonce = [0u8; 12];
+            let current_index = index;
+            chacha_nonce[0..core::mem::size_of_val(&current_index)]
+                .copy_from_slice(current_index.to_le_bytes().as_ref());
+            let mut chacha = ChaCha20::new(&prg_seed.into(), &chacha_nonce.into());
+            let mut next_seed = [0u8; 32];
+            chacha.apply_keystream(&mut next_seed);
+            let mut secret_nonce_bytes = [0u8; 64];
+            chacha.apply_keystream(&mut secret_nonce_bytes);
+            let secret_nonce = binonce::SecretNonce::from_bytes(secret_nonce_bytes)
+                .expect("computationally unreachable");
+
+            prg_seed = next_seed;
+            index += 1;
+
+            Some((current_index, secret_nonce, next_seed))
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct MemoryNonceSlot {
+    inner: Option<SecretNonceSlot>,
+}
+
+impl NonceStreamSlot for MemoryNonceSlot {
+    fn read_index(&mut self) -> Option<u32> {
+        self.inner.as_ref().map(|slot| slot.index)
+    }
+
+    fn read_slot(&mut self) -> Option<SecretNonceSlot> {
+        self.inner.clone()
+    }
+
+    fn write_slot(&mut self, value: &SecretNonceSlot) {
+        self.inner = Some(value.clone())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum NoncesUnavaillable {
+    IndexUsed { current: u32, requested: u32 },
+    Overflow,
+}
+
+impl core::fmt::Display for NoncesUnavaillable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            NoncesUnavaillable::IndexUsed { current, requested } => {
+                write!(
+                    f,
+                    "Attempt to reuse nonces! Current index: {current}. Requested: {requested}."
+                )
+            }
+            NoncesUnavaillable::Overflow => {
+                write!(f, "nonces were requested beyond the final index")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NoncesUnavaillable {}

--- a/frostsnap_core/src/nonce_stream.rs
+++ b/frostsnap_core/src/nonce_stream.rs
@@ -1,0 +1,195 @@
+use alloc::collections::VecDeque;
+use schnorr_fun::binonce;
+#[derive(Debug, Clone, PartialEq, bincode::Encode, bincode::Decode)]
+pub struct NonceStreamSegment {
+    pub stream_id: NonceStreamId,
+    pub nonces: VecDeque<binonce::Nonce>,
+    pub index: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, bincode::Encode, bincode::Decode)]
+pub struct SigningReqSubSegment {
+    pub segment: NonceStreamSegment,
+    pub remaining: u32,
+}
+
+impl SigningReqSubSegment {
+    pub fn coord_nonce_state(&self) -> CoordNonceStreamState {
+        CoordNonceStreamState {
+            stream_id: self.segment.stream_id,
+            index: self.segment.index,
+            remaining: self.remaining,
+        }
+    }
+}
+
+impl NonceStreamSegment {
+    /// When a coordinator needs to make a signing request you take a prefix of nonces from the
+    /// segment. You also need to know the "remaining" nonces in the segment so you can tell the
+    /// device about it so it replenishes at the right point.j
+    pub fn signing_req_sub_segment(&self, length: usize) -> Option<SigningReqSubSegment> {
+        let remaining = self.nonces.len().checked_sub(length)?.try_into().ok()?;
+
+        let segment = Self {
+            stream_id: self.stream_id,
+            nonces: self.nonces.iter().cloned().take(length).collect(),
+            index: self.index,
+        };
+
+        Some(SigningReqSubSegment { remaining, segment })
+    }
+
+    pub fn index_after_last(&self) -> Option<u32> {
+        self.index.checked_add(self.nonces.len().try_into().ok()?)
+    }
+
+    pub fn delete_up_to(&mut self, up_to_but_not_including: u32) -> bool {
+        let mut changed = false;
+        let to_delete = up_to_but_not_including.saturating_sub(self.index);
+        debug_assert!(to_delete as usize <= self.nonces.len());
+        debug_assert!((to_delete as usize + self.index as usize) < u32::MAX as usize);
+        for _ in 0..to_delete {
+            self.nonces.pop_front();
+            self.index += 1;
+            changed = true;
+        }
+        changed
+    }
+
+    fn _extend(
+        &self,
+        other: NonceStreamSegment,
+    ) -> Result<NonceStreamSegment, NonceSegmentIncompatible> {
+        let mut curr = self.clone();
+        if self.stream_id != other.stream_id {
+            return Err(NonceSegmentIncompatible::StreamIdDontMatch);
+        }
+        other
+            .index_after_last()
+            .ok_or(NonceSegmentIncompatible::Overflows)?;
+
+        let connect = if other.index > curr.index {
+            curr.index + self.nonces.len() as u32 >= other.index
+        } else {
+            other.index + other.nonces.len() as u32 >= curr.index
+        };
+
+        if !connect || curr.nonces.is_empty() {
+            return Ok(if curr.nonces.len() > other.nonces.len() {
+                debug_assert!(false, "was unable to extend update");
+                curr
+            } else {
+                other
+            });
+        }
+
+        let new_start = self.index.min(other.index);
+        let mut curr_end = self.index_after_last().expect("invariant") - 1;
+        let other_end = other.index_after_last().unwrap() - 1;
+        let new_end = curr_end.max(other_end);
+
+        while curr.index > new_start {
+            curr.index -= 1;
+            let other_nonce = other.get_nonce(curr.index).expect("must exist");
+            curr.nonces.push_front(other_nonce);
+        }
+
+        while curr_end < new_end {
+            curr_end += 1;
+            let other_nonce = other.get_nonce(curr_end).expect("must exist");
+            curr.nonces.push_back(other_nonce);
+        }
+
+        assert_eq!(curr.index, new_start, "should start at the right place now");
+        assert_eq!(
+            curr.index_after_last().unwrap() - 1,
+            new_end,
+            "should end at the right place now"
+        );
+
+        Ok(curr)
+    }
+
+    pub fn extend(&mut self, other: NonceStreamSegment) -> Result<bool, NonceSegmentIncompatible> {
+        let new = self._extend(other)?;
+        if new != *self {
+            *self = new;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    pub fn check_can_extend(
+        &self,
+        other: &NonceStreamSegment,
+    ) -> Result<(), NonceSegmentIncompatible> {
+        self._extend(other.clone())?;
+        Ok(())
+    }
+
+    fn get_nonce(&self, index: u32) -> Option<binonce::Nonce> {
+        self.nonces
+            .get(index.checked_sub(self.index)? as usize)
+            .copied()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NonceSegmentIncompatible {
+    StreamIdDontMatch,
+    Overflows,
+}
+
+impl core::fmt::Display for NonceSegmentIncompatible {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use NonceSegmentIncompatible::*;
+        match self {
+            StreamIdDontMatch => write!(f, "stream ids for nonce segments didn't match"),
+            Overflows => write!(f, "the segment we are trying to connect overflows"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for NonceSegmentIncompatible {}
+
+/// A way to index nonces on a device.
+/// Each device can produce a sequence of random nonces for any requested stream id
+#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct NonceStreamId(pub [u8; 16]);
+
+impl NonceStreamId {
+    pub fn random(rng: &mut impl rand_core::RngCore) -> Self {
+        let mut bytes = [0u8; 16];
+        rng.fill_bytes(&mut bytes);
+        NonceStreamId(bytes)
+    }
+}
+
+crate::impl_display_debug_serialize! {
+    fn to_bytes(nonce_stream_id: &NonceStreamId) -> [u8;16] {
+        nonce_stream_id.0
+    }
+}
+
+crate::impl_fromstr_deserialize! {
+    name => "nonce stream id",
+    fn from_bytes(bytes: [u8;16]) -> NonceStreamId {
+        NonceStreamId(bytes)
+    }
+}
+
+#[derive(Debug, Clone, Copy, bincode::Encode, bincode::Decode, PartialEq)]
+pub struct CoordNonceStreamState {
+    pub stream_id: NonceStreamId,
+    pub index: u32,
+    pub remaining: u32,
+}
+
+impl CoordNonceStreamState {
+    pub fn after_signing(mut self, n_sigs: usize) -> Self {
+        self.index = self.index.checked_add(n_sigs as u32).unwrap();
+        self.remaining = self.remaining.checked_sub(n_sigs as u32).unwrap();
+        self
+    }
+}

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -18,8 +18,8 @@ pub enum SignTask {
 #[derive(Debug, Clone, PartialEq)]
 /// A sign task bound to a single key. We only support signing tasks with single keys for now.
 pub struct CheckedSignTask {
-    master_appkey: MasterAppkey,
-    sign_task: SignTask,
+    pub master_appkey: MasterAppkey,
+    pub sign_task: SignTask,
 }
 
 impl SignTask {

--- a/frostsnap_core/src/symmetric_encryption.rs
+++ b/frostsnap_core/src/symmetric_encryption.rs
@@ -59,5 +59,13 @@ impl<const N: usize, T: bincode::Encode + bincode::Decode> Ciphertext<N, T> {
     }
 }
 
+impl<const N: usize> Ciphertext<N, [u8; N]> {
+    pub fn random(encrption_key: SymmetricKey, rng: &mut impl rand_core::RngCore) -> Self {
+        let mut bytes = [0u8; N];
+        rng.fill_bytes(&mut bytes[..]);
+        Self::encrypt(encrption_key, &bytes, rng)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct SymmetricKey(pub [u8; 32]);

--- a/frostsnapp/lib/device_settings.dart
+++ b/frostsnapp/lib/device_settings.dart
@@ -220,7 +220,6 @@ class NonceCounterDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return KeyValueListWidget(data: {
-      'Current nonce': coord.currentNonce(id: id).toString(),
       'Nonces left': coord.noncesAvailable(id: id).toString(),
     });
   }


### PR DESCRIPTION
```
To allow multiple nonce lists between the same and different
coordinators.

1. Coordinators open nonce streams with a random 16 byte id. The device
then responds with nonces for the id.
2. The device and coordinator try and reconcile deviations in their
nonce set when the device is plugged in.
3. The device permanently deletes a nonce once it's use to create a
signature. This is guaranteed by the design as long as the
NonceStreamSlot trait is implemented to correctly erase the slot when
it's written.
```


TOOD: exfil protoection