### PR TITLE
Upload firmware binary with actions

### DIFF
--- a/.github/actions/set-up-app-build/action.yml
+++ b/.github/actions/set-up-app-build/action.yml
@@ -14,8 +14,8 @@ runs:
     - uses: "./.github/actions/fetch-dart-deps"
     - uses: "./.github/actions/generate-frb"
     - uses: "./.github/actions/install-cargo-bins" # needed for espflash
-    - name: Rertrieve device firmware
+    - name: Retrieve device firmware
       uses: actions/download-artifact@v4
       with:
-        name: "frostsnap-${{ github.sha }}.elf"
+        name: "frostsnap-${{ github.sha }}.bin"
         path: target/riscv32imc-unknown-none-elf/release/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@just
       - uses: ./.github/actions/fetch-cargo-deps
+      - uses: "./.github/actions/install-cargo-bins"
 
       # RISC-V toolchain cache
       - uses: actions/cache@v4
@@ -50,10 +51,11 @@ jobs:
 
       - run: just lint-device --release --locked
       - run: just build-device ${{ matrix.board }} --locked
+      - run: just save-image ${{ matrix.board }}
       - uses: "./.github/actions/upload-artifact"
         with:
-          name: frostsnap-${{ github.sha }}.elf
-          path: target/riscv32imc-unknown-none-elf/release/v2
+          name: frostsnap-${{ github.sha }}.bin
+          path: target/riscv32imc-unknown-none-elf/release/firmware.bin
 
   test-ordinary-libs:
     name: Test ordinary libraries

--- a/frostsnapp/native/build.rs
+++ b/frostsnapp/native/build.rs
@@ -1,36 +1,27 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(bundle_firmware)");
-    use std::env;
-    use std::path::{Path, PathBuf};
-    use std::process::Command;
+
     if env::var("BUNDLE_FIRMWARE").is_ok() {
         println!("cargo:rustc-cfg=bundle_firmware");
+
+        let source_path =
+            Path::new("../../target/riscv32imc-unknown-none-elf/release/firmware.bin");
         let out_dir = env::var("OUT_DIR").unwrap();
-        let output_path = PathBuf::from(out_dir).join("firmware.bin");
+        let dest_path = Path::new(&out_dir).join("firmware.bin");
 
-        // // Ensure the output directory exists
-        // let out_dir = env::var("OUT_DIR").unwrap();
-        // let binary_path = Path::new(&out_dir).join("crate_a_binary");
-        let target_binary_path = Path::new("../../target/riscv32imc-unknown-none-elf/release/v2");
-        println!("cargo:rerun-if-changed={}", target_binary_path.display());
+        println!("cargo:rerun-if-changed={}", source_path.display());
 
-        if !target_binary_path.exists() {
+        if !source_path.exists() {
             eprintln!(
-                "device firmware elf file doesn't exist at {}. Build before trying to build app.",
-                target_binary_path.display()
+                "device firmware file doesn't exist at {}. Build before trying to build app.",
+                source_path.display()
             );
+        } else {
+            fs::copy(source_path, dest_path).expect("Failed to copy firmware.bin to OUT_DIR");
         }
-        // println!("cargo:rerun-if-changed=../crate_a/src/*");
-        let status = Command::new("espflash")
-            .args(["save-image", "--chip=esp32c3"])
-            .arg(target_binary_path)
-            .arg(&output_path)
-            .status()
-            .expect("Failed to create binary firmware file from elf file");
-
-        assert!(
-            status.success(),
-            "Unsuccesful exit of command to create binary firmware file from elf file"
-        );
     }
 }

--- a/justfile
+++ b/justfile
@@ -12,6 +12,9 @@ erase-device +ARGS="nvs":
 build-device BOARD=default_board +ARGS="":
     cd device && cargo build --release --features {{BOARD}} --bin {{BOARD}} {{ARGS}}
 
+save-image BOARD=default_board +ARGS="":
+    espflash save-image --chip=esp32c3 target/riscv32imc-unknown-none-elf/release/{{BOARD}} target/riscv32imc-unknown-none-elf/release/firmware.bin {{ARGS}}
+
 test-ordinary +ARGS="":
     cargo test {{ARGS}} {{ordinary_crates}}
 


### PR DESCRIPTION
Turns out you can't easily `espflash flash` a binary, see https://github.com/viamrobotics/micro-rdk/pull/289
Need to use `espflash write-bin 0x10000 ~/tmp/firmware.bin` with specific flash addresses