### PR TITLE
Make 1.87 clippy happy

### DIFF
--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -509,7 +509,7 @@ impl FrostCoordinator {
                                 // we use the share index as the input generator index. The input
                                 // generator at index 0 is the coordinator itself.
                                 (*share_index).into(),
-                                response.input,
+                                *response.input,
                             )
                             .map_err(|e| Error::coordinator_invalid_message(message_kind, e))?;
 
@@ -1790,7 +1790,7 @@ pub struct RequestDeviceSign {
 impl From<RequestDeviceSign> for CoordinatorSend {
     fn from(value: RequestDeviceSign) -> Self {
         CoordinatorSend::ToDevice {
-            message: CoordinatorToDeviceMessage::RequestSign(value.request_sign),
+            message: CoordinatorToDeviceMessage::RequestSign(Box::new(value.request_sign)),
             destinations: [value.device_id].into(),
         }
     }

--- a/frostsnap_core/src/device.rs
+++ b/frostsnap_core/src/device.rs
@@ -365,7 +365,7 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                 Ok(vec![DeviceSend::ToCoordinator(Box::new(
                     DeviceToCoordinatorMessage::KeyGenResponse(KeyGenResponse {
                         keygen_id,
-                        input: keygen_input,
+                        input: Box::new(keygen_input),
                     }),
                 ))])
             }
@@ -417,10 +417,11 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                     },
                 ))])
             }
-            RequestSign(self::RequestSign {
-                group_sign_req,
-                device_sign_req,
-            }) => {
+            RequestSign(request_sign) => {
+                let self::RequestSign {
+                    group_sign_req,
+                    device_sign_req,
+                } = *request_sign;
                 let session_id = group_sign_req.session_id();
                 let key_id = KeyId::from_rootkey(device_sign_req.rootkey);
                 let key_data = self

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -37,7 +37,7 @@ pub enum CoordinatorToDeviceMessage {
         keygen_id: KeygenId,
         agg_input: encpedpop::AggKeygenInput,
     },
-    RequestSign(RequestSign),
+    RequestSign(Box<RequestSign>),
     OpenNonceStreams {
         streams: Vec<CoordNonceStreamState>,
     },
@@ -212,7 +212,7 @@ pub struct HeldShare {
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, PartialEq)]
 pub struct KeyGenResponse {
     pub keygen_id: KeygenId,
-    pub input: encpedpop::KeygenInput,
+    pub input: Box<encpedpop::KeygenInput>,
 }
 
 impl Gist for DeviceToCoordinatorMessage {

--- a/frostsnapp/native/src/ffi_serial_port.rs
+++ b/frostsnapp/native/src/ffi_serial_port.rs
@@ -72,7 +72,7 @@ impl io::Read for FfiSerialPort {
                         std::thread::sleep(std::time::Duration::from_millis(1));
                     }
                 }
-                Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
+                Err(e) => return Err(io::Error::other(e)),
             }
         }
     }
@@ -93,7 +93,7 @@ impl std::io::Write for FfiSerialPort {
 
         match rx.recv().unwrap() {
             Ok(()) => Ok(buf.len()),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+            Err(e) => Err(io::Error::other(e)),
         }
     }
 


### PR DESCRIPTION
Worth noting that there were more warnings on https://github.com/frostsnap/frostsnap/pull/236 related to large enum variants.