### PR TITLE
[android] Disable x86 builds for all build types

### DIFF
--- a/frostsnapp/rust_builder/cargokit/gradle/plugin.gradle
+++ b/frostsnapp/rust_builder/cargokit/gradle/plugin.gradle
@@ -140,6 +140,9 @@ class CargoKitPlugin implements Plugin<Project> {
             //     platforms.add("android-x86")
             //     platforms.add("android-x64")
             // }
+            
+            // Also remove x86 platforms for all build types (including release)
+            platforms.removeAll { it == "android-x86" || it == "android-x64" }
 
             // The task name depends on plugin properties, which are not available
             // at this point


### PR DESCRIPTION
## Summary
- Extends the previous x86 build disabling to include release builds
- Filters out x86/x64 platforms for all Android build types to improve build performance
- This is an alternative approach to #260

## Changes
Added `platforms.removeAll { it == "android-x86" || it == "android-x64" }` to filter out x86 architectures for all build types, not just debug builds.

🤖 Generated with [Claude Code](https://claude.ai/code)