### PR TITLE
[app] Use our electrum servers as default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,6 @@ rand_core = "0.6"
 futures = "0.3.31"
 embedded-storage = "0.3.1"
 
-[patch.crates-io]
-schnorr_fun = { git = "https://github.com/LLFourn/secp256kfun.git", rev = "1f739e0edfad08556de4e84244aa562452d15ba8" }
-
 [profile.dev]
 # Rust debug is too slow.
 # For debug builds always builds with some optimization

--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -141,11 +141,11 @@ impl ChainClient {
 
 pub const fn default_electrum_server(network: bitcoin::Network) -> &'static str {
     match network {
-        bitcoin::Network::Bitcoin => "ssl://electrum.blockstream.info:50002",
+        bitcoin::Network::Bitcoin => "tcp://electrum.frostsn.app:50001",
         // we're using the tcp:// version since ssl ain't working for some reason
         bitcoin::Network::Testnet => "tcp://electrum.blockstream.info:60001",
         bitcoin::Network::Regtest => "tcp://localhost:60401",
-        bitcoin::Network::Signet => "tcp://signet-electrumx.wakiyamap.dev:50001",
+        bitcoin::Network::Signet => "tcp://electrum.frostsn.app:60001",
         _ => panic!("Unknown network"),
     }
 }


### PR DESCRIPTION
They are not using ssl until we can control ssl certs more closely.