### PR TITLE
Wait after changing BAUD before OTA

### DIFF
--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -314,6 +314,7 @@ where
                                                             if downstream_connection_state == DownstreamConnectionState::Established { Some(downstream_serial.inner_mut()) } else { None },
                                                             &mut ui,
                                                             &mut sha256,
+                                                            timer
                                                         );
                                                         reset(&mut upstream_serial);
                                                     } else {

--- a/frostsnapp/lib/restoration.dart
+++ b/frostsnapp/lib/restoration.dart
@@ -793,7 +793,7 @@ class _EnterThresholdViewState extends State<_EnterThresholdView> {
           ),
           const SizedBox(height: 24),
           DropdownButtonFormField<int>(
-            value: _threshold,
+            initialValue: _threshold,
             decoration: const InputDecoration(
               labelText: 'Threshold',
               border: OutlineInputBorder(),

--- a/frostsnapp/pubspec.lock
+++ b/frostsnapp/pubspec.lock
@@ -531,26 +531,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -887,10 +887,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:
@@ -1007,10 +1007,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
Upgrading devices in a daisy chain from android mysteriously broke in 408870de7267d57097d874ada495d6f25169fd69.

The top-most device fails to read the ready signal from the downstream device after it has changed its BAUD rates, waiting forever it never reads in the firmware from the coordinator as it believes the downstream device is not ready.

Adding a small wait after changing BAUD rates ensures that every device is on the same page before communicating again.

edit: Lloyd acked me tacking on the app lint fixes here