### PR TITLE
Skip x86 app build during release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
           link-to-sdk: true
           add-to-path: true
       - name: Build App APK
-        run: just frostsnapp/build apk --release
+        run: just frostsnapp/build apk --release --target-platform android-arm64,android-arm
       - name: Build appbundle
         run: just frostsnapp/build appbundle --release
       - name: Upload APK (Android)


### PR DESCRIPTION
For example, see this CI run:
https://github.com/frostsnap/frostsnap/actions/runs/15731852134/job/44334727770#step:9:67

This commit seems to only have disabled during debug runs
437326d62d235e3c0c05aa2f788ce2bf1cc63203