### PR TITLE
[ci] Pin proptest for right rand dependency

### DIFF
--- a/frostsnap_core/Cargo.toml
+++ b/frostsnap_core/Cargo.toml
@@ -24,7 +24,7 @@ rusqlite = { workspace = true, optional = true }
 [dev-dependencies]
 rand = "0.8"
 proptest-state-machine = "0.3"
-proptest = "1.6"
+proptest = "=1.6.0"
 
 [features]
 std = ["tracing?/std", "schnorr_fun/std"]


### PR DESCRIPTION
I don't understand how but people made breaking API changes in a minor version (1.7.0).