### PR TITLE
Nonce Generation UI Protocol

### DIFF
--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -411,6 +411,14 @@ pub fn run<'a>(resources: &'a mut Resources<'a>) -> ! {
                         }
                     },
                     CoordinatorSendBody::Core(core_message) => {
+                        if matches!(
+                            core_message,
+                            frostsnap_core::message::CoordinatorToDeviceMessage::OpenNonceStreams { .. }
+                        ) {
+                            ui.set_busy_task(ui::BusyTask::GeneratingNonces);
+                        } else {
+                            ui.clear_busy_task();
+                        }
                         outbox.extend(
                             signer
                                 .recv_coordinator_message(
@@ -420,7 +428,6 @@ pub fn run<'a>(resources: &'a mut Resources<'a>) -> ! {
                                 )
                                 .expect("failed to process coordinator message"),
                         );
-                        ui.clear_busy_task();
                     }
                     CoordinatorSendBody::Upgrade(upgrade_message) => match upgrade_message {
                         CoordinatorUpgradeMessage::PrepareUpgrade {

--- a/frostsnap_coordinator/src/lib.rs
+++ b/frostsnap_coordinator/src/lib.rs
@@ -3,6 +3,7 @@ pub mod display_backup;
 pub mod enter_physical_backup;
 pub mod firmware_upgrade;
 pub mod keygen;
+pub mod nonce_replenish;
 mod serial_port;
 pub mod signing;
 mod ui_protocol;

--- a/frostsnap_coordinator/src/nonce_replenish.rs
+++ b/frostsnap_coordinator/src/nonce_replenish.rs
@@ -58,7 +58,6 @@ impl NonceReplenishProtocol {
                     .expect("will only send messages to device"),
             );
         }
-
         self_
     }
 

--- a/frostsnap_coordinator/src/nonce_replenish.rs
+++ b/frostsnap_coordinator/src/nonce_replenish.rs
@@ -1,0 +1,124 @@
+use crate::{Completion, Sink, UiProtocol};
+
+use frostsnap_comms::CoordinatorSendMessage;
+use frostsnap_core::{
+    coordinator::{CoordinatorToUserMessage, FrostCoordinator},
+    DeviceId,
+};
+use std::collections::BTreeSet;
+
+pub struct NonceReplenishProtocol {
+    state: NonceReplenishState,
+    messages: Vec<CoordinatorSendMessage>,
+    sink: Box<dyn Sink<NonceReplenishState>>,
+}
+
+impl NonceReplenishProtocol {
+    pub fn new(
+        coordinator: &mut FrostCoordinator,
+        devices: BTreeSet<DeviceId>,
+        desired_nonce_streams: usize,
+        rng: &mut impl rand_core::RngCore,
+        sink: impl Sink<NonceReplenishState> + 'static,
+    ) -> Self {
+        let nonce_request =
+            coordinator.maybe_request_nonce_replenishment(&devices, desired_nonce_streams, rng);
+
+        let devices_with_messages: BTreeSet<DeviceId> = nonce_request
+            .replenish_requests
+            .iter()
+            .filter(|(_, streams)| !streams.is_empty())
+            .map(|(device_id, _)| *device_id)
+            .collect();
+
+        // devices that don't need messages as already "received from"
+        let received_from: Vec<DeviceId> = devices
+            .difference(&devices_with_messages)
+            .copied()
+            .collect();
+
+        let mut self_ = Self {
+            state: NonceReplenishState {
+                devices: devices.into_iter().collect(),
+                received_from,
+                abort: false,
+            },
+            messages: Default::default(),
+            sink: Box::new(sink),
+        };
+
+        // Convert NonceReplenishRequest to messages
+        for message in nonce_request {
+            self_.messages.push(
+                message
+                    .try_into()
+                    .expect("will only send messages to device"),
+            );
+        }
+
+        self_
+    }
+
+    pub fn emit_state(&self) {
+        self.sink.send(self.state.clone());
+    }
+}
+
+impl UiProtocol for NonceReplenishProtocol {
+    fn cancel(&mut self) {
+        self.state.abort = true;
+        self.emit_state();
+    }
+
+    fn is_complete(&self) -> Option<Completion> {
+        if BTreeSet::from_iter(self.state.received_from.iter())
+            == BTreeSet::from_iter(self.state.devices.iter())
+        {
+            Some(Completion::Success)
+        } else if self.state.abort {
+            Some(Completion::Abort {
+                send_cancel_to_all_devices: true,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn disconnected(&mut self, id: DeviceId) {
+        if self.state.devices.contains(&id) {
+            self.state.abort = true;
+            self.emit_state();
+        }
+    }
+
+    fn process_to_user_message(&mut self, message: CoordinatorToUserMessage) -> bool {
+        if let CoordinatorToUserMessage::ReplenishedNonces { device_id } = message {
+            if !self.state.received_from.contains(&device_id) {
+                self.state.received_from.push(device_id);
+                self.emit_state()
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    fn poll(&mut self) -> Vec<CoordinatorSendMessage> {
+        core::mem::take(&mut self.messages)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NonceReplenishState {
+    pub received_from: Vec<DeviceId>,
+    pub devices: Vec<DeviceId>,
+    pub abort: bool,
+}

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -404,6 +404,7 @@ impl FrostCoordinator {
         let message_kind = message.kind();
         match message {
             DeviceToCoordinatorMessage::NonceResponse { segments } => {
+                let mut outgoing = vec![];
                 for new_segment in segments {
                     self.nonce_cache
                         .check_can_extend(from, &new_segment)
@@ -420,7 +421,11 @@ impl FrostCoordinator {
                     });
                 }
 
-                Ok(vec![])
+                outgoing.push(CoordinatorSend::ToUser(
+                    CoordinatorToUserMessage::ReplenishedNonces { device_id: from },
+                ));
+
+                Ok(outgoing)
             }
             DeviceToCoordinatorMessage::KeyGenResponse(response) => {
                 let keygen_id = response.keygen_id;
@@ -1012,20 +1017,28 @@ impl FrostCoordinator {
 
     pub fn maybe_request_nonce_replenishment(
         &self,
-        device_id: DeviceId,
+        devices: &BTreeSet<DeviceId>,
         desired_nonce_streams: usize,
         rng: &mut impl rand_core::RngCore,
-    ) -> impl IntoIterator<Item = CoordinatorSend> {
-        core::iter::once(CoordinatorSend::ToDevice {
-            message: CoordinatorToDeviceMessage::OpenNonceStreams {
-                streams: self
-                    .nonce_cache
-                    .generate_nonce_stream_opening_requests(device_id, desired_nonce_streams, rng)
-                    .into_iter()
-                    .collect(),
-            },
-            destinations: [device_id].into(),
-        })
+    ) -> NonceReplenishRequest {
+        let replenish_requests = devices
+            .iter()
+            .map(|device_id| {
+                (
+                    *device_id,
+                    self.nonce_cache
+                        .generate_nonce_stream_opening_requests(
+                            *device_id,
+                            desired_nonce_streams,
+                            rng,
+                        )
+                        .into_iter()
+                        .collect(),
+                )
+            })
+            .collect();
+
+        NonceReplenishRequest { replenish_requests }
     }
 
     pub fn verify_address(
@@ -1595,6 +1608,25 @@ pub enum CoordinatorSend {
         destinations: BTreeSet<DeviceId>,
     },
     ToUser(CoordinatorToUserMessage),
+}
+
+pub struct NonceReplenishRequest {
+    pub replenish_requests: BTreeMap<DeviceId, Vec<CoordNonceStreamState>>,
+}
+
+impl IntoIterator for NonceReplenishRequest {
+    type Item = CoordinatorSend;
+    type IntoIter = std::vec::IntoIter<CoordinatorSend>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.replenish_requests
+            .into_iter()
+            .map(|(device_id, streams)| CoordinatorSend::ToDevice {
+                message: CoordinatorToDeviceMessage::OpenNonceStreams { streams },
+                destinations: [device_id].into(),
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -1617,8 +1617,8 @@ pub struct NonceReplenishRequest {
 impl NonceReplenishRequest {
     pub fn some_nonces_requested(&self) -> bool {
         self.replenish_requests
-            .iter()
-            .any(|(_, streams)| !streams.is_empty())
+            .values()
+            .any(|streams| streams.iter().any(|stream| stream.remaining == 0))
     }
 }
 

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -1614,6 +1614,14 @@ pub struct NonceReplenishRequest {
     pub replenish_requests: BTreeMap<DeviceId, Vec<CoordNonceStreamState>>,
 }
 
+impl NonceReplenishRequest {
+    pub fn some_nonces_requested(&self) -> bool {
+        self.replenish_requests
+            .iter()
+            .any(|(_, streams)| !streams.is_empty())
+    }
+}
+
 impl IntoIterator for NonceReplenishRequest {
     type Item = CoordinatorSend;
     type IntoIter = std::vec::IntoIter<CoordinatorSend>;

--- a/frostsnap_core/src/coordinator/coordinator_to_user.rs
+++ b/frostsnap_core/src/coordinator/coordinator_to_user.rs
@@ -9,6 +9,9 @@ pub enum CoordinatorToUserMessage {
     },
     Signing(CoordinatorToUserSigningMessage),
     Restoration(super::restoration::ToUserRestoration),
+    ReplenishedNonces {
+        device_id: DeviceId,
+    },
 }
 
 impl Gist for CoordinatorToUserMessage {

--- a/frostsnap_core/src/device.rs
+++ b/frostsnap_core/src/device.rs
@@ -327,7 +327,6 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                 let mut segments = vec![];
                 // we need to order prioritize streams that already exist since not getting a
                 // response to this message the coordinator will think that everything is ok.
-                // Ignoring new requests is fine it just means they won't be opened.
                 let (existing, new): (Vec<_>, Vec<_>) = streams
                     .iter()
                     .partition(|stream| self.nonce_slots.get(stream.stream_id).is_some());
@@ -347,12 +346,12 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                     }
                 }
 
-                let send = if !segments.is_empty() {
+                // we always send a response regardless if the segments are empty
+                // so that the coordinator can track UI progress.
+                let send = {
                     Some(DeviceSend::ToCoordinator(Box::new(
                         DeviceToCoordinatorMessage::NonceResponse { segments },
                     )))
-                } else {
-                    None
                 };
                 Ok(send.into_iter().collect())
             }

--- a/frostsnap_core/tests/common/mod.rs
+++ b/frostsnap_core/tests/common/mod.rs
@@ -278,13 +278,12 @@ impl Run {
         purpose: KeyPurpose,
     ) -> Self {
         let mut run = Self::start_after_keygen(n_devices, threshold, env, rng, purpose);
-        for device_id in run.device_set() {
-            run.extend(run.coordinator.maybe_request_nonce_replenishment(
-                device_id,
-                n_nonce_streams,
-                rng,
-            ));
-        }
+
+        run.extend(run.coordinator.maybe_request_nonce_replenishment(
+            &run.device_set(),
+            n_nonce_streams,
+            rng,
+        ));
         run.run_until_finished(env, rng).unwrap();
 
         run

--- a/frostsnap_core/tests/proptest.rs
+++ b/frostsnap_core/tests/proptest.rs
@@ -639,7 +639,7 @@ impl StateMachineTest for HappyPathTest {
             }
             Transition::CNonceReplenish { device_id } => {
                 let messages = run.coordinator.maybe_request_nonce_replenishment(
-                    device_id,
+                    &BTreeSet::from([device_id]),
                     ref_state.n_desired_nonce_streams_coord,
                     rng,
                 );

--- a/frostsnapp/lib/device_action_name.dart
+++ b/frostsnapp/lib/device_action_name.dart
@@ -45,6 +45,16 @@ class DeviceActionNameDialogController with ChangeNotifier {
     Function(String)? onNamed,
   }) async {
     _dialogController.addActionNeeded(context, id);
+
+    // Check if device already has this name
+    final currentName = coord.getDeviceName(id: id);
+    if (currentName == name) {
+      // Device already has this name, no need to rename
+      await _dialogController.removeActionNeeded(id);
+      onNamed?.call(name);
+      return name;
+    }
+
     await coord.finishNaming(id: id, name: name);
 
     final confirmedName = await Stream<String?>.fromFutures([

--- a/frostsnapp/lib/nonce_replenish.dart
+++ b/frostsnapp/lib/nonce_replenish.dart
@@ -1,65 +1,104 @@
 import 'package:flutter/material.dart';
-import 'package:frostsnap/global.dart';
-import 'package:frostsnap/id_ext.dart';
-import 'package:frostsnap/progress_indicator.dart';
-import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/nonce_replenish.dart';
-import 'package:frostsnap/theme.dart';
 
-// Standalone widget for nonce replenshment to be called after recovery, this is separate from the
-// streamlined widget that sits inside the wallet creation workflow.
-class NonceReplenishWidget extends StatelessWidget {
+/// Minimal nonce replenishment widget for use in wallet creation flow.
+/// Shows aggregate progress with auto-advance capability.
+class MinimalNonceReplenishWidget extends StatelessWidget {
   final Stream<NonceReplenishState> stream;
-  final VoidCallback? onCancel;
+  final VoidCallback? onComplete;
+  final bool autoAdvance;
 
-  const NonceReplenishWidget({super.key, required this.stream, this.onCancel});
+  const MinimalNonceReplenishWidget({
+    super.key,
+    required this.stream,
+    this.onComplete,
+    this.autoAdvance = false,
+  });
 
-  Widget _buildDeviceCard(
-    BuildContext context,
-    DeviceId deviceId,
-    bool isComplete,
-  ) {
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final deviceName = coord.getDeviceName(id: deviceId);
-    return Card.filled(
-      margin: EdgeInsets.symmetric(vertical: 4),
-      color: theme.colorScheme.surfaceContainerHigh,
-      clipBehavior: Clip.hardEdge,
-      child: ListTile(
-        title: Text(deviceName ?? 'Setting name..', style: monospaceTextStyle),
-        leading: Icon(Icons.key),
-        contentPadding: EdgeInsets.symmetric(horizontal: 16),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          spacing: 8,
-          children: [
-            Flexible(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.end,
+
+    return StreamBuilder<NonceReplenishState>(
+      stream: stream,
+      builder: (context, snapshot) {
+        final state = snapshot.data;
+
+        Widget content;
+        if (state == null) {
+          content = Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 24),
+              Text('Connecting...', style: theme.textTheme.bodyLarge),
+            ],
+          );
+        } else {
+          final progress = state.receivedFrom.length;
+          final total = state.devices.length;
+          final isComplete = progress == total;
+
+          // Auto-advance when complete
+          if (isComplete && autoAdvance && onComplete != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              onComplete!();
+            });
+          }
+
+          content = Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Preparing devices', style: theme.textTheme.headlineMedium),
+              SizedBox(height: 32),
+              Stack(
+                alignment: Alignment.center,
                 children: [
-                  Text(
-                    isComplete ? 'Ready' : 'Preparing..',
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      color: isComplete ? Colors.green : null,
+                  SizedBox(
+                    width: 120,
+                    height: 120,
+                    child: CircularProgressIndicator(
+                      value: total > 0 ? progress / total : null,
+                      strokeWidth: 8,
+                      backgroundColor:
+                          theme.colorScheme.surfaceContainerHighest,
                     ),
+                  ),
+                  Text(
+                    '$progress of $total',
+                    style: theme.textTheme.headlineSmall,
                   ),
                 ],
               ),
-            ),
-            if (isComplete)
-              Icon(Icons.check_circle_rounded, color: Colors.green)
-            else
-              SizedBox(
-                width: 20,
-                height: 20,
-                child: CircularProgressIndicator(strokeWidth: 2),
+              SizedBox(height: 16),
+              Text(
+                isComplete ? 'Complete!' : 'Please wait...',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: isComplete
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurfaceVariant,
+                ),
               ),
-          ],
-        ),
-      ),
+            ],
+          );
+        }
+
+        return Padding(
+          padding: EdgeInsets.symmetric(vertical: 32),
+          child: Align(alignment: Alignment.topCenter, child: content),
+        );
+      },
     );
   }
+}
+
+/// Full-screen nonce replenishment dialog with Done/Cancel buttons.
+/// Used after wallet restoration where user interaction is required.
+class NonceReplenishDialog extends StatelessWidget {
+  final Stream<NonceReplenishState> stream;
+  final VoidCallback? onCancel;
+
+  const NonceReplenishDialog({super.key, required this.stream, this.onCancel});
 
   @override
   Widget build(BuildContext context) {
@@ -76,108 +115,19 @@ class NonceReplenishWidget extends StatelessWidget {
             shrinkWrap: true,
             slivers: [
               SliverAppBar(
-                title: Text('', style: theme.textTheme.titleMedium),
+                title: Text(
+                  'Preparing devices',
+                  style: theme.textTheme.titleMedium,
+                ),
                 automaticallyImplyLeading: false,
                 pinned: true,
-              ),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 36, 20, 36),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    spacing: 12,
-                    children: [
-                      Text(
-                        'Preparing devices',
-                        style: theme.textTheme.headlineLarge,
-                      ),
-                    ],
-                  ),
-                ),
               ),
               SliverPadding(
                 padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
                 sliver: SliverToBoxAdapter(
-                  child: StreamBuilder<NonceReplenishState>(
+                  child: MinimalNonceReplenishWidget(
                     stream: stream,
-                    builder: (context, snapshot) {
-                      if (!snapshot.hasData) {
-                        return Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            SizedBox(height: 20),
-                            FsProgressIndicator(),
-                            SizedBox(height: 20),
-                            Text(
-                              'Please wait...',
-                              style: theme.textTheme.bodyLarge,
-                              textAlign: TextAlign.center,
-                            ),
-                          ],
-                        );
-                      }
-
-                      final state = snapshot.data!;
-
-                      if (state.abort) {
-                        return Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            SizedBox(height: 20),
-                            Icon(
-                              Icons.error_outline,
-                              size: 48,
-                              color: theme.colorScheme.error,
-                            ),
-                            SizedBox(height: 16),
-                            Text(
-                              'Process was cancelled',
-                              style: theme.textTheme.bodyLarge,
-                              textAlign: TextAlign.center,
-                            ),
-                          ],
-                        );
-                      }
-
-                      final allComplete =
-                          state.receivedFrom.length == state.devices.length;
-
-                      return Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          // Device list
-                          ...state.devices.map((device) {
-                            final isComplete = state.receivedFrom.any(
-                              (id) => deviceIdEquals(id, device),
-                            );
-                            return _buildDeviceCard(
-                              context,
-                              device,
-                              isComplete,
-                            );
-                          }).toList(),
-
-                          SizedBox(height: 20),
-
-                          // Bottom status message
-                          Center(
-                            child: Text(
-                              allComplete
-                                  ? 'Devices ready.'
-                                  : 'Please wait...',
-                              style: theme.textTheme.bodyLarge?.copyWith(
-                                fontWeight: allComplete
-                                    ? FontWeight.w600
-                                    : FontWeight.normal,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                          ),
-                        ],
-                      );
-                    },
+                    autoAdvance: false,
                   ),
                 ),
               ),
@@ -248,3 +198,6 @@ class NonceReplenishWidget extends StatelessWidget {
     );
   }
 }
+
+// Backwards compatibility alias
+typedef NonceReplenishWidget = NonceReplenishDialog;

--- a/frostsnapp/lib/nonce_replenish.dart
+++ b/frostsnapp/lib/nonce_replenish.dart
@@ -6,6 +6,8 @@ import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/nonce_replenish.dart';
 import 'package:frostsnap/theme.dart';
 
+// Standalone widget for nonce replenshment to be called after recovery, this is separate from the
+// streamlined widget that sits inside the wallet creation workflow.
 class NonceReplenishWidget extends StatelessWidget {
   final Stream<NonceReplenishState> stream;
   final VoidCallback? onCancel;
@@ -37,7 +39,7 @@ class NonceReplenishWidget extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   Text(
-                    isComplete ? 'Ready' : 'Finalizing..',
+                    isComplete ? 'Ready' : 'Preparing..',
                     style: theme.textTheme.titleSmall?.copyWith(
                       color: isComplete ? Colors.green : null,
                     ),
@@ -87,11 +89,11 @@ class NonceReplenishWidget extends StatelessWidget {
                     spacing: 12,
                     children: [
                       Text(
-                        'Finalizing wallet',
+                        'Preparing devices',
                         style: theme.textTheme.headlineLarge,
                       ),
                       Text(
-                        'Preparing for future signing sessions.',
+                        'Preparing devices for future signing sessions.',
                         style: theme.textTheme.bodyLarge,
                       ),
                     ],
@@ -167,8 +169,8 @@ class NonceReplenishWidget extends StatelessWidget {
                           Center(
                             child: Text(
                               allComplete
-                                  ? 'Wallet ready.'
-                                  : 'Finalizing wallet and preparing for future signing.',
+                                  ? 'Devices ready.'
+                                  : 'Preparing devices for future signing.',
                               style: theme.textTheme.bodyLarge?.copyWith(
                                 fontWeight: allComplete
                                     ? FontWeight.w600

--- a/frostsnapp/lib/nonce_replenish.dart
+++ b/frostsnapp/lib/nonce_replenish.dart
@@ -207,6 +207,3 @@ class NonceReplenishDialog extends StatelessWidget {
     );
   }
 }
-
-// Backwards compatibility alias
-typedef NonceReplenishWidget = NonceReplenishDialog;

--- a/frostsnapp/lib/nonce_replenish.dart
+++ b/frostsnapp/lib/nonce_replenish.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/material.dart';
+import 'package:frostsnap/global.dart';
+import 'package:frostsnap/id_ext.dart';
+import 'package:frostsnap/progress_indicator.dart';
+import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/src/rust/api/nonce_replenish.dart';
+import 'package:frostsnap/theme.dart';
+
+class NonceReplenishWidget extends StatelessWidget {
+  final Stream<NonceReplenishState> stream;
+  final VoidCallback? onCancel;
+
+  const NonceReplenishWidget({super.key, required this.stream, this.onCancel});
+
+  Widget _buildDeviceCard(
+    BuildContext context,
+    DeviceId deviceId,
+    bool isComplete,
+  ) {
+    final theme = Theme.of(context);
+    final deviceName = coord.getDeviceName(id: deviceId);
+    return Card.filled(
+      margin: EdgeInsets.symmetric(vertical: 4),
+      color: theme.colorScheme.surfaceContainerHigh,
+      clipBehavior: Clip.hardEdge,
+      child: ListTile(
+        title: Text(deviceName ?? 'Setting name..', style: monospaceTextStyle),
+        leading: Icon(Icons.key),
+        contentPadding: EdgeInsets.symmetric(horizontal: 16),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 8,
+          children: [
+            Flexible(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    isComplete ? 'Ready' : 'Finalizing..',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: isComplete ? Colors.green : null,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (isComplete)
+              Icon(Icons.check_circle_rounded, color: Colors.green)
+            else
+              SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final mediaQuery = MediaQuery.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Flexible(
+          child: CustomScrollView(
+            physics: ClampingScrollPhysics(),
+            shrinkWrap: true,
+            slivers: [
+              SliverAppBar(
+                title: Text('', style: theme.textTheme.titleMedium),
+                automaticallyImplyLeading: false,
+                pinned: true,
+              ),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 36, 20, 36),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    spacing: 12,
+                    children: [
+                      Text(
+                        'Finalizing wallet',
+                        style: theme.textTheme.headlineLarge,
+                      ),
+                      Text(
+                        'Preparing for future signing sessions.',
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
+                sliver: SliverToBoxAdapter(
+                  child: StreamBuilder<NonceReplenishState>(
+                    stream: stream,
+                    builder: (context, snapshot) {
+                      if (!snapshot.hasData) {
+                        return Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SizedBox(height: 20),
+                            FsProgressIndicator(),
+                            SizedBox(height: 20),
+                            Text(
+                              'Preparing for future signing..',
+                              style: theme.textTheme.bodyLarge,
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
+                        );
+                      }
+
+                      final state = snapshot.data!;
+
+                      if (state.abort) {
+                        return Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SizedBox(height: 20),
+                            Icon(
+                              Icons.error_outline,
+                              size: 48,
+                              color: theme.colorScheme.error,
+                            ),
+                            SizedBox(height: 16),
+                            Text(
+                              'Process was cancelled',
+                              style: theme.textTheme.bodyLarge,
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
+                        );
+                      }
+
+                      final allComplete =
+                          state.receivedFrom.length == state.devices.length;
+
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          // Device list
+                          ...state.devices.map((device) {
+                            final isComplete = state.receivedFrom.any(
+                              (id) => deviceIdEquals(id, device),
+                            );
+                            return _buildDeviceCard(
+                              context,
+                              device,
+                              isComplete,
+                            );
+                          }).toList(),
+
+                          SizedBox(height: 20),
+
+                          // Bottom status message
+                          Center(
+                            child: Text(
+                              allComplete
+                                  ? 'Wallet ready.'
+                                  : 'Finalizing wallet and preparing for future signing.',
+                              style: theme.textTheme.bodyLarge?.copyWith(
+                                fontWeight: allComplete
+                                    ? FontWeight.w600
+                                    : FontWeight.normal,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                ),
+              ),
+              SliverPadding(padding: EdgeInsets.only(bottom: 32)),
+            ],
+          ),
+        ),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Divider(height: 0),
+            Padding(
+              padding: EdgeInsets.all(
+                20,
+              ).add(EdgeInsets.only(bottom: mediaQuery.viewInsets.bottom)),
+              child: SafeArea(
+                top: false,
+                child: StreamBuilder<NonceReplenishState>(
+                  stream: stream,
+                  builder: (context, snapshot) {
+                    final state = snapshot.data;
+                    final allComplete =
+                        state != null &&
+                        state.receivedFrom.length == state.devices.length;
+                    final isAborted = state?.abort ?? false;
+
+                    return Row(
+                      mainAxisSize: MainAxisSize.max,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Flexible(
+                          child: TextButton(
+                            onPressed: (!allComplete && !isAborted)
+                                ? onCancel
+                                : null,
+                            child: Text(
+                              'Cancel',
+                              softWrap: false,
+                              overflow: TextOverflow.fade,
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          flex: 2,
+                          child: Align(
+                            alignment: AlignmentDirectional.centerEnd,
+                            child: FilledButton(
+                              onPressed: allComplete
+                                  ? () => Navigator.pop(context, true)
+                                  : null,
+                              child: Text(
+                                allComplete ? 'Done' : 'Please wait...',
+                                softWrap: false,
+                                overflow: TextOverflow.fade,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/frostsnapp/lib/nonce_replenish.dart
+++ b/frostsnapp/lib/nonce_replenish.dart
@@ -92,10 +92,6 @@ class NonceReplenishWidget extends StatelessWidget {
                         'Preparing devices',
                         style: theme.textTheme.headlineLarge,
                       ),
-                      Text(
-                        'Preparing devices for future signing sessions.',
-                        style: theme.textTheme.bodyLarge,
-                      ),
                     ],
                   ),
                 ),
@@ -114,7 +110,7 @@ class NonceReplenishWidget extends StatelessWidget {
                             FsProgressIndicator(),
                             SizedBox(height: 20),
                             Text(
-                              'Preparing for future signing..',
+                              'Please wait...',
                               style: theme.textTheme.bodyLarge,
                               textAlign: TextAlign.center,
                             ),
@@ -170,7 +166,7 @@ class NonceReplenishWidget extends StatelessWidget {
                             child: Text(
                               allComplete
                                   ? 'Devices ready.'
-                                  : 'Preparing devices for future signing.',
+                                  : 'Please wait...',
                               style: theme.textTheme.bodyLarge?.copyWith(
                                 fontWeight: allComplete
                                     ? FontWeight.w600

--- a/frostsnapp/lib/nonce_replenish.dart
+++ b/frostsnapp/lib/nonce_replenish.dart
@@ -6,12 +6,14 @@ import 'package:frostsnap/src/rust/api/nonce_replenish.dart';
 class MinimalNonceReplenishWidget extends StatelessWidget {
   final Stream<NonceReplenishState> stream;
   final VoidCallback? onComplete;
+  final VoidCallback? onAbort;
   final bool autoAdvance;
 
   const MinimalNonceReplenishWidget({
     super.key,
     required this.stream,
     this.onComplete,
+    this.onAbort,
     this.autoAdvance = false,
   });
 
@@ -35,6 +37,13 @@ class MinimalNonceReplenishWidget extends StatelessWidget {
             ],
           );
         } else {
+          // Handle abort (device disconnection)
+          if (state.abort && onAbort != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              onAbort!();
+            });
+          }
+
           final progress = state.receivedFrom.length;
           final total = state.devices.length;
           final isComplete = progress == total;

--- a/frostsnapp/lib/restoration.dart
+++ b/frostsnapp/lib/restoration.dart
@@ -18,7 +18,6 @@ import 'package:frostsnap/src/rust/api/recovery.dart';
 import 'package:frostsnap/stream_ext.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:frostsnap/wallet_add.dart';
-import 'package:frostsnap/wallet_create.dart';
 
 class WalletRecoveryPage extends StatelessWidget {
   final RestoringKey restoringKey;
@@ -120,8 +119,9 @@ class WalletRecoveryPage extends StatelessWidget {
                         .map((share) => share.deviceId)
                         .toList();
 
-                    final nonceRequest = await coord
-                        .createNonceRequest(devices: devices);
+                    final nonceRequest = await coord.createNonceRequest(
+                      devices: devices,
+                    );
 
                     if (nonceRequest.someNoncesRequested()) {
                       await MaybeFullscreenDialog.show<bool>(

--- a/frostsnapp/lib/restoration.dart
+++ b/frostsnapp/lib/restoration.dart
@@ -14,6 +14,7 @@ import 'package:frostsnap/snackbar.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/device_list.dart';
+import 'package:frostsnap/src/rust/api/nonce_replenish.dart';
 import 'package:frostsnap/src/rust/api/recovery.dart';
 import 'package:frostsnap/stream_ext.dart';
 import 'package:frostsnap/theme.dart';
@@ -115,32 +116,8 @@ class WalletRecoveryPage extends StatelessWidget {
                       encryptionKey: encryptionKey,
                     );
 
-                    final devices = restoringKey.sharesObtained
-                        .map((share) => share.deviceId)
-                        .toList();
-
-                    final nonceRequest = await coord.createNonceRequest(
-                      devices: devices,
-                    );
-
-                    if (nonceRequest.someNoncesRequested()) {
-                      await MaybeFullscreenDialog.show<bool>(
-                        context: context,
-                        child: NonceReplenishWidget(
-                          stream: coord
-                              .replenishNonces(
-                                nonceRequest: nonceRequest,
-                                devices: devices,
-                              )
-                              .toBehaviorSubject(),
-                          onCancel: () {
-                            coord.cancelProtocol();
-                            Navigator.pop(context, false);
-                          },
-                        ),
-                      );
-                    }
-
+                    // Nonce generation now happens when each device is enrolled,
+                    // not at the end of wallet restoration
                     onWalletRecovered(accessStructureRef);
                   } catch (e) {
                     if (context.mounted) {
@@ -389,7 +366,7 @@ class WalletRecoveryFlow extends StatefulWidget {
 }
 
 class _RecoveryFlowPrevState {
-  String currentStep = 'start';
+  RecoveryFlowStep currentStep = RecoveryFlowStep.start;
   RecoverShare? candidate;
   ShareCompatibility? compatibility;
   ConnectedDevice? blankDevice;
@@ -409,7 +386,7 @@ class _RecoveryFlowPrevState {
 class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
   late final MethodChoiceKind kind;
 
-  String currentStep = 'start';
+  RecoveryFlowStep currentStep = RecoveryFlowStep.start;
   RecoverShare? candidate;
   ShareCompatibility? compatibility;
   ConnectedDevice? blankDevice;
@@ -418,6 +395,8 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
   BitcoinNetwork? bitcoinNetwork;
   int? threshold;
   String? error;
+  Stream<NonceReplenishState>? activeNonceStream;
+  StreamSubscription? _nonceStreamSubscription;
 
   // For back gesture.
   final prevStates = List<_RecoveryFlowPrevState>.empty(growable: true);
@@ -454,11 +433,20 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
   }
 
   @override
+  void dispose() {
+    _nonceStreamSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
   void initState() {
     super.initState();
 
     final initialStep = widget.initialStep;
-    if (initialStep != null) currentStep = initialStep;
+    if (initialStep != null) {
+      // Map string to enum for backwards compatibility
+      currentStep = _mapStringToStep(initialStep);
+    }
 
     if (widget.continuing != null) {
       kind = MethodChoiceKind.continueRecovery;
@@ -480,7 +468,7 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
     _TitledWidget child;
 
     switch (currentStep) {
-      case 'wait_device':
+      case RecoveryFlowStep.waitDevice:
         child = _PlugInPromptView(
           continuing: widget.continuing,
           existing: widget.existing,
@@ -490,43 +478,138 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
                 pushPrevState();
                 candidate = detectedShare;
                 this.compatibility = compatibility;
-                currentStep = 'candidate_ready';
+                currentStep = RecoveryFlowStep.candidateReady;
               });
             }
           },
         );
         break;
-      case 'candidate_ready':
+      case RecoveryFlowStep.candidateReady:
         child = _CandidateReadyView(
           candidate: candidate!,
           compatibility: compatibility!,
           continuing: widget.continuing,
           existing: widget.existing,
+          onDeviceDisconnected: () {
+            // Device disconnected during nonce generation - go back to waiting
+            setState(() {
+              candidate = null;
+              compatibility = null;
+              currentStep = RecoveryFlowStep.waitDevice;
+            });
+          },
         );
         break;
-      case 'wait_physical_backup_device':
+      case RecoveryFlowStep.waitPhysicalBackupDevice:
         child = _PlugInBlankView(
           onBlankDeviceConnected: (device) {
             setState(() {
               pushPrevState();
               blankDevice = device;
-              currentStep = 'enter_device_name';
+              currentStep = RecoveryFlowStep.enterDeviceName;
             });
           },
         );
         break;
 
-      case 'enter_device_name':
+      case RecoveryFlowStep.enterDeviceName:
+        // Check if device is still connected
+        if (blankDevice == null) {
+          child = _ErrorView(
+            title: 'Device Disconnected',
+            message:
+                'The device was disconnected. Please reconnect and try again.',
+            onRetry: () {
+              setState(() {
+                currentStep = RecoveryFlowStep.waitPhysicalBackupDevice;
+                error = null;
+              });
+            },
+          );
+          break;
+        }
+
         child = _EnterDeviceNameView(
           deviceId: blankDevice!.id,
           onDeviceName: (name) {
-            setState(() {
-              pushPrevState();
-              currentStep = 'enter_backup';
-            });
+            // Check nonces synchronously, just like we do for existing device recovery
+            final device = blankDevice;
+            if (device == null) {
+              setState(() {
+                error = 'Device disconnected';
+                currentStep = RecoveryFlowStep.waitPhysicalBackupDevice;
+              });
+              return;
+            }
+
+            final nonceRequest = coord.createNonceRequest(devices: [device.id]);
+
+            if (nonceRequest.someNoncesRequested()) {
+              // Show nonce generation UI immediately
+              final stream = coord
+                  .replenishNonces(
+                    nonceRequest: nonceRequest,
+                    devices: [device.id],
+                  )
+                  .toBehaviorSubject();
+
+              setState(() {
+                pushPrevState();
+                activeNonceStream = stream;
+                currentStep = RecoveryFlowStep.generatingNonces;
+              });
+            } else {
+              // Go straight to backup entry
+              setState(() {
+                pushPrevState();
+                currentStep = RecoveryFlowStep.enterBackup;
+              });
+            }
           },
         );
-      case 'enter_backup':
+
+      case RecoveryFlowStep.generatingNonces:
+        if (activeNonceStream == null) {
+          // Stream not ready, go back
+          setState(() {
+            currentStep = RecoveryFlowStep.waitPhysicalBackupDevice;
+          });
+          child = _LoadingView(title: 'Preparing...', subtitle: null);
+        } else {
+          // Use the same enrollment dialog UI for consistency
+          child = _EnrollmentNonceDialog(
+            stream: activeNonceStream!,
+            deviceName: blankDevice != null
+                ? coord.getDeviceName(id: blankDevice!.id)
+                : null,
+            onComplete: () {
+              setState(() {
+                activeNonceStream = null;
+                currentStep = RecoveryFlowStep.enterBackup;
+              });
+            },
+            onCancel: () {
+              coord.cancelProtocol();
+              setState(() {
+                activeNonceStream = null;
+                currentStep = RecoveryFlowStep.waitPhysicalBackupDevice;
+              });
+            },
+            onError: (error) {
+              setState(() {
+                // Don't set error for device disconnection - just go back
+                if (!error.contains('disconnected')) {
+                  this.error = error;
+                }
+                activeNonceStream = null;
+                currentStep = RecoveryFlowStep.waitPhysicalBackupDevice;
+              });
+            },
+          );
+        }
+        break;
+
+      case RecoveryFlowStep.enterBackup:
         final stream = coord.tellDeviceToEnterPhysicalBackup(
           deviceId: blankDevice!.id,
         );
@@ -561,19 +644,19 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
                   );
                   setState(() {
                     pushPrevState();
-                    currentStep = "physical_backup_success";
+                    currentStep = RecoveryFlowStep.physicalBackupSuccess;
                   });
                 } else {
                   setState(() {
                     pushPrevState();
-                    currentStep = "physical_backup_fail";
+                    currentStep = RecoveryFlowStep.physicalBackupFail;
                   });
                 }
               }
             } catch (e) {
               setState(() {
                 pushPrevState();
-                currentStep = "physical_backup_fail";
+                currentStep = RecoveryFlowStep.physicalBackupFail;
                 error = e.toString();
               });
             }
@@ -581,13 +664,13 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
           onError: (e) {
             setState(() {
               pushPrevState();
-              currentStep = "physical_backup_fail";
+              currentStep = RecoveryFlowStep.physicalBackupFail;
               error = e.toString();
             });
           },
         );
         break;
-      case 'enter_restoration_details':
+      case RecoveryFlowStep.enterRestorationDetails:
         child = _EnterWalletNameView(
           initialWalletName: walletName,
           initialBitcoinNetwork: bitcoinNetwork,
@@ -596,13 +679,13 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
               pushPrevState();
               this.walletName = walletName;
               this.bitcoinNetwork = bitcoinNetwork;
-              currentStep = 'enter_threshold';
+              currentStep = RecoveryFlowStep.enterThreshold;
             });
           },
         );
         break;
 
-      case 'enter_threshold':
+      case RecoveryFlowStep.enterThreshold:
         child = _EnterThresholdView(
           walletName: walletName!,
           network: bitcoinNetwork!,
@@ -611,12 +694,12 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
             setState(() {
               pushPrevState();
               this.threshold = threshold;
-              currentStep = 'wait_physical_backup_device';
+              currentStep = RecoveryFlowStep.waitPhysicalBackupDevice;
             });
           },
         );
         break;
-      case 'physical_backup_success':
+      case RecoveryFlowStep.physicalBackupSuccess:
         child = _PhysicalBackupSuccessView(
           deviceName: coord.getDeviceName(id: blankDevice!.id)!,
           onClose: () {
@@ -624,14 +707,14 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
           },
         );
         break;
-      case 'physical_backup_fail':
+      case RecoveryFlowStep.physicalBackupFail:
         child = _PhysicalBackupFailView(
           errorMessage: error,
           compatibility: compatibility,
           onRetry: () {
             setState(() {
               pushPrevState();
-              currentStep = 'enter_backup';
+              currentStep = RecoveryFlowStep.enterBackup;
               error = null;
             });
           },
@@ -646,7 +729,7 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
           onDeviceChosen: () {
             setState(() {
               pushPrevState();
-              currentStep = 'wait_device';
+              currentStep = RecoveryFlowStep.waitDevice;
             });
           },
           onPhysicalBackupChosen: () {
@@ -654,11 +737,11 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
               switch (kind) {
                 case MethodChoiceKind.startRecovery:
                   pushPrevState();
-                  currentStep = "enter_restoration_details";
+                  currentStep = RecoveryFlowStep.enterRestorationDetails;
                   break;
                 default:
                   pushPrevState();
-                  currentStep = 'wait_physical_backup_device';
+                  currentStep = RecoveryFlowStep.waitPhysicalBackupDevice;
               }
             });
           },
@@ -736,12 +819,39 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
     }
   }
 
+  // Helper function for backwards compatibility with string-based initial steps
+  RecoveryFlowStep _mapStringToStep(String step) {
+    switch (step) {
+      case 'wait_device':
+        return RecoveryFlowStep.waitDevice;
+      case 'enter_restoration_details':
+        return RecoveryFlowStep.enterRestorationDetails;
+      default:
+        return RecoveryFlowStep.start;
+    }
+  }
+
   void goBackOrClose(BuildContext) {
     if (!tryPopPrevState(context)) Navigator.pop(context);
   }
 }
 
 enum MethodChoiceKind { startRecovery, continueRecovery, addToWallet }
+
+// Recovery flow step states
+enum RecoveryFlowStep {
+  start,
+  waitDevice,
+  candidateReady,
+  waitPhysicalBackupDevice,
+  enterDeviceName,
+  generatingNonces,
+  enterBackup,
+  enterRestorationDetails,
+  enterThreshold,
+  physicalBackupSuccess,
+  physicalBackupFail,
+}
 
 mixin _TitledWidget on Widget {
   String get titleText;
@@ -1460,7 +1570,10 @@ class _PlugInPromptViewState extends State<_PlugInPromptView> {
       );
     } else {
       // No error: show the spinner centered within the space.
-      displayWidget = CircularProgressIndicator();
+      displayWidget = Semantics(
+        label: 'Waiting for device to connect',
+        child: CircularProgressIndicator(),
+      );
     }
 
     final String prompt;
@@ -1500,34 +1613,155 @@ class _PlugInPromptViewState extends State<_PlugInPromptView> {
   }
 }
 
-class _CandidateReadyView extends StatelessWidget with _TitledWidget {
+class _CandidateReadyView extends StatefulWidget with _TitledWidget {
   final RecoverShare candidate;
   final ShareCompatibility compatibility;
   final RestorationId? continuing;
   final AccessStructureRef? existing;
+  final VoidCallback? onDeviceDisconnected;
 
   const _CandidateReadyView({
     required this.candidate,
     required this.compatibility,
     this.continuing,
     this.existing,
+    this.onDeviceDisconnected,
   });
 
   @override
   String get titleText => 'Restore with existing key';
 
   @override
-  Widget build(BuildContext context) {
-    final deviceName = coord.getDeviceName(id: candidate.heldBy) ?? '<empty>';
+  State<_CandidateReadyView> createState() => _CandidateReadyViewState();
+}
 
+class _CandidateReadyViewState extends State<_CandidateReadyView> {
+  bool _isGeneratingNonces = false;
+  bool _isEnrolling = false; // Prevent duplicate enrollments
+  Stream<NonceReplenishState>? _nonceStream;
+  StreamSubscription? _nonceStreamSubscription;
+
+  @override
+  void dispose() {
+    _nonceStreamSubscription?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _completeEnrollment(BuildContext context) async {
+    // Prevent duplicate enrollments
+    if (_isEnrolling) return;
+
+    setState(() {
+      _isEnrolling = true;
+    });
+
+    try {
+      RestorationId? restorationId;
+      if (widget.continuing != null) {
+        await coord.continueRestoringWalletFromDeviceShare(
+          restorationId: widget.continuing!,
+          recoverShare: widget.candidate,
+        );
+      } else if (widget.existing != null) {
+        final encryptionKey = await SecureKeyProvider.getEncryptionKey();
+        await coord.recoverShare(
+          accessStructureRef: widget.existing!,
+          recoverShare: widget.candidate,
+          encryptionKey: encryptionKey,
+        );
+      } else {
+        restorationId = await coord.startRestoringWalletFromDeviceShare(
+          recoverShare: widget.candidate,
+        );
+      }
+
+      if (context.mounted) {
+        Navigator.pop(context, restorationId);
+      }
+    } catch (e) {
+      if (context.mounted) {
+        setState(() {
+          _isEnrolling = false; // Reset on error
+        });
+        showErrorSnackbarBottom(context, "Failed to recover key: $e");
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final deviceName =
+        coord.getDeviceName(id: widget.candidate.heldBy) ?? '<empty>';
+
+    // If we're generating nonces, show the nonce UI inline
+    if (_isGeneratingNonces && _nonceStream != null) {
+      return Column(
+        key: const ValueKey('nonceGeneration'),
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          MaterialDialogCard(
+            title: SizedBox.shrink(),
+            content: Container(
+              constraints: BoxConstraints(minHeight: 120),
+              child: StreamBuilder<NonceReplenishState>(
+                stream: _nonceStream!,
+                builder: (context, snapshot) {
+                  final state = snapshot.data;
+
+                  // Handle abort (device disconnection)
+                  if (state != null && state.abort) {
+                    // Device disconnected - go back to waiting for device
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (mounted) {
+                        coord.cancelProtocol();
+                        _nonceStreamSubscription?.cancel();
+                        // Call parent callback to go back to waitDevice state
+                        widget.onDeviceDisconnected?.call();
+                      }
+                    });
+                    return SizedBox.shrink(); // Return early to avoid showing completion UI
+                  }
+
+                  // Handle completion
+                  if (state != null) {
+                    final isComplete =
+                        state.receivedFrom.length == state.devices.length;
+                    if (isComplete) {
+                      // Add a delay to show completion before proceeding
+                      Future.delayed(Durations.long1, () async {
+                        if (mounted) {
+                          await _nonceStreamSubscription?.cancel();
+                          // Don't change UI state - just complete enrollment which will navigate
+                          _completeEnrollment(context);
+                        }
+                      });
+                    }
+                  }
+
+                  return MinimalNonceReplenishWidget(
+                    stream: _nonceStream!,
+                    autoAdvance: false,
+                  );
+                },
+              ),
+            ),
+            actions:
+                [], // No cancel button - user can disconnect device to cancel
+          ),
+        ],
+      );
+    }
+
+    // Otherwise show the normal "Key ready" UI
     IconData icon;
     String title;
     String message;
     String buttonText;
     bool buttonFilled;
-    VoidCallback buttonAction;
+    VoidCallback? buttonAction;
 
-    switch (compatibility) {
+    switch (widget.compatibility) {
       case ShareCompatibility_Compatible() ||
           // we ignore the problem of different wallet names on the shares for now.
           // This happens when you eneter a physical backup and enter a different
@@ -1537,54 +1771,66 @@ class _CandidateReadyView extends StatelessWidget with _TitledWidget {
         icon = Icons.check_circle;
         title = 'Key ready';
 
-        if (continuing != null || existing != null) {
+        if (widget.continuing != null || widget.existing != null) {
           message =
-              'Key \'$deviceName\' is ready to be added to wallet \'${candidate.heldShare.keyName}\'.';
-          buttonText = 'Add to wallet';
+              'Key \'$deviceName\' is ready to be added to wallet \'${widget.candidate.heldShare.keyName}\'.';
+          buttonText = _isEnrolling ? 'Adding...' : 'Add to wallet';
         } else {
           message =
-              'Key \'$deviceName\' is part of a wallet called \'${candidate.heldShare.keyName}\'.';
-          buttonText = 'Start restoring';
+              'Key \'$deviceName\' is part of a wallet called \'${widget.candidate.heldShare.keyName}\'.';
+          buttonText = _isEnrolling ? 'Starting...' : 'Start restoring';
         }
 
         buttonFilled = true;
-        buttonAction = () async {
-          try {
-            RestorationId? restorationId;
-            if (continuing != null) {
-              await coord.continueRestoringWalletFromDeviceShare(
-                restorationId: continuing!,
-                recoverShare: candidate,
-              );
-            } else if (existing != null) {
-              final encryptionKey = await SecureKeyProvider.getEncryptionKey();
-              await coord.recoverShare(
-                accessStructureRef: existing!,
-                recoverShare: candidate,
-                encryptionKey: encryptionKey,
-              );
-            } else {
-              restorationId = await coord.startRestoringWalletFromDeviceShare(
-                recoverShare: candidate,
-              );
-            }
+        buttonAction = _isEnrolling
+            ? null
+            : () {
+                // Prevent duplicate clicks
+                if (_isEnrolling) return;
 
-            if (context.mounted) {
-              Navigator.pop(context, restorationId);
-            }
-          } catch (e) {
-            if (context.mounted) {
-              showErrorSnackbarBottom(context, "Failed to recover key: $e");
-            }
-          }
-        };
+                // Run async operations in a fire-and-forget manner
+                () async {
+                  try {
+                    // Check if device needs nonces before enrolling
+                    final nonceRequest = await coord.createNonceRequest(
+                      devices: [widget.candidate.heldBy],
+                    );
+
+                    if (nonceRequest.someNoncesRequested()) {
+                      // Show nonce generation inline instead of in a dialog
+                      if (mounted) {
+                        setState(() {
+                          _isGeneratingNonces = true;
+                          _nonceStream = coord
+                              .replenishNonces(
+                                nonceRequest: nonceRequest,
+                                devices: [widget.candidate.heldBy],
+                              )
+                              .toBehaviorSubject();
+                          // The abort flag in NonceReplenishState will handle device disconnection
+                        });
+                      }
+                      return; // Don't proceed until nonces are done
+                    }
+
+                    // If no nonces needed, proceed directly
+                    if (mounted) {
+                      _completeEnrollment(context);
+                    }
+                  } catch (e) {
+                    if (mounted) {
+                      showErrorSnackbarBottom(context, e.toString());
+                    }
+                  }
+                }();
+              };
 
         break;
 
       case ShareCompatibility_AlreadyGotIt():
         icon = Icons.info_rounded;
         title = 'Key already restored';
-        message = 'You’ve already restored "$deviceName".';
+        message = "You've already restored '$deviceName'.";
         buttonText = 'Close';
         buttonFilled = false;
         buttonAction = () => Navigator.pop(context);
@@ -1594,7 +1840,7 @@ class _CandidateReadyView extends StatelessWidget with _TitledWidget {
         icon = Icons.error_rounded;
         title = 'Key cannot be used';
         message =
-            'This key "$deviceName" is part of a different wallet called "${candidate.heldShare.keyName}".';
+            'This key "$deviceName" is part of a different wallet called "${widget.candidate.heldShare.keyName}".';
         buttonText = 'Close';
         buttonFilled = false;
         buttonAction = () => Navigator.pop(context);
@@ -1604,7 +1850,7 @@ class _CandidateReadyView extends StatelessWidget with _TitledWidget {
         icon = Icons.error_rounded;
         title = 'Backup does not match';
         message =
-            "You have already restored backup #$index on ‘${coord.getDeviceName(id: deviceId)!}’ and it doesn't match the one you just entered. Consider removing that key from the restoration first.";
+            "You have already restored backup #$index on '${coord.getDeviceName(id: deviceId)!}' and it doesn't match the one you just entered. Consider removing that key from the restoration first.";
         buttonText = 'Close';
         buttonFilled = false;
         buttonAction = () => Navigator.pop(context);
@@ -1699,6 +1945,201 @@ class _PhysicalBackupFailView extends StatelessWidget with _TitledWidget {
 
   @override
   String get titleText => '';
+}
+
+// Loading view with optional subtitle
+class _LoadingView extends StatelessWidget with _TitledWidget {
+  final String title;
+  final String? subtitle;
+
+  const _LoadingView({required this.title, this.subtitle});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AnimatedSwitcher(
+      duration: Durations.medium2,
+      child: Center(
+        key: ValueKey('$title$subtitle'),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 24),
+            AnimatedDefaultTextStyle(
+              style: theme.textTheme.titleMedium!,
+              duration: Durations.short4,
+              child: Text(title, textAlign: TextAlign.center),
+            ),
+            if (subtitle != null) ...[
+              SizedBox(height: 8),
+              AnimatedDefaultTextStyle(
+                style: theme.textTheme.bodyMedium!.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                duration: Durations.short4,
+                child: Text(subtitle!, textAlign: TextAlign.center),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  String get titleText => '';
+}
+
+// Error view with retry option
+class _ErrorView extends StatelessWidget with _TitledWidget {
+  final String title;
+  final String message;
+  final VoidCallback? onRetry;
+
+  const _ErrorView({required this.title, required this.message, this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return MaterialDialogCard(
+      iconData: Icons.error_outline_rounded,
+      title: Text(title),
+      content: Text(message, textAlign: TextAlign.center),
+      backgroundColor: theme.colorScheme.errorContainer,
+      textColor: theme.colorScheme.onErrorContainer,
+      iconColor: theme.colorScheme.onErrorContainer,
+      actions: onRetry != null
+          ? [
+              FilledButton.icon(
+                icon: Icon(Icons.refresh),
+                label: Text('Try Again'),
+                onPressed: onRetry,
+                style: FilledButton.styleFrom(
+                  backgroundColor: theme.colorScheme.error,
+                  foregroundColor: theme.colorScheme.onError,
+                ),
+              ),
+            ]
+          : [],
+    );
+  }
+
+  @override
+  String get titleText => 'Error';
+}
+
+// Unified nonce dialog for both enrollment and physical backup flows
+class _EnrollmentNonceDialog extends StatefulWidget with _TitledWidget {
+  final Stream<NonceReplenishState> stream;
+  final String? deviceName;
+  final VoidCallback onComplete;
+  final VoidCallback onCancel;
+  final Function(String) onError;
+
+  const _EnrollmentNonceDialog({
+    required this.stream,
+    this.deviceName,
+    required this.onComplete,
+    required this.onCancel,
+    required this.onError,
+  });
+
+  @override
+  State<_EnrollmentNonceDialog> createState() => _EnrollmentNonceDialogState();
+
+  @override
+  String get titleText => 'Preparing Device';
+}
+
+class _EnrollmentNonceDialogState extends State<_EnrollmentNonceDialog> {
+  bool _hasCompleted = false;
+  bool _hasErrored = false;
+  StreamSubscription? _streamSubscription;
+
+  @override
+  void dispose() {
+    _streamSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<NonceReplenishState>(
+      stream: widget.stream,
+      builder: (context, snapshot) {
+        // Handle stream errors
+        if (snapshot.hasError && !_hasErrored) {
+          _hasErrored = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              try {
+                widget.onError('Failed to prepare device: ${snapshot.error}');
+              } catch (e) {
+                debugPrint('Error in onError callback: $e');
+              }
+            }
+          });
+        }
+
+        final state = snapshot.data;
+
+        // Handle completion
+        if (state != null && !_hasCompleted && !_hasErrored) {
+          final isComplete = state.receivedFrom.length == state.devices.length;
+          if (isComplete) {
+            _hasCompleted = true;
+            // Add a delay to show the completion state before transitioning
+            Future.delayed(Durations.long1, () {
+              if (mounted) {
+                try {
+                  widget.onComplete();
+                } catch (e) {
+                  debugPrint('Error in onComplete callback: $e');
+                }
+              }
+            });
+          }
+        }
+
+        // Handle abort
+        if (state?.abort == true && !_hasCompleted && !_hasErrored) {
+          _hasErrored = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              try {
+                widget.onError('Device disconnected during preparation');
+              } catch (e) {
+                debugPrint('Error in onError callback: $e');
+              }
+            }
+          });
+        }
+
+        // Build compact dialog card without redundant icon/title
+        return Column(
+          key: const ValueKey('nonceGeneration'),
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            MaterialDialogCard(
+              title: SizedBox.shrink(),
+              content: Container(
+                constraints: BoxConstraints(minHeight: 120),
+                child: MinimalNonceReplenishWidget(
+                  stream: widget.stream,
+                  autoAdvance: false,
+                ),
+              ),
+              actions:
+                  [], // No cancel button - user can disconnect device to cancel
+              actionsAlignment: MainAxisAlignment.center,
+            ),
+          ],
+        );
+      },
+    );
+  }
 }
 
 void continueWalletRecoveryFlowDialog(

--- a/frostsnapp/lib/stream_ext.dart
+++ b/frostsnapp/lib/stream_ext.dart
@@ -12,19 +12,16 @@ extension StreamToBehaviorSubjectExtension<T> on Stream<T> {
         : BehaviorSubject<T>();
 
     // Listen to the original stream and forward events to the BehaviorSubject
-    // CRITICAL FIX: Store subscription so it can be cancelled
     late StreamSubscription<T> subscription;
     subscription = listen(
       (data) => subject.add(data),
       onError: (error) => subject.addError(error),
       onDone: () {
         subject.close();
-        // No need to cancel subscription here as stream is done
       },
     );
 
-    // CRITICAL FIX: Cancel subscription when subject is closed manually
-    // This prevents memory leaks when the subject is disposed before stream completes
+    // Cancel subscription when subject is closed to prevent memory leaks
     subject.onCancel = () {
       subscription.cancel();
     };
@@ -43,19 +40,16 @@ extension StreamToBehaviorSubjectExtension<T> on Stream<T> {
         : ReplaySubject<T>();
 
     // Listen to the original stream and forward events to the ReplaySubject
-    // CRITICAL FIX: Store subscription so it can be cancelled
     late StreamSubscription<T> subscription;
     subscription = listen(
       (data) => subject.add(data),
       onError: (error) => subject.addError(error),
       onDone: () {
         subject.close();
-        // No need to cancel subscription here as stream is done
       },
     );
 
-    // CRITICAL FIX: Cancel subscription when subject is closed manually
-    // This prevents memory leaks when the subject is disposed before stream completes
+    // Cancel subscription when subject is closed to prevent memory leaks
     subject.onCancel = () {
       subscription.cancel();
     };

--- a/frostsnapp/lib/stream_ext.dart
+++ b/frostsnapp/lib/stream_ext.dart
@@ -12,11 +12,22 @@ extension StreamToBehaviorSubjectExtension<T> on Stream<T> {
         : BehaviorSubject<T>();
 
     // Listen to the original stream and forward events to the BehaviorSubject
-    listen(
+    // CRITICAL FIX: Store subscription so it can be cancelled
+    late StreamSubscription<T> subscription;
+    subscription = listen(
       (data) => subject.add(data),
       onError: (error) => subject.addError(error),
-      onDone: () => subject.close(),
+      onDone: () {
+        subject.close();
+        // No need to cancel subscription here as stream is done
+      },
     );
+
+    // CRITICAL FIX: Cancel subscription when subject is closed manually
+    // This prevents memory leaks when the subject is disposed before stream completes
+    subject.onCancel = () {
+      subscription.cancel();
+    };
 
     return subject;
   }
@@ -32,11 +43,22 @@ extension StreamToBehaviorSubjectExtension<T> on Stream<T> {
         : ReplaySubject<T>();
 
     // Listen to the original stream and forward events to the ReplaySubject
-    listen(
+    // CRITICAL FIX: Store subscription so it can be cancelled
+    late StreamSubscription<T> subscription;
+    subscription = listen(
       (data) => subject.add(data),
       onError: (error) => subject.addError(error),
-      onDone: () => subject.close(),
+      onDone: () {
+        subject.close();
+        // No need to cancel subscription here as stream is done
+      },
     );
+
+    // CRITICAL FIX: Cancel subscription when subject is closed manually
+    // This prevents memory leaks when the subject is disposed before stream completes
+    subject.onCancel = () {
+      subscription.cancel();
+    };
 
     return subject;
   }

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -27,7 +27,6 @@ import 'package:frostsnap/settings.dart';
 import 'package:frostsnap/wallet_tx_details.dart';
 import 'package:rxdart/rxdart.dart';
 
-
 class Wallet {
   final SuperWallet superWallet;
   final MasterAppkey masterAppkey;

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -6,7 +6,6 @@ import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/device_list.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
-import 'package:frostsnap/keygen.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/nonce_replenish.dart';
 import 'package:frostsnap/psbt.dart';
@@ -28,7 +27,6 @@ import 'package:frostsnap/settings.dart';
 import 'package:frostsnap/wallet_tx_details.dart';
 import 'package:rxdart/rxdart.dart';
 
-import 'maybe_fullscreen_dialog.dart';
 
 class Wallet {
   final SuperWallet superWallet;

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -6,6 +6,9 @@ import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/device_list.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
+import 'package:frostsnap/keygen.dart';
+import 'package:frostsnap/maybe_fullscreen_dialog.dart';
+import 'package:frostsnap/nonce_replenish.dart';
 import 'package:frostsnap/psbt.dart';
 import 'package:frostsnap/restoration.dart';
 import 'package:frostsnap/sign_message.dart';
@@ -15,6 +18,7 @@ import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
 import 'package:frostsnap/src/rust/api/signing.dart';
 import 'package:frostsnap/src/rust/api/super_wallet.dart';
+import 'package:frostsnap/stream_ext.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:frostsnap/wallet_add.dart';
 import 'package:frostsnap/wallet_list_controller.dart';
@@ -143,8 +147,33 @@ class WalletHome extends StatelessWidget {
               WalletItemRestoration item => WalletRecoveryPage(
                 key: Key(item.restoringKey.restorationId.toHex()),
                 restoringKey: item.restoringKey,
-                onWalletRecovered: (accessStructureRef) {
+                onWalletRecovered: (accessStructureRef) async {
                   walletListController.selectWallet(accessStructureRef.keyId);
+
+                  final accessStructure = coord.getAccessStructure(
+                    asRef: accessStructureRef,
+                  )!; // we just made this access structure
+                  final devices = accessStructure.devices();
+                  final nonceRequest = await coord.createNonceRequest(
+                    devices: devices,
+                  );
+                  if (nonceRequest.someNoncesRequested()) {
+                    await MaybeFullscreenDialog.show<bool>(
+                      context: context,
+                      child: NonceReplenishWidget(
+                        stream: coord
+                            .replenishNonces(
+                              nonceRequest: nonceRequest,
+                              devices: devices,
+                            )
+                            .toBehaviorSubject(),
+                        onCancel: () {
+                          coord.cancelProtocol();
+                          Navigator.pop(context, false);
+                        },
+                      ),
+                    );
+                  }
                 },
               ),
             };

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -157,7 +157,7 @@ class WalletHome extends StatelessWidget {
                   if (nonceRequest.someNoncesRequested()) {
                     await MaybeFullscreenDialog.show<bool>(
                       context: context,
-                      child: NonceReplenishWidget(
+                      child: NonceReplenishDialog(
                         stream: coord
                             .replenishNonces(
                               nonceRequest: nonceRequest,

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -919,6 +919,15 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
             _controller.next(context);
           }
         },
+        onAbort: () {
+          // Device disconnected - go back to device selection
+          if (mounted) {
+            coord.cancelProtocol();
+            _controller._nonceStream = null;
+            _controller._step = WalletCreateStep.deviceCount;
+            _controller.notifyListeners();
+          }
+        },
       ),
     );
   }

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -366,13 +366,15 @@ class WalletCreateController extends ChangeNotifier {
       _step = nextStep;
       notifyListeners();
     } else {
-      // wallet creation complete - now show nonce replenishment
-      if (context.mounted) {
+      // wallet creation complete - now show nonce replenishment if required
+      final devices = form.selectedDevices.toList();
+      final nonceRequest = await coord.createNonceRequest(devices: devices);
+      if (context.mounted && nonceRequest.someNoncesRequested()) {
         await MaybeFullscreenDialog.show<bool>(
           context: context,
           child: NonceReplenishWidget(
             stream: coord
-                .replenishNonces(devices: form.selectedDevices.toList())
+                .replenishNonces(nonceRequest: nonceRequest, devices: devices)
                 .toBehaviorSubject(),
             onCancel: () {
               coord.cancelProtocol();

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -51,13 +51,8 @@ class WalletCreateController extends ChangeNotifier {
   late final StreamSubscription _deviceListSub;
   late DeviceListState _deviceList;
 
-  bool _nonceReplenishmentComplete = false;
-  bool get nonceReplenishmentComplete => _nonceReplenishmentComplete;
-
-  void setNonceReplenishmentComplete({required bool complete}) {
-    _nonceReplenishmentComplete = complete;
-    notifyListeners();
-  }
+  bool _hasAutoAdvanced = false;
+  Stream<NonceReplenishState>? _nonceStream;
 
   KeyGenState? _keygenState;
   late final FullscreenActionDialogController _keygenController;
@@ -236,12 +231,18 @@ class WalletCreateController extends ChangeNotifier {
     return nonceRequest.someNoncesRequested();
   }
 
+  Future<bool> _shouldShowNonceStep() async {
+    final devices = _form.selectedDevices.toList();
+    final nonceRequest = await coord.createNonceRequest(devices: devices);
+    return nonceRequest.someNoncesRequested();
+  }
+
   bool get canGoNext => switch (_step) {
     WalletCreateStep.name =>
       _nameError == null && _nameController.value.text.isNotEmpty,
     WalletCreateStep.deviceCount =>
       _deviceList.devices.isNotEmpty && !devicesNeedUpgrade && !devicesUsed,
-    WalletCreateStep.nonceReplenish => _nonceReplenishmentComplete,
+    WalletCreateStep.nonceReplenish => false, // Auto-advances, no manual next
     WalletCreateStep.deviceNames =>
       allWalletDevicesConnected && _form.allDevicesNamed,
     WalletCreateStep.threshold =>
@@ -265,7 +266,8 @@ class WalletCreateController extends ChangeNotifier {
   /// Does additional checks (maybe) and tries to populate the _form.
   Future<bool> _handleNext(BuildContext context) async {
     _isAnimationForward = true;
-    if (!canGoNext) return false;
+    // Skip canGoNext check for nonceReplenish since it auto-advances
+    if (_step != WalletCreateStep.nonceReplenish && !canGoNext) return false;
     switch (_step) {
       case WalletCreateStep.name:
         _form.name = _nameController.text;
@@ -273,6 +275,17 @@ class WalletCreateController extends ChangeNotifier {
       case WalletCreateStep.deviceCount:
         _form.selectedDevices.clear();
         _form.selectedDevices.addAll(_deviceList.devices.map((dev) => dev.id));
+        // Check if nonces are needed after selecting devices
+        final needsNonces = await _shouldShowNonceStep();
+        if (needsNonces) {
+          // Prepare the nonce stream for the next step
+          final devices = _form.selectedDevices.toList();
+          final nonceRequest = await coord.createNonceRequest(devices: devices);
+          _nonceStream = coord
+              .replenishNonces(nonceRequest: nonceRequest, devices: devices)
+              .toBehaviorSubject();
+          _hasAutoAdvanced = false; // Reset for this run
+        }
         return true;
       case WalletCreateStep.nonceReplenish:
         return true;
@@ -375,10 +388,32 @@ class WalletCreateController extends ChangeNotifier {
   }
 
   void next(BuildContext context) async {
-    if (!await _handleNext(context)) return;
-    if (!context.mounted) return;
+    if (!await _handleNext(context)) {
+      return;
+    }
+    if (!context.mounted) {
+      return;
+    }
 
-    final nextStep = WalletCreateStep.values.elementAtOrNull(_step.index + 1);
+    // Determine next step, potentially skipping nonce replenishment
+    WalletCreateStep? nextStep;
+    if (_step == WalletCreateStep.deviceCount) {
+      // Check if we should skip nonce replenishment
+      if (_nonceStream == null) {
+        // No nonces needed, skip to device names
+        nextStep = WalletCreateStep.deviceNames;
+      } else {
+        // Nonces needed, go to nonce replenishment
+        nextStep = WalletCreateStep.nonceReplenish;
+      }
+    } else if (_step == WalletCreateStep.nonceReplenish) {
+      // After nonce replenishment, go to device names
+      nextStep = WalletCreateStep.deviceNames;
+    } else {
+      // Normal progression
+      nextStep = WalletCreateStep.values.elementAtOrNull(_step.index + 1);
+    }
+    
     if (nextStep != null) {
       _step = nextStep;
       notifyListeners();
@@ -397,8 +432,24 @@ class WalletCreateController extends ChangeNotifier {
 
   void back(context) {
     if (!_handleBack(context)) return;
-    final prevIndex = _step.index - 1;
-    final prevStep = WalletCreateStep.values.elementAtOrNull(prevIndex);
+    
+    // Handle back navigation, skipping nonce step if it was skipped forward
+    WalletCreateStep? prevStep;
+    if (_step == WalletCreateStep.deviceNames) {
+      // Check if we should skip nonce step when going back
+      if (_nonceStream == null) {
+        // Nonce step was skipped, go directly to deviceCount
+        prevStep = WalletCreateStep.deviceCount;
+      } else {
+        // Nonce step was shown, go back to it
+        prevStep = WalletCreateStep.nonceReplenish;
+      }
+    } else {
+      // Normal back navigation
+      final prevIndex = _step.index - 1;
+      prevStep = WalletCreateStep.values.elementAtOrNull(prevIndex);
+    }
+    
     if (prevStep != null) {
       _step = prevStep;
       notifyListeners();
@@ -434,8 +485,7 @@ class WalletCreateController extends ChangeNotifier {
     WalletCreateStep.name => 'Choose a name for this wallet',
     WalletCreateStep.deviceCount =>
       'Connect devices to become keys for "${form.name ?? ''}"',
-    WalletCreateStep.nonceReplenish =>
-      "Preparing devices for future signing sessions.",
+    WalletCreateStep.nonceReplenish => '',
     WalletCreateStep.deviceNames => 'Each device needs a name to idenitfy it',
     WalletCreateStep.threshold =>
       'Decide how many devices will be required to sign transactions or to make changes to this wallet',
@@ -829,134 +879,115 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
   );
 
   Widget buildNonceReplenish(BuildContext context) {
-    return FutureBuilder<Stream<NonceReplenishState>?>(
-      future: _createNonceStream(),
-      builder: (context, futureSnapshot) {
-        if (futureSnapshot.connectionState != ConnectionState.done) {
-          return MultiSliver(
+    final theme = Theme.of(context);
+    
+    // Use the pre-initialized stream
+    final stream = _controller._nonceStream;
+    if (stream == null) {
+      // This shouldn't happen as we skip the step when no nonces are needed
+      // But if it does, auto-advance immediately
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && !_controller._hasAutoAdvanced) {
+          _controller._hasAutoAdvanced = true;
+          _controller.next(context);
+        }
+      });
+      return SliverToBoxAdapter(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              SliverDeviceList(
-                deviceBuilder: (context, device) => buildDevice(
-                  context,
-                  device,
-                  trailing: buildDeviceTrailingInfo(
-                    context,
-                    text: 'Preparing..',
-                    icon: null,
-                  ),
-                ),
-              ),
+              CircularProgressIndicator(),
+              SizedBox(height: 24),
+              Text('Initializing...', style: theme.textTheme.bodyLarge),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Nonces needed - show progress
+    return StreamBuilder<NonceReplenishState>(
+      stream: stream,
+      builder: (context, snapshot) {
+        final state = snapshot.data;
+        
+        Widget content;
+        if (state == null) {
+          content = Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(height: 24),
+              Text('Connecting...', style: theme.textTheme.bodyLarge),
             ],
           );
-        }
+        } else {
+          final progress = state.receivedFrom.length;
+          final total = state.devices.length;
+          final isComplete = progress == total;
 
-        final stream = futureSnapshot.data;
-        if (stream == null) {
-          // No nonces needed - all devices ready immediately
-          if (!_controller.nonceReplenishmentComplete) {
+          // Auto-advance when complete
+          if (isComplete && !_controller._hasAutoAdvanced) {
+            _controller._hasAutoAdvanced = true;
             WidgetsBinding.instance.addPostFrameCallback((_) {
               if (mounted) {
-                _controller.setNonceReplenishmentComplete(complete: true);
+                _controller.next(context);
               }
             });
           }
-          return MultiSliver(
+
+          content = Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              SliverDeviceList(
-                deviceBuilder: (context, device) => buildDevice(
-                  context,
-                  device,
-                  trailing: buildDeviceTrailingInfo(
-                    context,
-                    text: 'Ready',
-                    icon: Icons.check_circle_rounded,
-                    color: Colors.green,
+              Text(
+                'Preparing devices',
+                style: theme.textTheme.headlineMedium,
+              ),
+              SizedBox(height: 32),
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  SizedBox(
+                    width: 120,
+                    height: 120,
+                    child: CircularProgressIndicator(
+                      value: total > 0 ? progress / total : null,
+                      strokeWidth: 8,
+                      backgroundColor: theme.colorScheme.surfaceVariant,
+                    ),
                   ),
+                  Text(
+                    '$progress of $total',
+                    style: theme.textTheme.headlineSmall,
+                  ),
+                ],
+              ),
+              SizedBox(height: 16),
+              Text(
+                isComplete ? 'Complete!' : 'Please wait...',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: isComplete 
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurfaceVariant,
                 ),
               ),
             ],
           );
         }
-
-        // Nonces needed - show progress
-        return StreamBuilder<NonceReplenishState>(
-          stream: stream,
-          builder: (context, snapshot) {
-            if (!snapshot.hasData) {
-              return MultiSliver(
-                children: [
-                  SliverDeviceList(
-                    deviceBuilder: (context, device) => buildDevice(
-                      context,
-                      device,
-                      trailing: buildDeviceTrailingInfo(
-                        context,
-                        text: 'Preparing..',
-                        icon: null,
-                      ),
-                    ),
-                  ),
-                ],
-              );
-            }
-
-            final state = snapshot.data!;
-            final allComplete =
-                state.receivedFrom.length == state.devices.length;
-
-            // Update completion state only when it changes, after build
-            if (_controller.nonceReplenishmentComplete != allComplete) {
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (mounted) {
-                  _controller.setNonceReplenishmentComplete(
-                    complete: allComplete,
-                  );
-                }
-              });
-            }
-
-            return MultiSliver(
-              children: [
-                SliverDeviceList(
-                  deviceBuilder: (context, device) {
-                    final isDeviceComplete = state.receivedFrom.any(
-                      (deviceId) => deviceIdEquals(deviceId, device.id),
-                    );
-                    return buildDevice(
-                      context,
-                      device,
-                      trailing: buildDeviceTrailingInfo(
-                        context,
-                        text: isDeviceComplete ? 'Ready' : 'Preparing..',
-                        icon: isDeviceComplete
-                            ? Icons.check_circle_rounded
-                            : null,
-                        color: isDeviceComplete ? Colors.green : null,
-                      ),
-                    );
-                  },
-                ),
-              ],
-            );
-          },
+        
+        return SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 32),
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: content,
+            ),
+          ),
         );
       },
     );
-  }
-
-  Future<Stream<NonceReplenishState>?> _createNonceStream() async {
-    final form = _controller.form;
-    final devices = form.selectedDevices.toList();
-    final nonceRequest = await coord.createNonceRequest(devices: devices);
-
-    if (nonceRequest.someNoncesRequested()) {
-      return coord
-          .replenishNonces(nonceRequest: nonceRequest, devices: devices)
-          .toBehaviorSubject();
-    }
-
-    // No nonces needed
-    return null;
   }
 
   Widget buildBody(BuildContext context) {

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -376,10 +376,10 @@ class WalletCreateController extends ChangeNotifier {
             stream: coord
                 .replenishNonces(nonceRequest: nonceRequest, devices: devices)
                 .toBehaviorSubject(),
-            onCancel: () {
-              coord.cancelProtocol();
-              Navigator.pop(context, false);
-            },
+            // onCancel: () {
+            //   coord.cancelProtocol();
+            //   Navigator.pop(context, false);
+            // },
           ),
         );
 

--- a/frostsnapp/rust/src/api/mod.rs
+++ b/frostsnapp/rust/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod firmware_upgrade;
 pub mod init;
 pub mod keygen;
 pub mod log;
+pub mod nonce_replenish;
 pub mod port;
 pub mod qr;
 pub mod recovery;

--- a/frostsnapp/rust/src/api/nonce_replenish.rs
+++ b/frostsnapp/rust/src/api/nonce_replenish.rs
@@ -2,7 +2,7 @@ use crate::{frb_generated::StreamSink, sink_wrap::SinkWrap};
 use anyhow::Result;
 use flutter_rust_bridge::frb;
 pub use frostsnap_coordinator::nonce_replenish::NonceReplenishState;
-use frostsnap_core::DeviceId;
+use frostsnap_core::{coordinator::NonceReplenishRequest, DeviceId};
 
 #[frb(mirror(NonceReplenishState), unignore)]
 pub struct _NonceReplenishState {
@@ -12,14 +12,35 @@ pub struct _NonceReplenishState {
 }
 
 impl super::coordinator::Coordinator {
+    pub fn create_nonce_request(&self, devices: Vec<DeviceId>) -> NonceRequest {
+        NonceRequest {
+            inner: self
+                .0
+                .nonce_replenish_request(devices.into_iter().collect()),
+        }
+    }
+
     pub fn replenish_nonces(
         &self,
+        nonce_request: NonceRequest,
         devices: Vec<DeviceId>,
         event_stream: StreamSink<NonceReplenishState>,
     ) -> Result<()> {
-        self.0
-            .replenish_nonces(devices.into_iter().collect(), SinkWrap(event_stream))?;
+        self.0.replenish_nonces(
+            nonce_request.inner,
+            devices.into_iter().collect(),
+            SinkWrap(event_stream),
+        )
+    }
+}
 
-        Ok(())
+pub struct NonceRequest {
+    inner: NonceReplenishRequest,
+}
+
+impl NonceRequest {
+    #[frb(sync)]
+    pub fn some_nonces_requested(&self) -> bool {
+        self.inner.some_nonces_requested()
     }
 }

--- a/frostsnapp/rust/src/api/nonce_replenish.rs
+++ b/frostsnapp/rust/src/api/nonce_replenish.rs
@@ -12,6 +12,7 @@ pub struct _NonceReplenishState {
 }
 
 impl super::coordinator::Coordinator {
+    #[frb(sync)]
     pub fn create_nonce_request(&self, devices: Vec<DeviceId>) -> NonceRequest {
         NonceRequest {
             inner: self

--- a/frostsnapp/rust/src/api/nonce_replenish.rs
+++ b/frostsnapp/rust/src/api/nonce_replenish.rs
@@ -1,0 +1,25 @@
+use crate::{frb_generated::StreamSink, sink_wrap::SinkWrap};
+use anyhow::Result;
+use flutter_rust_bridge::frb;
+pub use frostsnap_coordinator::nonce_replenish::NonceReplenishState;
+use frostsnap_core::DeviceId;
+
+#[frb(mirror(NonceReplenishState), unignore)]
+pub struct _NonceReplenishState {
+    pub received_from: Vec<DeviceId>,
+    pub devices: Vec<DeviceId>,
+    pub abort: bool,
+}
+
+impl super::coordinator::Coordinator {
+    pub fn replenish_nonces(
+        &self,
+        devices: Vec<DeviceId>,
+        event_stream: StreamSink<NonceReplenishState>,
+    ) -> Result<()> {
+        self.0
+            .replenish_nonces(devices.into_iter().collect(), SinkWrap(event_stream))?;
+
+        Ok(())
+    }
+}

--- a/frostsnapp/rust/src/sink_wrap.rs
+++ b/frostsnapp/rust/src/sink_wrap.rs
@@ -7,6 +7,7 @@ use frostsnap_coordinator::{
     bitcoin::chain_sync::ChainStatus,
     firmware_upgrade::FirmwareUpgradeConfirmState,
     keygen::KeyGenState,
+    nonce_replenish::NonceReplenishState,
     signing::SigningState,
     verify_address::VerifyAddressProtocolState,
 };
@@ -34,6 +35,7 @@ bridge_sink!(f32);
 bridge_sink!(ChainStatus);
 bridge_sink!(DeviceListUpdate);
 bridge_sink!(KeyState);
+bridge_sink!(NonceReplenishState);
 bridge_sink!(());
 bridge_sink!(crate::api::recovery::EnterPhysicalBackupState);
 bridge_sink!(crate::api::recovery::WaitForRecoveryShareState);


### PR DESCRIPTION
There are two (similar) nonce-replenish UIs: one streamlined in the wallet creation workflow, and one generic that is called after wallet recovery. 

The determination on whether we need actually need to replenish nonces is somewhat unique since it is independent of having a key. For example you can reach the nonce-replenish screen and then back-out and revisit it. I have decided to always show it for consistency.

Should we also conditionally have this this generic widget display on the wallet home-screen if nonces get out of sync? Or alternatively, run it entirely in the background?

I stopped working on the device UI to display that it is generating nonces. The code for `BusyTask` was not being called due to new `WaitingFor` states, and after a minor rabbit hole trying to reimplement I decided to leave this out-of-scope for this PR.