### PR TITLE
Upgrade to bincode v2 and latest secp256kfun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,19 +228,20 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bincode"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
  "bincode_derive",
  "serde",
+ "unty",
 ]
 
 [[package]]
 name = "bincode_derive"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
 ]
@@ -1260,7 +1261,6 @@ name = "frostsnap_comms"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "bincode_derive",
  "frostsnap_core",
  "serde",
 ]
@@ -2567,10 +2567,10 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "schnorr_fun"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca8c22cb9ac73a4f0f1807ed9cfb8ca16de23c0ec520fc9475816eb3d6e7c13"
+source = "git+https://github.com/LLFourn/secp256kfun?rev=3831f3656e76c2f1680e573e04511d1077f7e9f0#3831f3656e76c2f1680e573e04511d1077f7e9f0"
 dependencies = [
  "bech32",
+ "bincode",
  "secp256kfun",
 ]
 
@@ -2606,7 +2606,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes 0.12.0",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -2651,8 +2651,7 @@ dependencies = [
 [[package]]
 name = "secp256kfun"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39f4d955c99d8f7487ab89f2b7d296a05d2a9288687464ce9743027f41dbc3f"
+source = "git+https://github.com/LLFourn/secp256kfun?rev=3831f3656e76c2f1680e573e04511d1077f7e9f0#3831f3656e76c2f1680e573e04511d1077f7e9f0"
 dependencies = [
  "bincode",
  "digest",
@@ -2669,8 +2668,7 @@ dependencies = [
 [[package]]
 name = "secp256kfun_arithmetic_macros"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b7c385a72530ebfe6010ff476ad9e235743fb33408a360052bb706f1481e1e"
+source = "git+https://github.com/LLFourn/secp256kfun?rev=3831f3656e76c2f1680e573e04511d1077f7e9f0#3831f3656e76c2f1680e573e04511d1077f7e9f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3222,6 +3220,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "ur"
 version = "0.4.1"
 source = "git+https://github.com/nickfarrow/ur-rs?rev=2e267e5e019b6c8129f66efba00327ff3d0ae5a4#2e267e5e019b6c8129f66efba00327ff3d0ae5a4"
@@ -3259,9 +3263,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtue"
-version = "0.0.13"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,17 @@ members = [
 ]
 resolver = "2"
 
+[patch.crates-io]
+schnorr_fun = { git = "https://github.com/LLFourn/secp256kfun", rev = "3831f3656e76c2f1680e573e04511d1077f7e9f0" }
+secp256kfun = { git = "https://github.com/LLFourn/secp256kfun", rev = "3831f3656e76c2f1680e573e04511d1077f7e9f0" }
+
 
 [workspace.dependencies]
-bincode = { version = "=2.0.0-rc.3", features = [
+bincode = { version = "2.0.1", features = [
     "serde",
     "alloc",
     "derive",
 ], default-features = false }
-# Can be removed after we upgrade to bincode version 2
-bincode_derive = { version = "=2.0.0-rc.3" }
 serde = { version = "1", features = [
     "derive",
     "alloc",

--- a/device/src/efuse.rs
+++ b/device/src/efuse.rs
@@ -290,7 +290,7 @@ impl frostsnap_core::device::DeviceSymmetricKeyGen for EfuseHmacKey<'_> {
     fn get_share_encryption_key(
         &mut self,
         access_structure_ref: AccessStructureRef,
-        party_index: frostsnap_core::schnorr_fun::frost::PartyIndex,
+        party_index: frostsnap_core::schnorr_fun::frost::ShareIndex,
         coord_key: frostsnap_core::CoordShareDecryptionContrib,
     ) -> frostsnap_core::SymmetricKey {
         let mut src = [0u8; 128];

--- a/device/src/io.rs
+++ b/device/src/io.rs
@@ -100,7 +100,10 @@ where
         Ok(())
     }
 
-    pub fn receive(&mut self) -> Option<Result<ReceiveSerial<D>, bincode::error::DecodeError>> {
+    pub fn receive(&mut self) -> Option<Result<ReceiveSerial<D>, bincode::error::DecodeError>>
+    where
+        ReceiveSerial<D>: bincode::Decode<()>,
+    {
         self.fill_buffer();
         if !self.ring_buffer.is_empty() {
             Some(bincode::decode_from_reader(self, BINCODE_CONFIG))

--- a/frostsnap_comms/Cargo.toml
+++ b/frostsnap_comms/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 frostsnap_core = { workspace = true  }
 serde = { workspace = true }
 bincode =  { workspace = true }
-bincode_derive.workspace =true
 
 [features]
 std = []

--- a/frostsnap_coordinator/src/persist.rs
+++ b/frostsnap_coordinator/src/persist.rs
@@ -236,7 +236,7 @@ impl<T: bincode::Encode> ToSql for BincodeWrapper<T> {
     }
 }
 
-impl<T: bincode::Decode> FromSql for BincodeWrapper<T> {
+impl<T: bincode::Decode<()>> FromSql for BincodeWrapper<T> {
     fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
         let (decoded, _len) =
             bincode::decode_from_slice::<T, _>(value.as_blob()?, bincode::config::standard())

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -21,10 +21,10 @@ use core::fmt;
 use frostsnap_macros::Kind;
 use schnorr_fun::{
     frost::{
-        self, chilldkg::encpedpop, CoordinatorSignSession, Frost, PartyIndex, SharedKey,
+        self, chilldkg::encpedpop, CoordinatorSignSession, Frost, ShareIndex, SharedKey,
         SignatureShare,
     },
-    fun::{poly, prelude::*},
+    fun::prelude::*,
     Schnorr, Signature,
 };
 use sha2::Sha256;
@@ -474,7 +474,7 @@ impl FrostCoordinator {
                                 device_to_share_index: device_to_share_index
                                     .into_iter()
                                     .map(|(device, share_index)| {
-                                        (device, PartyIndex::from(share_index))
+                                        (device, ShareIndex::from(share_index))
                                     })
                                     .collect(),
                                 acks: Default::default(),
@@ -679,7 +679,7 @@ impl FrostCoordinator {
         }
         let share_receivers_enckeys = device_to_share_index
             .iter()
-            .map(|(device, share_index)| (PartyIndex::from(*share_index), device.pubkey()))
+            .map(|(device, share_index)| (ShareIndex::from(*share_index), device.pubkey()))
             .collect::<BTreeMap<_, _>>();
         let schnorr = schnorr_fun::new_with_deterministic_nonces::<Sha256>();
         let mut input_aggregator = encpedpop::Coordinator::new(
@@ -986,7 +986,7 @@ impl FrostCoordinator {
         &mut self,
         name: String,
         root_shared_key: SharedKey,
-        device_to_share_index: BTreeMap<DeviceId, PartyIndex>,
+        device_to_share_index: BTreeMap<DeviceId, ShareIndex>,
         encryption_key: SymmetricKey,
         purpose: KeyPurpose,
         rng: &mut impl rand_core::RngCore,
@@ -1151,7 +1151,7 @@ impl FrostCoordinator {
         &self,
         device_id: DeviceId,
         access_structure_ref: AccessStructureRef,
-        index: PartyIndex,
+        index: ShareIndex,
     ) -> bool {
         let already_got_under_key = self
             .keys
@@ -1198,7 +1198,7 @@ impl SignSessionProgress {
         frost: &Frost<sha2::Sha256, NG>,
         app_shared_key: Xpub<SharedKey>,
         sign_item: SignItem,
-        nonces: BTreeMap<frost::PartyIndex, frost::Nonce>,
+        nonces: BTreeMap<frost::ShareIndex, frost::Nonce>,
         rng: &mut impl rand_core::RngCore,
     ) -> Self {
         let tweaked_key = sign_item.app_tweak.derive_xonly_key(&app_shared_key);
@@ -1302,7 +1302,7 @@ pub enum KeyGenState {
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, PartialEq)]
 pub struct CoordAccessStructure {
     app_shared_key: Xpub<SharedKey>,
-    device_to_share_index: BTreeMap<DeviceId, PartyIndex>,
+    device_to_share_index: BTreeMap<DeviceId, ShareIndex>,
     kind: crate::AccessStructureKind,
 }
 
@@ -1415,7 +1415,7 @@ pub enum Mutation {
     NewShare {
         access_structure_ref: AccessStructureRef,
         device_id: DeviceId,
-        share_index: PartyIndex,
+        share_index: ShareIndex,
     },
     DeleteKey(KeyId),
     NewNonces {

--- a/frostsnap_core/src/lib.rs
+++ b/frostsnap_core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod tweak;
 use core::ops::RangeBounds;
 
 use schnorr_fun::{
-    frost::{self, chilldkg::encpedpop, PartyIndex, SharedKey},
+    frost::{chilldkg::encpedpop, ShareImage, ShareIndex, SharedKey},
     fun::{hash::HashAdd, prelude::*},
 };
 pub use sha2;
@@ -262,7 +262,7 @@ impl CoordShareDecryptionContrib {
     /// knowledge of the main polynomial.
     pub fn for_master_share(
         device_id: DeviceId,
-        share_index: PartyIndex,
+        share_index: ShareIndex,
         shared_key: &SharedKey<Normal, impl ZeroChoice>,
     ) -> Self {
         Self(
@@ -316,25 +316,6 @@ impl_fromstr_deserialize! {
     }
 }
 
-#[derive(Clone, Copy, Debug, bincode::Encode, bincode::Decode, Ord, PartialOrd, PartialEq, Eq)]
-pub struct ShareImage {
-    pub share_index: PartyIndex,
-    pub point: Point<Normal, Public, Zero>,
-}
-
-impl ShareImage {
-    pub fn from_secret(secret_share: frost::SecretShare) -> Self {
-        Self {
-            share_index: secret_share.index,
-            point: g!(secret_share.share * G).normalize(),
-        }
-    }
-
-    pub fn share_index_u16(&self) -> u16 {
-        // XXX: temporary HACK
-        u16::from_str_radix(&self.share_index.to_string(), 16).expect("share index is small")
-    }
-}
 // Uniquely identifies an access structure for a particular `key_id`.
 #[derive(
     Debug, Clone, Copy, bincode::Encode, bincode::Decode, PartialEq, Eq, Hash, Ord, PartialOrd,

--- a/frostsnap_core/src/macros.rs
+++ b/frostsnap_core/src/macros.rs
@@ -146,7 +146,7 @@ macro_rules! impl_fromstr_deserialize {
             }
         }
 
-        impl$(<$($tpl $(:$tcl)?),*>)? $crate::bincode::de::Decode for $type {
+        impl<__Context, $($($tpl $(:$tcl)?),*)?> $crate::bincode::de::Decode<__Context> for $type {
             fn decode<D: $crate::bincode::de::Decoder>(decoder: &mut D) -> Result<Self, $crate::bincode::error::DecodeError> {
                 use $crate::bincode::de::read::Reader;
                 let mut $input = [0u8; $len];
@@ -157,7 +157,7 @@ macro_rules! impl_fromstr_deserialize {
             }
         }
 
-        impl<'de, $($($tpl $(:$tcl)?),*)?> $crate::bincode::BorrowDecode<'de> for $type {
+        impl<'de, __Context, $($($tpl $(:$tcl)?),*)?> $crate::bincode::BorrowDecode<'de, __Context> for $type {
             fn borrow_decode<D: $crate::bincode::de::BorrowDecoder<'de>>(
                 decoder: &mut D,
             ) -> core::result::Result<Self, $crate::bincode::error::DecodeError> {

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -14,7 +14,7 @@ use alloc::{
 use core::num::NonZeroU32;
 use frostsnap_macros::Kind;
 use schnorr_fun::binonce;
-use schnorr_fun::frost::{chilldkg::encpedpop, PartyIndex};
+use schnorr_fun::frost::{chilldkg::encpedpop, ShareIndex};
 use schnorr_fun::frost::{SharedKey, SignatureShare};
 use schnorr_fun::fun::prelude::*;
 use schnorr_fun::fun::Point;
@@ -63,14 +63,14 @@ pub enum CoordinatorRestoration {
     DisplayBackup {
         access_structure_ref: AccessStructureRef,
         coord_share_decryption_contrib: CoordShareDecryptionContrib,
-        party_index: PartyIndex,
+        party_index: ShareIndex,
     },
     RequestHeldShares,
 }
 
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, PartialEq)]
 pub struct ConsolidateBackup {
-    pub share_index: PartyIndex,
+    pub share_index: ShareIndex,
     pub root_shared_key: SharedKey,
     pub key_name: String,
     pub purpose: KeyPurpose,
@@ -78,7 +78,7 @@ pub struct ConsolidateBackup {
 
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, PartialEq)]
 pub struct GroupSignReq<ST = WireSignTask> {
-    pub parties: BTreeSet<PartyIndex>,
+    pub parties: BTreeSet<ShareIndex>,
     pub agg_nonces: Vec<binonce::Nonce<Zero>>,
     pub sign_task: ST,
     pub access_structure_id: AccessStructureId,
@@ -141,7 +141,7 @@ pub enum DeviceRestoration {
     PhysicalSaved(ShareImage),
     FinishedConsolidation {
         access_structure_ref: AccessStructureRef,
-        share_index: PartyIndex,
+        share_index: ShareIndex,
     },
     HeldShares(Vec<HeldShare>),
 }

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -1,7 +1,7 @@
 use crate::{bitcoin_transaction, device::KeyPurpose, tweak::AppTweak, MasterAppkey};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use bitcoin::hashes::Hash;
-use schnorr_fun::{fun::marker::*, Message, Schnorr, Signature};
+use schnorr_fun::{Message, Schnorr, Signature};
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Hash)]
 pub enum WireSignTask {
@@ -153,9 +153,9 @@ impl SignItem {
         schnorr.verify(&derived_key, self.schnorr_fun_message(), signature)
     }
 
-    pub fn schnorr_fun_message(&'_ self) -> schnorr_fun::Message<'_, Public> {
+    pub fn schnorr_fun_message(&self) -> schnorr_fun::Message<'_> {
         match self.app_tweak {
-            AppTweak::TestMessage => Message::plain("frostsnap-test", &self.message[..]),
+            AppTweak::TestMessage => Message::new("frostsnap-test", &self.message[..]),
             AppTweak::Bitcoin(_) => Message::raw(&self.message[..]),
             AppTweak::Nostr => Message::raw(&self.message[..]),
         }

--- a/frostsnap_core/src/symmetric_encryption.rs
+++ b/frostsnap_core/src/symmetric_encryption.rs
@@ -12,7 +12,7 @@ pub struct Ciphertext<const N: usize, T> {
     tag: [u8; 16],
 }
 
-impl<const N: usize, T: bincode::Encode + bincode::Decode> Ciphertext<N, T> {
+impl<const N: usize, T: bincode::Encode + bincode::Decode<()>> Ciphertext<N, T> {
     pub fn decrypt(&self, encryption_key: SymmetricKey) -> Option<T> {
         let cipher = ChaCha20Poly1305::new(&encryption_key.0.into());
         let mut plaintext = self.data;

--- a/frostsnap_core/src/tweak.rs
+++ b/frostsnap_core/src/tweak.rs
@@ -429,6 +429,10 @@ mod test {
             3,
             5,
             5,
+            schnorr_fun::frost::Fingerprint {
+                tag: "frostsnap-v0",
+                bit_length: 10,
+            },
             &mut rand::thread_rng(),
         );
 

--- a/frostsnap_core/tests/common/mod.rs
+++ b/frostsnap_core/tests/common/mod.rs
@@ -11,7 +11,7 @@ use frostsnap_core::{
 };
 use frostsnap_core::{AccessStructureRef, MessageResult};
 use rand::RngCore;
-use schnorr_fun::frost::PartyIndex;
+use schnorr_fun::frost::ShareIndex;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 pub const TEST_ENCRYPTION_KEY: SymmetricKey = SymmetricKey([42u8; 32]);
@@ -76,7 +76,7 @@ impl DeviceSymmetricKeyGen for TestDeviceKeyGen {
     fn get_share_encryption_key(
         &mut self,
         _access_structure_ref: AccessStructureRef,
-        _party_index: PartyIndex,
+        _party_index: ShareIndex,
         _coord_key: frostsnap_core::CoordShareDecryptionContrib,
     ) -> SymmetricKey {
         TEST_ENCRYPTION_KEY

--- a/frostsnap_core/tests/endtoend.rs
+++ b/frostsnap_core/tests/endtoend.rs
@@ -145,7 +145,7 @@ impl common::Env for TestEnv {
                                     if !run.coordinator.knows_about_share(
                                         held_by,
                                         access_structure_ref,
-                                        held_share.share_image.share_index,
+                                        held_share.share_image.index,
                                     ) {
                                         run.coordinator
                                             .recover_share(

--- a/frostsnap_embedded/src/ab_write.rs
+++ b/frostsnap_embedded/src/ab_write.rs
@@ -57,10 +57,7 @@ impl<'a, S: NorFlash> AbSlot<'a, S> {
         self.slots[other_slot].write(slot_value);
     }
 
-    pub fn read<T>(&self) -> Option<T>
-    where
-        T: bincode::Decode,
-    {
+    pub fn read<T: bincode::Decode<()>>(&self) -> Option<T> {
         let current_slot = self.current_slot();
         let slot_value = self.slots[current_slot].read();
         slot_value.map(|slot_value| slot_value.value)
@@ -99,7 +96,7 @@ struct Slot<'a, S> {
 
 impl<S: NorFlash> Slot<'_, S> {
     // TODO: justify no erorr type here
-    pub fn read<T: bincode::Decode>(&self) -> Option<SlotValue<T>> {
+    pub fn read<T: bincode::Decode<()>>(&self) -> Option<SlotValue<T>> {
         let value = bincode::decode_from_reader::<SlotValue<T>, _, _>(
             self.flash.bincode_reader(),
             ABWRITE_BINCODE_CONFIG,

--- a/frostsnap_embedded/src/nor_flash_log.rs
+++ b/frostsnap_embedded/src/nor_flash_log.rs
@@ -43,7 +43,7 @@ impl<'a, S: NorFlash> NorFlashLog<'a, S> {
         Ok(())
     }
 
-    pub fn seek_iter<I: bincode::Decode>(
+    pub fn seek_iter<I: bincode::Decode<()>>(
         &mut self,
     ) -> impl Iterator<Item = Result<I, bincode::error::DecodeError>> + use<'_, 'a, S, I> {
         self.word_pos = 0;

--- a/frostsnapp/rust/src/api/coordinator.rs
+++ b/frostsnapp/rust/src/api/coordinator.rs
@@ -6,7 +6,7 @@ pub use frostsnap_core::coordinator::CoordAccessStructure as AccessStructure;
 pub use frostsnap_core::device::KeyPurpose;
 use frostsnap_core::{
     coordinator::CoordFrostKey,
-    schnorr_fun::frost::{PartyIndex, SharedKey},
+    schnorr_fun::frost::{ShareIndex, SharedKey},
     tweak::Xpub,
     AccessStructureId, AccessStructureRef, DeviceId, KeyId, MasterAppkey, SymmetricKey,
 };
@@ -81,7 +81,7 @@ impl From<CoordFrostKey> for FrostKey {
 #[allow(unused)]
 pub struct _AccessStructure {
     app_shared_key: Xpub<SharedKey>,
-    device_to_share_index: BTreeMap<DeviceId, PartyIndex>,
+    device_to_share_index: BTreeMap<DeviceId, ShareIndex>,
 }
 
 #[frb(external)]

--- a/frostsnapp/rust/src/api/recovery.rs
+++ b/frostsnapp/rust/src/api/recovery.rs
@@ -10,7 +10,7 @@ pub use frostsnap_core::coordinator::restoration::{
 };
 use frostsnap_core::{device::KeyPurpose, AccessStructureRef, DeviceId, RestorationId};
 
-pub use frostsnap_core::{message::HeldShare, ShareImage};
+pub use frostsnap_core::{message::HeldShare, schnorr_fun::frost::ShareImage};
 use std::collections::HashSet;
 use tracing::{event, Level};
 
@@ -78,7 +78,12 @@ impl super::coordinator::Coordinator {
                 AlreadyGotThisShare => ShareCompatibility::AlreadyGotIt,
                 ConflictingShareImage { conflicts_with } => ShareCompatibility::ConflictsWith {
                     device_id: conflicts_with,
-                    index: recover_share.held_share.share_image.share_index_u16(),
+                    index: recover_share
+                        .held_share
+                        .share_image
+                        .index
+                        .try_into()
+                        .expect("should be small"),
                 },
             },
         }
@@ -209,7 +214,12 @@ impl super::coordinator::Coordinator {
                 AlreadyGotThisShare => ShareCompatibility::AlreadyGotIt,
                 ConflictingShareImage { conflicts_with } => ShareCompatibility::ConflictsWith {
                     device_id: conflicts_with,
-                    index: phase.backup.share_image.share_index_u16(),
+                    index: phase
+                        .backup
+                        .share_image
+                        .index
+                        .try_into()
+                        .expect("should be small"),
                 },
             },
         }

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -1006,7 +1006,7 @@ impl FfiCoordinator {
             {
                 return device_id == phase.from
                     && rid == restoration_id
-                    && share_index == phase.backup.share_image.share_index;
+                    && share_index == phase.backup.share_image.index;
             }
             false
         });
@@ -1054,7 +1054,7 @@ impl FfiCoordinator {
             {
                 return device_id == phase.from
                     && assid == access_structure_ref
-                    && share_index == phase.backup.share_image.share_index;
+                    && share_index == phase.backup.share_image.index;
             }
             false
         });


### PR DESCRIPTION
- Upgrade bincode from rc3 to 2.0.1
- Update to latest secp256kfun/schnorr_fun master
- Migrate from PartyIndex to ShareIndex
- Use upstream ShareImage instead of local definition
- Fix bincode::Decode bounds to use () context where functions control decoding