### PR TITLE
Backup checklist

### DIFF
--- a/frostsnap_coordinator/src/backup_run.rs
+++ b/frostsnap_coordinator/src/backup_run.rs
@@ -1,0 +1,146 @@
+use crate::persist::Persist;
+use frostsnap_core::{DeviceId, KeyId};
+use rusqlite::params;
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, PartialEq, bincode::Encode, bincode::Decode, Default)]
+pub struct BackupRun {
+    pub devices: Vec<(DeviceId, Option<u32>)>,
+}
+
+impl BackupRun {
+    pub fn new(devices: Vec<DeviceId>) -> Self {
+        Self {
+            devices: devices.into_iter().map(|d| (d, None)).collect(),
+        }
+    }
+
+    pub fn mark_device_complete(&mut self, device_id: DeviceId) {
+        if let Some(entry) = self.devices.iter_mut().find(|(d, _)| *d == device_id) {
+            entry.1 = Some(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as u32,
+            );
+        }
+    }
+
+    pub fn is_run_complete(&self) -> bool {
+        self.devices
+            .iter()
+            .all(|(_, timestamp)| timestamp.is_some())
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct BackupState {
+    pub runs: BTreeMap<KeyId, BackupRun>,
+}
+
+#[derive(Debug, Clone)]
+pub enum BackupMutation {
+    StartBackup {
+        key_id: KeyId,
+        devices: Vec<DeviceId>,
+    },
+    MarkDeviceComplete {
+        key_id: KeyId,
+        device_id: DeviceId,
+        timestamp: u32,
+    },
+}
+
+impl Persist<rusqlite::Connection> for BackupState {
+    type Update = Vec<BackupMutation>;
+    type InitParams = ();
+
+    fn initialize(conn: &mut rusqlite::Connection, _: ()) -> anyhow::Result<Self> {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS backup_runs (
+                key_id TEXT NOT NULL,
+                device_id TEXT NOT NULL,
+                timestamp INTEGER,
+                PRIMARY KEY (key_id, device_id)
+            )",
+            [],
+        )?;
+
+        let mut stmt = conn.prepare(
+            "SELECT key_id, device_id, timestamp 
+             FROM backup_runs 
+             ORDER BY key_id",
+        )?;
+
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,      // key_id
+                row.get::<_, String>(1)?,      // device_id
+                row.get::<_, Option<u32>>(2)?, // timestamp
+            ))
+        })?;
+
+        // group by key_id and build BackupRun for each group
+        let runs = rows
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .fold(
+                BTreeMap::new(),
+                |mut map: BTreeMap<_, Vec<_>>, (key_id, device_id, timestamp)| {
+                    map.entry(key_id).or_default().push((device_id, timestamp));
+                    map
+                },
+            )
+            .into_iter()
+            .map(|(key_id, devices)| {
+                let devices = devices
+                    .into_iter()
+                    .map(|(device_id, timestamp)| Ok((device_id.parse()?, timestamp)))
+                    .collect::<Result<Vec<_>, anyhow::Error>>()?;
+
+                Ok((key_id.parse()?, BackupRun { devices }))
+            })
+            .collect::<Result<BTreeMap<_, _>, anyhow::Error>>()?;
+
+        Ok(BackupState { runs })
+    }
+
+    fn persist_update(
+        conn: &mut rusqlite::Connection,
+        update: Vec<BackupMutation>,
+    ) -> anyhow::Result<()> {
+        for mutation in update {
+            match mutation {
+                BackupMutation::StartBackup { key_id, devices } => {
+                    // Delete any previous backup run
+                    conn.execute(
+                        "DELETE FROM backup_runs WHERE key_id = ?1",
+                        params![key_id.to_string()],
+                    )?;
+
+                    for device_id in devices {
+                        conn.execute(
+                            "INSERT OR REPLACE INTO backup_runs (key_id, device_id, timestamp) 
+                             VALUES (?1, ?2, ?3)",
+                            params![key_id.to_string(), device_id.to_string(), None::<u32>],
+                        )?;
+                    }
+                }
+                BackupMutation::MarkDeviceComplete {
+                    key_id,
+                    device_id,
+                    timestamp,
+                } => {
+                    conn.execute(
+                        "INSERT OR REPLACE INTO backup_runs (key_id, device_id, timestamp) 
+                         VALUES (?1, ?2, ?3)",
+                        params![key_id.to_string(), device_id.to_string(), Some(timestamp)],
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/frostsnap_coordinator/src/check_share.rs
+++ b/frostsnap_coordinator/src/check_share.rs
@@ -67,7 +67,7 @@ impl CheckShareProtocol {
 
 impl UiProtocol for CheckShareProtocol {
     fn cancel(&mut self) {
-        self.abort("loading share cancelled".to_string())
+        self.abort("Loading share cancelled".to_string())
     }
 
     fn is_complete(&self) -> Option<Completion> {

--- a/frostsnap_coordinator/src/lib.rs
+++ b/frostsnap_coordinator/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backup_run;
 pub mod check_share;
 pub mod display_backup;
 pub mod firmware_upgrade;
@@ -12,6 +13,7 @@ pub use frostsnap_comms;
 pub use frostsnap_core;
 pub use serial_port::*;
 mod settings;
+pub use backup_run::*;
 pub use settings::*;
 pub use ui_protocol::*;
 pub use usb_serial_manager::*;

--- a/frostsnapp/lib/backup_workflow.dart
+++ b/frostsnapp/lib/backup_workflow.dart
@@ -1,0 +1,293 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:frostsnapp/contexts.dart';
+import 'package:frostsnapp/global.dart';
+import 'package:frostsnapp/id_ext.dart';
+import 'package:frostsnapp/settings.dart';
+import 'package:frostsnapp/show_backup.dart';
+import 'ffi.dart' if (dart.library.html) 'ffi_web.dart';
+
+class BackupChecklistPage extends StatelessWidget {
+  final AccessStructure accessStructure;
+  const BackupChecklistPage({super.key, required this.accessStructure});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final backgroundColor = ElevationOverlay.applySurfaceTint(
+      theme.colorScheme.surface,
+      theme.colorScheme.surfaceTint,
+      0,
+    );
+    return Scaffold(
+      backgroundColor: backgroundColor,
+      appBar: FsAppBar(title: const Text('Security Checklist')),
+      body: BackupChecklist(accessStructure: accessStructure),
+    );
+  }
+}
+
+class BackupChecklist extends StatelessWidget {
+  final AccessStructure accessStructure;
+  const BackupChecklist({super.key, required this.accessStructure});
+
+  Future<void> _handleBackupDevice(
+    BuildContext context,
+    DeviceId deviceId,
+  ) async {
+    final manager = FrostsnapContext.of(context)!.backupManager;
+    final keyId = accessStructure.accessStructureRef().keyId;
+    final completed = await backupDeviceDialog(
+      context,
+      deviceId: deviceId,
+      accessStructure: accessStructure,
+    );
+    if (completed) {
+      await manager.markBackupComplete(deviceId: deviceId, keyId: keyId);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final walletCtx = WalletContext.of(context)!;
+    final backupStream = walletCtx.backupStream;
+    final manager = FrostsnapContext.of(context)!.backupManager;
+
+    return StreamBuilder<BackupRun>(
+      stream: backupStream,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final backupRun = snapshot.data;
+        final allDevices = accessStructure.devices();
+        final completedDevices =
+            backupRun == null
+                ? <DeviceId>[]
+                : allDevices
+                    .where(
+                      (deviceId) => backupRun.devices.any(
+                        (d) => deviceIdEquals(d.$1, deviceId) && d.$2 != null,
+                      ),
+                    )
+                    .toList();
+
+        return ListView(
+          padding: const EdgeInsets.all(16.0),
+          children: [
+            Text(
+              'To secure this wallet, you will store your devices in several geographically separate locations.',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'At each location, you will create a backup to store alongside your device.',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Make sure to bring:',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final item in [
+                    'Your Frostsnap device',
+                    Platform.isAndroid
+                        ? 'This phone'
+                        : Platform.isIOS
+                        ? 'This phone'
+                        : 'This laptop',
+                    'A backup card',
+                    'A pencil',
+                  ]) ...[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8.0),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '–  ',
+                            style: theme.textTheme.bodyLarge?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                          Expanded(
+                            child: Text(
+                              item,
+                              style: theme.textTheme.bodyLarge?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Travel to separate locations to secure each device:',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 24),
+            // Device list with elevated cards
+            ...allDevices.map((deviceId) {
+              final deviceName = coord.getDeviceName(id: deviceId) ?? "";
+              final isCompleted = completedDevices.any(
+                (d) => deviceIdEquals(d, deviceId),
+              );
+
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 4.0),
+                child: Card(
+                  elevation: 2,
+                  color: theme.colorScheme.surfaceContainerHighest,
+                  child: ListTile(
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 16.0,
+                      vertical: 8.0,
+                    ),
+                    title: Text(
+                      deviceName,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (isCompleted)
+                          FilledButton(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  theme.colorScheme.surfaceContainerLow,
+                              foregroundColor:
+                                  theme.colorScheme.onSurfaceVariant,
+                            ),
+                            onPressed: () async {
+                              await verifyBackup(
+                                context,
+                                deviceId,
+                                accessStructure.accessStructureRef(),
+                              );
+                            },
+                            child: const Text('Check'),
+                          ),
+                        const SizedBox(width: 8),
+                        FilledButton(
+                          style:
+                              isCompleted
+                                  ? FilledButton.styleFrom(
+                                    backgroundColor:
+                                        theme.colorScheme.surfaceContainerLow,
+                                    foregroundColor:
+                                        theme.colorScheme.onSurfaceVariant,
+                                  )
+                                  : FilledButton.styleFrom(
+                                    backgroundColor: theme.colorScheme.primary,
+                                  ),
+                          onPressed: () async {
+                            final shouldWarn = manager.shouldQuickBackupWarn(
+                              keyId: walletCtx.wallet.keyId(),
+                              deviceId: deviceId,
+                            );
+                            if (shouldWarn) {
+                              final result = await showDialog<bool>(
+                                context: context,
+                                builder:
+                                    (BuildContext context) => AlertDialog(
+                                      title: Text('That was quick!'),
+                                      content: const Column(
+                                        mainAxisSize: MainAxisSize.min,
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            'A backup of a device was performed recently.',
+                                          ),
+                                          SizedBox(height: 12),
+                                          Text(
+                                            'Make sure your devices are secured in separate locations!',
+                                          ),
+                                        ],
+                                      ),
+                                      actions: [
+                                        FilledButton(
+                                          onPressed:
+                                              () => Navigator.of(
+                                                context,
+                                              ).pop(false),
+                                          child: Text('Back'),
+                                        ),
+                                        FilledButton(
+                                          onPressed:
+                                              () => Navigator.of(
+                                                context,
+                                              ).pop(true),
+                                          child: Text('Show Backup'),
+                                        ),
+                                      ],
+                                    ),
+                              );
+                              if (context.mounted && result == true) {
+                                await _handleBackupDevice(context, deviceId);
+                              }
+                            } else {
+                              await _handleBackupDevice(context, deviceId);
+                            }
+                          },
+                          child: const Text('Backup'),
+                        ),
+                        const SizedBox(width: 16),
+                        Icon(
+                          isCompleted
+                              ? Icons.check_circle
+                              : Icons.circle_outlined,
+                          color:
+                              isCompleted
+                                  ? theme.colorScheme.primary
+                                  : theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            }),
+            if (completedDevices.length == allDevices.length) ...[
+              const SizedBox(height: 24),
+              Center(
+                child: FilledButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  child: const Text('Done'),
+                ),
+              ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}

--- a/frostsnapp/lib/device_settings.dart
+++ b/frostsnapp/lib/device_settings.dart
@@ -474,9 +474,9 @@ class BackupSettingsPage extends StatelessWidget {
               SizedBox(height: 8),
               ElevatedButton(
                 onPressed: () async {
-                  await doBackupWorkflow(
+                  await backupDeviceDialog(
                     context,
-                    devices: [id],
+                    deviceId: id,
                     accessStructure:
                         coord.getAccessStructure(asRef: accessStructureRef)!,
                   );
@@ -488,81 +488,15 @@ class BackupSettingsPage extends StatelessWidget {
               SizedBox(height: 8),
               ElevatedButton(
                 onPressed: () async {
-                  final shareRestoreStream =
-                      coord
-                          .checkShareOnDevice(
-                            deviceId: id,
-                            accessStructureRef: accessStructureRef,
-                          )
-                          .asBroadcastStream();
-
-                  final aborted = shareRestoreStream
-                      .firstWhere((state) => state.abort != null)
-                      .then((state) {
-                        if (context.mounted) {
-                          showErrorSnackbarBottom(context, state.abort!);
-                        }
-                        return null;
-                      });
-
-                  final result = await showDeviceActionDialog<bool>(
-                    context: context,
-                    complete: aborted,
-                    builder: (BuildContext context) {
-                      return StreamBuilder(
-                        stream: shareRestoreStream,
-                        builder: (context, snapshot) {
-                          final outcome = snapshot.data?.outcome;
-                          return Column(
-                            children: [
-                              DialogHeader(
-                                child: Text("Enter the backup on the device."),
-                              ),
-                              Expanded(
-                                child: DeviceListWithIcons(
-                                  iconAssigner: (context, deviceId) {
-                                    if (deviceIdEquals(deviceId, id)) {
-                                      final Widget icon = DevicePrompt(
-                                        icon: Icon(Icons.keyboard),
-                                        text: "",
-                                      );
-                                      return (null, icon);
-                                    } else {
-                                      return (null, null);
-                                    }
-                                  },
-                                ),
-                              ),
-                              DialogFooter(
-                                child: ElevatedButton(
-                                  onPressed: () {
-                                    Navigator.pop(context, outcome);
-                                  },
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: switch (outcome) {
-                                      true => Colors.green,
-                                      false => Colors.red,
-                                      null => null,
-                                    },
-                                  ),
-                                  child: Text(switch (outcome) {
-                                    true => "Your backup is valid",
-                                    false => "Your backup is invalid",
-                                    null => "Cancel",
-                                  }),
-                                ),
-                              ),
-                            ],
-                          );
-                        },
-                      );
-                    },
+                  await verifyBackup(
+                    context,
+                    id,
+                    coord
+                        .getAccessStructure(asRef: accessStructureRef)!
+                        .accessStructureRef(),
                   );
-                  if (result == null) {
-                    coord.cancelProtocol();
-                  }
                 },
-                child: Text('Check Backup'),
+                child: const Text("Verify Backup"),
               ),
             ],
           ),

--- a/frostsnapp/lib/key_list.dart
+++ b/frostsnapp/lib/key_list.dart
@@ -4,6 +4,7 @@ import 'package:frostsnapp/access_structures.dart';
 import 'package:frostsnapp/contexts.dart';
 import 'package:frostsnapp/global.dart';
 import 'package:frostsnapp/goal_progress.dart';
+import 'package:frostsnapp/keygen.dart';
 import 'package:frostsnapp/settings.dart';
 import 'package:frostsnapp/snackbar.dart';
 import 'package:frostsnapp/stream_ext.dart';
@@ -12,7 +13,6 @@ import 'package:frostsnapp/either.dart';
 
 import 'ffi.dart' if (dart.library.html) 'ffi_web.dart';
 import 'package:flutter/material.dart';
-import 'package:confetti/confetti.dart';
 
 typedef KeyItem = Either<FrostKey, RecoverableKey>;
 
@@ -280,12 +280,11 @@ class KeyCard extends StatelessWidget {
     if (superWallet == null || keyId == null || frostKey == null) return null;
     return () => Navigator.push(
       context,
-      MaterialPageRoute(
-        builder:
-            (context) => superWallet.tryWrapInWalletContext(
-              keyId: keyId!,
-              child: WalletHome(),
-            ),
+      createRoute(
+        superWallet.tryWrapInWalletContext(
+          keyId: keyId!,
+          child: WalletHomeWithConfetti(),
+        ),
       ),
     );
   }
@@ -335,9 +334,8 @@ class KeyCard extends StatelessWidget {
   }
 }
 
-class KeyListWithConfetti extends StatelessWidget {
-  final ConfettiController controller;
-  const KeyListWithConfetti({super.key, required this.controller});
+class ActiveAndRecoverableKeyList extends StatelessWidget {
+  const ActiveAndRecoverableKeyList({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -387,13 +385,6 @@ class KeyListWithConfetti extends StatelessWidget {
             recoverableBuilder: (context, recoverableKey) {
               return RecoverableKeyCard(recoverableKey: recoverableKey);
             },
-          ),
-        ),
-        Center(
-          child: ConfettiWidget(
-            confettiController: controller,
-            blastDirectionality: BlastDirectionality.explosive,
-            numberOfParticles: 50,
           ),
         ),
       ],

--- a/frostsnapp/lib/settings.dart
+++ b/frostsnapp/lib/settings.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:frostsnapp/address.dart';
 import 'package:frostsnapp/access_structures.dart';
+import 'package:frostsnapp/backup_workflow.dart';
 import 'package:frostsnapp/bullet_list.dart';
 import 'package:frostsnapp/contexts.dart';
 import 'package:frostsnapp/electrum_server_settings.dart';
@@ -81,6 +82,7 @@ class SettingsPage extends StatelessWidget {
     final walletCtx = WalletContext.of(context);
     final keyCtx = KeyContext.of(context);
     final logCtx = FrostsnapContext.of(context);
+
     return Scaffold(
       appBar: AppBar(title: Text('Settings')),
       body: Center(
@@ -114,6 +116,19 @@ class SettingsPage extends StatelessWidget {
                         return AccessPage();
                       },
                     ),
+                    if (walletCtx != null)
+                      SettingsItem(
+                        title: Text('Backup Checklist'),
+                        icon: Icons.assignment,
+                        bodyBuilder: (context) {
+                          final frostKey = walletCtx.wallet.frostKey();
+                          if (frostKey != null) {
+                            return BackupChecklist(
+                              accessStructure: frostKey.accessStructures()[0],
+                            );
+                          }
+                        },
+                      ),
                     SettingsItem(
                       title: Text('Check address'),
                       icon: Icons.policy,

--- a/frostsnapp/lib/show_backup.dart
+++ b/frostsnapp/lib/show_backup.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:frostsnapp/device.dart';
 import 'package:frostsnapp/device_action.dart';
@@ -8,162 +5,210 @@ import 'package:frostsnapp/id_ext.dart';
 import 'package:frostsnapp/device_list.dart';
 import 'package:frostsnapp/ffi.dart';
 import 'package:frostsnapp/global.dart';
-import 'package:frostsnapp/hex.dart';
-import 'package:frostsnapp/theme.dart';
+import 'package:frostsnapp/snackbar.dart';
 
-Future<void> doBackupWorkflow(
-  BuildContext context, {
-  required List<DeviceId> devices,
-  required AccessStructure accessStructure,
-}) async {
-  for (final deviceId in devices) {
-    if (context.mounted) {
-      final confirmed = await showDeviceBackupDialog(
-        context,
-        deviceId: deviceId,
-        accessStructureRef: accessStructure.accessStructureRef(),
-      );
-
-      if (confirmed && context.mounted) {
-        await showBackupInstructionsDialog(
-          context,
-          accessStructure: accessStructure,
-        );
-      }
-    }
-    await coord.cancelProtocol();
-  }
-}
-
-Future<bool> showDeviceBackupDialog(
+Future<bool> backupDeviceDialog(
   BuildContext context, {
   required DeviceId deviceId,
-  required AccessStructureRef accessStructureRef,
-}) async {
-  final result = await showDeviceActionDialog<bool>(
-    context: context,
-    complete:
-        coord
-            .displayBackup(id: deviceId, accessStructureRef: accessStructureRef)
-            .first,
-    builder: (context) {
-      return Column(
-        children: [
-          DialogHeader(child: Text("Confirm on device to show backup")),
-          DeviceListWithIcons(
-            iconAssigner: (context, id) {
-              if (deviceIdEquals(deviceId, id)) {
-                final Widget icon = ConfirmPrompt();
-                return (null, icon);
-              } else {
-                return (null, null);
-              }
-            },
-          ),
-        ],
-      );
-    },
-  );
-
-  final confirmed = result == true;
-
-  return confirmed;
-}
-
-Future<void> showBackupInstructionsDialog(
-  BuildContext context, {
   required AccessStructure accessStructure,
 }) async {
-  return showDialog(
-    context: context,
-    builder: (context) {
-      return AlertDialog(
-        actions: [
-          ElevatedButton(
-            child: Text("I have written down my backup"),
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          ),
-        ],
-        content: SizedBox(
-          width: Platform.isAndroid ? double.maxFinite : 400.0,
-          child: Align(
-            alignment: Alignment.center,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text.rich(
-                  TextSpan(
-                    text:
-                        "Write down each device's backup for this key onto separate pieces of paper. Each piece of paper should look like this with every ",
-                    children: const [
-                      TextSpan(
-                        text: 'X',
-                        style: TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      TextSpan(
-                        text: ' replaced with the character shown on screen.',
-                      ),
-                    ],
-                  ),
-                ),
-                SizedBox(height: 8),
-                Divider(),
-                Center(
-                  child: Text.rich(
-                    TextSpan(
-                      text: 'frost[',
-                      children: const <TextSpan>[
-                        TextSpan(
-                          text: 'X',
-                          style: TextStyle(fontWeight: FontWeight.bold),
-                        ),
-                        TextSpan(text: ']'),
-                      ],
-                    ),
-                  ),
-                ),
-                Center(
-                  child: Text(
-                    "xxxx xxxx xxxx\nxxxx xxxx xxxx\nxxxx xxxx xxxx\nxxxx xxxx xxxx\nxxxx xxxx xx",
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontFamily: monospaceTextStyle.fontFamily,
-                    ),
-                  ),
-                ),
-                Center(
-                  child: Text(
-                    "Identifier: ${toSpacedHex(Uint8List.fromList(accessStructure.id().field0.sublist(0, 4)))}",
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontFamily: monospaceTextStyle.fontFamily,
-                    ),
-                  ),
-                ),
-                Divider(),
-                SizedBox(height: 16),
-                Text(
-                  "Alongside each backup, also record the identifier above.",
-                ),
-                SizedBox(height: 8),
-                Text(
-                  "This identifier is useful for knowing that these share backups belong to the same key and are compatibile.",
-                ),
-                SizedBox(height: 24),
-                Text(
-                  "Any ${accessStructure.threshold()} of these backups will provide complete control over this key.",
-                ),
-                SizedBox(height: 8),
-                Text(
-                  "You should store these backups securely in separate locations.",
-                ),
-              ],
+  Future<bool> displayBackupOnDevice() async {
+    final displayStream =
+        coord
+            .displayBackup(
+              id: deviceId,
+              accessStructureRef: accessStructure.accessStructureRef(),
+            )
+            .asBroadcastStream();
+    final deviceName = coord.getDeviceName(id: deviceId);
+    final confirmed = await showDeviceActionDialog<bool>(
+      context: context,
+      complete: displayStream.first,
+      builder: (context) {
+        return Column(
+          children: [
+            DialogHeader(
+              child: Text("Connect $deviceName to display its backup"),
             ),
+            Expanded(
+              child: DeviceListWithIcons(
+                iconAssigner: (context, id) {
+                  if (deviceIdEquals(deviceId, id)) {
+                    final Widget icon = ConfirmPrompt();
+                    return (null, icon);
+                  } else {
+                    return (null, null);
+                  }
+                },
+              ),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) {
+      await coord.cancelProtocol();
+      return false;
+    }
+    return true;
+  }
+
+  if (!await displayBackupOnDevice()) {
+    return false;
+  }
+
+  if (context.mounted) {
+    final result = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return AlertDialog(
+          titlePadding: const EdgeInsets.fromLTRB(24, 16, 16, 0),
+          title: Row(
+            children: [
+              const Expanded(child: Text('Write Down Your Backup')),
+              IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () {
+                  Navigator.pop(context, false);
+                },
+              ),
+            ],
           ),
-        ),
+          content: const Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Write down the backup shown on the device.'),
+              SizedBox(height: 8),
+              Text(
+                'Then store it alongside your device in this secure location.',
+              ),
+            ],
+          ),
+          actions: [
+            FilledButton(
+              onPressed: () {
+                Navigator.pop(context, true);
+              },
+              child: const Text('Backup & Device Secured'),
+            ),
+          ],
+        );
+      },
+    );
+
+    await coord.cancelProtocol();
+    return result ?? false;
+  }
+
+  await coord.cancelProtocol();
+  return false;
+}
+
+Future<bool?> verifyBackup(
+  BuildContext context,
+  DeviceId deviceId,
+  AccessStructureRef accessStructureRef,
+) async {
+  final shareRestoreStream =
+      coord
+          .checkShareOnDevice(
+            deviceId: deviceId,
+            accessStructureRef: accessStructureRef,
+          )
+          .asBroadcastStream();
+
+  final aborted = shareRestoreStream
+      .firstWhere((state) => state.abort != null)
+      .then((state) {
+        if (context.mounted) {
+          showErrorSnackbarBottom(context, state.abort!);
+        }
+        return null;
+      });
+
+  final result = await showDeviceActionDialog<bool>(
+    context: context,
+    complete: aborted,
+    builder: (BuildContext context) {
+      return StreamBuilder(
+        stream: shareRestoreStream,
+        builder: (context, snapshot) {
+          final outcome = snapshot.data?.outcome;
+          return Column(
+            children: [
+              DialogHeader(child: Text("Enter the backup on the device.")),
+              Expanded(
+                child: DeviceListWithIcons(
+                  iconAssigner: (context, deviceId) {
+                    if (deviceIdEquals(deviceId, deviceId)) {
+                      const icon = DevicePrompt(
+                        icon: Icon(Icons.keyboard),
+                        text: "",
+                      );
+                      return (null, icon);
+                    } else {
+                      return (null, null);
+                    }
+                  },
+                ),
+              ),
+              DialogFooter(
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.pop(context, outcome);
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: switch (outcome) {
+                      true => Colors.green,
+                      false => Colors.red,
+                      null => null,
+                    },
+                  ),
+                  child: Text(switch (outcome) {
+                    true => "Your backup is valid. Done!",
+                    false => "Your backup is invalid. Display again.",
+                    null => "Cancel",
+                  }),
+                ),
+              ),
+            ],
+          );
+        },
       );
     },
   );
+
+  if (result == null) {
+    await coord.cancelProtocol();
+  }
+  return result;
+}
+
+class BackupInstructions extends StatelessWidget {
+  final AccessStructure accessStructure;
+
+  const BackupInstructions({super.key, required this.accessStructure});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          "Your device has presented a backup, write it down on your Frostsnap backup card.",
+        ),
+        const SizedBox(height: 16),
+        Text(
+          "Any ${accessStructure.threshold()} of these backups will provide complete control over this key.",
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          "You must store these backups securely in separate locations.",
+        ),
+      ],
+    );
+  }
 }


### PR DESCRIPTION
Introduces a backup workflow (https://github.com/frostsnap/frostsnap/issues/160) where users are instructed to backup each device and leave in different geographic locations. This process automatically begins at the end of key generation.

Users can pause and resume the process at any time, they can also go through the (greyed out) backup checklist items again if they so desire.

If a backup run has not been completed, a warning banner will display in the wallet.

A warning is displayed if a user tries to backup successive different devices too quickly (<5min), encouraging geographic separation.

This does not yet add much excitement to these tasks, still thinking on that one - what emotion and vibe we want the app to exude.