### PR TITLE
[comms] Devices send Reset signal when they reset

### DIFF
--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -221,6 +221,9 @@ where
                                         .expect("failed to write conch upstream");
                                 }
                                 ReceiveSerial::Reset => {
+                                    upstream_connection.send_to_coordinator([
+                                        DeviceSendBody::DisconnectDownstream,
+                                    ]);
                                     downstream_connection_state =
                                         DownstreamConnectionState::Disconnected;
                                     break;

--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -220,6 +220,11 @@ where
                                         .write_conch()
                                         .expect("failed to write conch upstream");
                                 }
+                                ReceiveSerial::Reset => {
+                                    downstream_connection_state =
+                                        DownstreamConnectionState::Disconnected;
+                                    break;
+                                }
                                 _ => { /* unused */ }
                             };
                         }
@@ -267,6 +272,8 @@ where
                     while let Some(received_message) = upstream_serial.receive() {
                         match received_message {
                             Ok(received_message) => {
+                                // Do this here because it needs to be set to false if it was
+                                // previously true.
                                 last_message_was_magic_bytes =
                                     matches!(received_message, ReceiveSerial::MagicBytes(_));
                                 match received_message {
@@ -301,7 +308,7 @@ where
                                                             &mut ui,
                                                             &mut sha256,
                                                         );
-                                                        esp_hal::reset::software_reset();
+                                                        reset(&mut upstream_serial);
                                                     } else {
                                                         panic!("upgrade cannot start because we were not warned about it")
                                                     }
@@ -326,6 +333,7 @@ where
                                         has_conch = true;
                                         conch_is_downstream = false;
                                     }
+                                    ReceiveSerial::Reset => { /* upstream doesn't send this */ }
                                     _ => { /* unused */ }
                                 }
                             }
@@ -574,7 +582,7 @@ where
                     }
                     UiEvent::WipeDataConfirm => {
                         partitions.nvs.erase_all().expect("failed to erase nvs");
-                        esp_hal::reset::software_reset();
+                        reset(&mut upstream_serial);
                     }
                 }
 
@@ -598,4 +606,9 @@ where
             }
         }
     }
+}
+
+fn reset<T: timer::Timer>(upstream_serial: &mut SerialInterface<'_, T, Upstream>) {
+    let _ = upstream_serial.send_reset_signal();
+    esp_hal::reset::software_reset();
 }

--- a/device/src/io.rs
+++ b/device/src/io.rs
@@ -135,7 +135,7 @@ where
             &mut *self,
             BINCODE_CONFIG,
         )?;
-        self.io.nb_flush();
+        self.flush();
 
         Ok(())
     }

--- a/device/src/io.rs
+++ b/device/src/io.rs
@@ -129,6 +129,17 @@ where
         Ok(())
     }
 
+    pub fn send_reset_signal(&mut self) -> Result<(), bincode::error::EncodeError> {
+        bincode::encode_into_writer(
+            ReceiveSerial::<D::Opposite>::Reset,
+            &mut *self,
+            BINCODE_CONFIG,
+        )?;
+        self.io.nb_flush();
+
+        Ok(())
+    }
+
     /// Blocking flush
     pub fn flush(&mut self) {
         self.io.flush()

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -70,6 +70,7 @@ impl<D: Direction> Gist for ReceiveSerial<D> {
             ReceiveSerial::MagicBytes(_) => "MagicBytes".into(),
             ReceiveSerial::Message(msg) => msg.gist(),
             ReceiveSerial::Conch => "Conch".into(),
+            ReceiveSerial::Reset => "Reset".into(),
             _ => "Unused".into(),
         }
     }

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -51,8 +51,8 @@ pub enum ReceiveSerial<D: Direction> {
     /// You can only send messages if you have the conch. Also devices should only do work if no one
     /// downstream of them has the conch.
     Conch,
+    Reset,
     // to allow devices to ignore messages they don't understand
-    Unused9,
     Unused8,
     Unused7,
     Unused6,

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -47,8 +47,6 @@ pub struct UsbSerialManager {
     outbox_sender: std::sync::mpsc::Sender<CoordinatorSendMessage>,
     /// The firmware binary provided to devices who are doing an upgrade
     firmware_bin: Option<FirmwareBin>,
-    /// Ports we should artificially disconnect next time
-    pending_disconnect_ports: HashSet<String>,
 }
 
 pub struct DevicePort {
@@ -79,7 +77,6 @@ impl UsbSerialManager {
             reverse_device_ports: Default::default(),
             registered_devices: Default::default(),
             device_names: Default::default(),
-            pending_disconnect_ports: Default::default(),
             port_outbox: receiver,
             outbox_sender: sender,
             firmware_bin,
@@ -131,10 +128,6 @@ impl UsbSerialManager {
         let span = span!(Level::DEBUG, "poll_ports");
         let _enter = span.enter();
         let mut device_changes = vec![];
-
-        for to_disconnect in core::mem::take(&mut self.pending_disconnect_ports) {
-            self.disconnect(&to_disconnect, &mut device_changes);
-        }
 
         let connected_now: HashSet<String> = self
             .serial_impl
@@ -412,6 +405,9 @@ impl UsbSerialManager {
                         }
                     }
                 }
+                ReceiveSerial::Reset => {
+                    self.disconnect(&port_name, &mut device_changes);
+                }
                 _ => { /* unused */ }
             }
         }
@@ -633,8 +629,6 @@ impl UsbSerialManager {
                     ((port_index as u32 * n_chunks) + i as u32) as f32 / (total_chunks - 1) as f32
                 ))
             }));
-
-            self.pending_disconnect_ports.insert(port.to_string());
         }
 
         Ok(iters.into_iter().flatten())

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -406,6 +406,7 @@ impl UsbSerialManager {
                     }
                 }
                 ReceiveSerial::Reset => {
+                    event!(Level::DEBUG, port = port_name, "Read reset downstream!");
                     self.disconnect(&port_name, &mut device_changes);
                 }
                 _ => { /* unused */ }
@@ -585,6 +586,8 @@ impl UsbSerialManager {
                 );
                 continue;
             }
+
+            io.wait_for_conch()?;
 
             event!(Level::INFO, port = port, "starting writing firmware");
             let mut chunks = firmware_bin


### PR DESCRIPTION
Weird bugs in the Linux kernel driver for ACM CDC devices was being triggered by our aggressive disconnect and reconnect for devices that had finished firmware upgrade. It happened so fast that data got corrupted somehow by the CDC ACM control message `2122030000000000`. Now we only disconnect the port once the device has cleanly finished the upgrade and sent our reset signal.