### PR TITLE
Make showBottomSheetOrDialog accept a Widget title

### DIFF
--- a/frostsnapp/lib/address.dart
+++ b/frostsnapp/lib/address.dart
@@ -69,7 +69,7 @@ class _CheckAddressPageState extends State<CheckAddressPage> {
         ElevatedButton(
           onPressed: () => showBottomSheetOrDialog(
             context,
-            titleText: 'Receive',
+            title: Text('Receive'),
             builder: (context, scrollController) => walletCtx.wrap(
               ReceivePage(
                 wallet: walletCtx.wallet,

--- a/frostsnapp/lib/keygen.dart
+++ b/frostsnapp/lib/keygen.dart
@@ -476,7 +476,7 @@ showWalletCreatedDialog(
                 Navigator.of(context).pop();
                 showBottomSheetOrDialog(
                   context,
-                  titleText: 'Backup Checklist',
+                  title: Text('Backup Checklist'),
                   builder: (context, scrollController) =>
                       SuperWalletContext.of(context)!.tryWrapInWalletContext(
                         keyId: accessStructureRef.keyId,

--- a/frostsnapp/lib/theme.dart
+++ b/frostsnapp/lib/theme.dart
@@ -30,7 +30,7 @@ Color tintOnSurface(
 Future<T?> showBottomSheetOrDialog<T>(
   BuildContext context, {
   required Widget Function(BuildContext, ScrollController) builder,
-  required String titleText,
+  required Widget title,
   Color? backgroundColor,
 }) {
   final mediaSize = MediaQuery.sizeOf(context);
@@ -46,7 +46,7 @@ Future<T?> showBottomSheetOrDialog<T>(
       mainAxisSize: MainAxisSize.min,
       children: [
         TopBar(
-          titleText: titleText,
+          title: title,
           backgroundColor: backgroundColor,
           isDialog: isDialog,
           scrollController: scrollController,
@@ -142,14 +142,14 @@ class TopBar extends StatefulWidget implements PreferredSizeWidget {
   static const headerPadding = EdgeInsets.fromLTRB(20, 0, 20, 16);
   static const animationDuration = Durations.short3;
 
-  final String? titleText;
+  final Widget? title;
   final bool isDialog;
   final Color? backgroundColor;
   final ScrollController? scrollController;
 
   const TopBar({
     super.key,
-    this.titleText,
+    this.title,
     this.backgroundColor,
     this.scrollController,
     this.isDialog = false,
@@ -187,9 +187,9 @@ class _TopBarState extends State<TopBar> {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Expanded(
-            child: Text(
-              widget.titleText ?? '',
-              style: theme.textTheme.titleLarge,
+            child: DefaultTextStyle(
+              style: theme.textTheme.titleLarge!,
+              child: widget.title ?? const SizedBox.shrink(),
             ),
           ),
           if (widget.isDialog)

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -434,7 +434,7 @@ class _TxListState extends State<TxList> {
                   return TxSentOrReceivedTile(
                     onTap: () => showBottomSheetOrDialog(
                       context,
-                      titleText: 'Transaction Details',
+                      title: Text('Transaction Details'),
                       builder: (context, scrollController) => walletCtx.wrap(
                         TxDetailsPage.needsBroadcast(
                           scrollController: scrollController,
@@ -469,7 +469,7 @@ class _TxListState extends State<TxList> {
                   return TxSentOrReceivedTile(
                     onTap: () => showBottomSheetOrDialog(
                       context,
-                      titleText: 'Transaction Details',
+                      title: Text('Transaction Details'),
                       builder: (context, scrollController) => walletCtx.wrap(
                         TxDetailsPage.restoreSigning(
                           scrollController: scrollController,
@@ -517,7 +517,7 @@ class _TxListState extends State<TxList> {
                     txDetails: txDetails,
                     onTap: () => showBottomSheetOrDialog(
                       context,
-                      titleText: 'Transaction Details',
+                      title: Text('Transaction Details'),
                       builder: (context, scrollController) => walletCtx.wrap(
                         TxDetailsPage(
                           scrollController: scrollController,
@@ -736,7 +736,7 @@ class WalletBottomBar extends StatelessWidget {
                 child: ElevatedButton.icon(
                   onPressed: () => showBottomSheetOrDialog(
                     context,
-                    titleText: 'Receive',
+                    title: Text('Receive'),
                     builder: (context, scrollController) => walletCtx.wrap(
                       ReceivePage(
                         wallet: walletCtx.wallet,
@@ -758,7 +758,7 @@ class WalletBottomBar extends StatelessWidget {
                 child: ElevatedButton.icon(
                   onPressed: () => showBottomSheetOrDialog(
                     context,
-                    titleText: 'Send',
+                    title: Text('Send'),
                     builder: (context, scrollController) => walletCtx.wrap(
                       WalletSendPage(scrollController: scrollController),
                     ),
@@ -1062,7 +1062,7 @@ class BackupWarningBanner extends StatelessWidget {
   onTap(BuildContext context, WalletContext walletContext) {
     showBottomSheetOrDialog(
       context,
-      titleText: 'Backup Checklist',
+      title: Text('Backup Checklist'),
       builder: (context, scrollController) => walletContext.wrap(
         BackupChecklist(
           scrollController: scrollController,

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -772,7 +772,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
   ) async {
     await showBottomSheetOrDialog(
       context,
-      titleText: "Name device",
+      title: Text("Name device"),
       builder: (context, _) {
         final mediaQuery = MediaQuery.of(context);
         return SafeArea(

--- a/frostsnapp/lib/wallet_receive.dart
+++ b/frostsnapp/lib/wallet_receive.dart
@@ -565,7 +565,7 @@ class _ReceiverPageState extends State<ReceivePage> {
         txDetails: txDetails,
         onTap: () => showBottomSheetOrDialog(
           context,
-          titleText: 'Transaction Details',
+          title: Text('Transaction Details'),
           builder: (context, scrollController) => walletCtx.wrap(
             TxDetailsPage(
               scrollController: scrollController,
@@ -703,7 +703,7 @@ class _ReceiverPageState extends State<ReceivePage> {
     final walletCtx = WalletContext.of(context)!;
     showBottomSheetOrDialog(
       context,
-      titleText: 'Receive Addresses',
+      title: Text('Receive Addresses'),
       builder: (context, scrollController) {
         return walletCtx.wrap(
           AddressList(

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -521,7 +521,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
     nextPageOrPop(null);
     await showBottomSheetOrDialog(
       context,
-      titleText: 'Transaction Details',
+      title: Text('Transaction Details'),
       builder: (context, scrollController) => walletCtx.wrap(
         TxDetailsPage.startSigning(
           txStates: walletCtx.txStream,


### PR DESCRIPTION
## Summary
- Changed `showBottomSheetOrDialog` to accept `Widget title` instead of `String titleText`
- This allows for more flexible title customization in bottom sheets and dialogs

## Changes
- Modified `showBottomSheetOrDialog` function signature
- Updated `TopBar` widget to use `Widget? title`
- Updated all call sites to wrap string titles in `Text()` widgets