### PR TITLE
Use HMAC for Device Secrets

### DIFF
--- a/device/src/efuse.rs
+++ b/device/src/efuse.rs
@@ -1,4 +1,3 @@
-// use core::num::NonZeroU8;
 use esp_hal::efuse::{self as hal_efuse, Efuse};
 use esp_hal::hmac::{self, Hmac};
 use esp_hal::peripherals::EFUSE;
@@ -251,7 +250,7 @@ impl<'a> EfuseHmacKey<'a> {
 
     pub fn hash(
         &mut self,
-        domain_separator: &'static str,
+        domain_separator: &str,
         input: &[u8],
     ) -> Result<[u8; 32], esp_hal::hmac::Error> {
         let mut hmac = self.hmac.borrow_mut();
@@ -286,7 +285,7 @@ impl<'a> EfuseHmacKey<'a> {
     }
 }
 
-impl frostsnap_core::device::DeviceSymmetricKeyGen for EfuseHmacKey<'_> {
+impl frostsnap_core::device::DeviceHmacKeys for EfuseHmacKey<'_> {
     fn get_share_encryption_key(
         &mut self,
         access_structure_ref: AccessStructureRef,
@@ -307,5 +306,9 @@ impl frostsnap_core::device::DeviceSymmetricKeyGen for EfuseHmacKey<'_> {
         let output = self.hash("share-encryption", &src).unwrap();
 
         frostsnap_core::SymmetricKey(output)
+    }
+
+    fn derive_nonce_seed(&mut self, domain: &str, input: &[u8; 32]) -> [u8; 32] {
+        self.hash(domain, input).unwrap()
     }
 }

--- a/device/src/efuse.rs
+++ b/device/src/efuse.rs
@@ -308,7 +308,7 @@ impl frostsnap_core::device::DeviceHmacKeys for EfuseHmacKey<'_> {
         frostsnap_core::SymmetricKey(output)
     }
 
-    fn derive_nonce_seed(&mut self, domain: &str, input: &[u8; 32]) -> [u8; 32] {
-        self.hash(domain, input).unwrap()
+    fn derive_prng_seed(&mut self, input: &[u8; 32]) -> [u8; 32] {
+        self.hash("nonce-generation", input).unwrap()
     }
 }

--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -83,7 +83,11 @@ where
         // The event log gets the reset of the sectors
         let mut mutation_log = MutationLog::new(share_partition, nvs_partition);
 
-        let mut signer = FrostSigner::new(header.device_keypair(), nonce_slots);
+        // Since this call is made upon startup there is some risk of side-channel attacks, and so
+        // we choose to use the less important fixed-entropy HMAC rather than the extremely important
+        // share-encryption HMAC for this device keypair.
+        let device_keypair = header.device_keypair(&mut hmac_keys.fixed_entropy);
+        let mut signer = FrostSigner::new(device_keypair, nonce_slots);
 
         let mut name = None;
 

--- a/device/src/flash/header.rs
+++ b/device/src/flash/header.rs
@@ -21,9 +21,9 @@ pub struct Header {
 impl Header {
     pub fn device_keypair(&self, hmac: &mut EfuseHmacKey) -> KeyPair {
         KeyPair::new(match self.body {
-            HeaderBody::V0 { static_hmac_seed } => {
+            HeaderBody::V0 { device_id_seed } => {
                 let secret_scalar_bytes = hmac
-                    .hash("frostsnap-device-keypair", &static_hmac_seed)
+                    .hash("frostsnap-device-keypair", &device_id_seed)
                     .unwrap();
                 Scalar::from_slice_mod_order(&secret_scalar_bytes)
                     .expect("just got 32 bytes from fixed entropy hash")
@@ -36,21 +36,21 @@ impl Header {
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode)]
 pub enum HeaderBody {
-    V0 { static_hmac_seed: [u8; 32] },
+    V0 { device_id_seed: [u8; 32] },
 }
 
 impl Header {
-    pub fn new(static_hmac_seed: [u8; 32]) -> Self {
+    pub fn new(device_id_seed: [u8; 32]) -> Self {
         Header {
             magic_bytes: Default::default(),
-            body: HeaderBody::V0 { static_hmac_seed },
+            body: HeaderBody::V0 { device_id_seed },
         }
     }
 
     pub fn init(rng: &mut impl rand_core::RngCore) -> Self {
-        let mut static_hmac_seed = [0u8; 32];
-        rng.fill_bytes(&mut static_hmac_seed);
-        Header::new(static_hmac_seed)
+        let mut device_id_seed = [0u8; 32];
+        rng.fill_bytes(&mut device_id_seed);
+        Header::new(device_id_seed)
     }
 }
 

--- a/frostsnap_core/src/device.rs
+++ b/frostsnap_core/src/device.rs
@@ -812,7 +812,7 @@ pub trait DeviceHmacKeys {
         coord_key: CoordShareDecryptionContrib,
     ) -> SymmetricKey;
 
-    fn derive_nonce_seed(&mut self, domain: &str, input: &[u8; 32]) -> [u8; 32];
+    fn derive_prng_seed(&mut self, input: &[u8; 32]) -> [u8; 32];
 }
 
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, PartialEq)]

--- a/frostsnap_core/src/device/restoration.rs
+++ b/frostsnap_core/src/device/restoration.rs
@@ -231,7 +231,7 @@ impl<S: Debug + NonceStreamSlot> FrostSigner<S> {
     pub fn display_backup_ack(
         &mut self,
         phase: BackupDisplayPhase,
-        symm_keygen: &mut impl DeviceSymmetricKeyGen,
+        symm_keygen: &mut impl DeviceHmacKeys,
     ) -> Result<Vec<DeviceSend>, ActionError> {
         let key_data = self
             .keys
@@ -324,7 +324,7 @@ impl<S: Debug + NonceStreamSlot> FrostSigner<S> {
 
     pub fn finish_consolidation(
         &mut self,
-        symm_keygen: &mut impl DeviceSymmetricKeyGen,
+        symm_keygen: &mut impl DeviceHmacKeys,
         phase: ConsolidatePhase,
         rng: &mut impl rand_core::RngCore,
     ) -> impl IntoIterator<Item = DeviceSend> {

--- a/frostsnap_core/src/device/restoration.rs
+++ b/frostsnap_core/src/device/restoration.rs
@@ -231,7 +231,7 @@ impl<S: Debug + NonceStreamSlot> FrostSigner<S> {
     pub fn display_backup_ack(
         &mut self,
         phase: BackupDisplayPhase,
-        symm_keygen: &mut impl DeviceHmacKeys,
+        symm_keygen: &mut impl DeviceSecretDerivation,
     ) -> Result<Vec<DeviceSend>, ActionError> {
         let key_data = self
             .keys
@@ -324,7 +324,7 @@ impl<S: Debug + NonceStreamSlot> FrostSigner<S> {
 
     pub fn finish_consolidation(
         &mut self,
-        symm_keygen: &mut impl DeviceHmacKeys,
+        symm_keygen: &mut impl DeviceSecretDerivation,
         phase: ConsolidatePhase,
         rng: &mut impl rand_core::RngCore,
     ) -> impl IntoIterator<Item = DeviceSend> {

--- a/frostsnap_core/src/device_nonces.rs
+++ b/frostsnap_core/src/device_nonces.rs
@@ -293,7 +293,6 @@ impl SecretNonceSlot {
     ) -> impl Iterator<Item = (u32, binonce::SecretNonce, [u8; 32])> + 'a {
         let mut seed_material = self.ratchet_prg_seed_material;
         let mut index = self.index;
-        let stream_id = self.nonce_stream_id;
 
         core::iter::from_fn(move || {
             if index == u32::MAX {
@@ -303,8 +302,7 @@ impl SecretNonceSlot {
             let current_index = index;
 
             // Derive actual nonce seed from material AND eFuse HMAC
-            let domain = format!("frostsnap-nonce-{}-{}", stream_id, current_index);
-            let actual_seed_bytes = device_hmac.derive_nonce_seed(&domain, &seed_material);
+            let actual_seed_bytes = device_hmac.derive_prng_seed(&seed_material);
             let actual_seed = ChaChaSeed::from_bytes(actual_seed_bytes);
 
             let mut chacha_nonce = [0u8; 12];

--- a/frostsnap_core/src/device_nonces.rs
+++ b/frostsnap_core/src/device_nonces.rs
@@ -1,3 +1,8 @@
+use crate::{
+    device::DeviceHmacKeys,
+    nonce_stream::{CoordNonceStreamState, NonceStreamId, NonceStreamSegment},
+    SignSessionId, Versioned, NONCE_BATCH_SIZE,
+};
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use chacha20::{
@@ -9,11 +14,6 @@ use schnorr_fun::{
     binonce,
     frost::{NonceKeyPair, PairedSecretShare, PartySignSession, SignatureShare},
     fun::prelude::*,
-};
-
-use crate::{
-    nonce_stream::{CoordNonceStreamState, NonceStreamId, NonceStreamSegment},
-    SignSessionId, Versioned, NONCE_BATCH_SIZE,
 };
 
 #[derive(bincode::Encode, bincode::Decode, Copy, Clone, Debug, PartialEq)]
@@ -40,7 +40,7 @@ impl ChaChaSeed {
 pub struct SecretNonceSlot {
     pub index: u32,
     pub nonce_stream_id: NonceStreamId,
-    pub ratchet_prg_seed: ChaChaSeed,
+    pub ratchet_prg_seed_material: [u8; 32],
     /// for clearing slots based on least recently used
     pub last_used: u32,
     pub signing_state: Option<SigningState>,
@@ -66,11 +66,12 @@ pub trait NonceStreamSlot {
     }
 
     fn initialize(&mut self, stream_id: NonceStreamId, last_used: u32, rng: &mut impl RngCore) {
-        let ratchet_prg_seed = ChaChaSeed::new(rng);
+        let mut ratchet_prg_seed_material = [0u8; 32];
+        rng.fill_bytes(&mut ratchet_prg_seed_material);
         let value = SecretNonceSlot {
             index: 0,
             nonce_stream_id: stream_id,
-            ratchet_prg_seed,
+            ratchet_prg_seed_material,
             last_used,
             signing_state: None,
         };
@@ -80,15 +81,16 @@ pub trait NonceStreamSlot {
     fn reconcile_coord_nonce_stream_state(
         &mut self,
         state: CoordNonceStreamState,
+        device_hmac: &mut impl DeviceHmacKeys,
     ) -> Option<NonceStreamSegment> {
         let value = self.read_slot()?;
         let our_index = value.index;
         if our_index > state.index || state.remaining < NONCE_BATCH_SIZE {
-            Some(value.nonce_segment(None, NONCE_BATCH_SIZE as usize))
+            Some(value.nonce_segment(None, NONCE_BATCH_SIZE as usize, device_hmac))
         } else if our_index == state.index {
             None
         } else {
-            Some(value.nonce_segment(None, (state.index - our_index) as usize))
+            Some(value.nonce_segment(None, (state.index - our_index) as usize, device_hmac))
         }
     }
 
@@ -102,6 +104,7 @@ pub trait NonceStreamSlot {
         coord_nonce_state: CoordNonceStreamState,
         last_used: u32,
         sessions: impl IntoIterator<Item = (PairedSecretShare<EvenY>, PartySignSession)>,
+        device_hmac: &mut impl DeviceHmacKeys,
     ) -> (Vec<SignatureShare>, Option<NonceStreamSegment>) {
         let slot_value = self
             .read_slot()
@@ -110,7 +113,6 @@ pub trait NonceStreamSlot {
             coord_nonce_state.stream_id, slot_value.nonce_stream_id,
             "wrong stream id"
         );
-
         if coord_nonce_state.index < slot_value.index {
             panic!("trying to sign with old nonce");
         }
@@ -128,18 +130,17 @@ pub trait NonceStreamSlot {
             }
             _ => {
                 let mut nonce_iter = slot_value
-                    .iter_secret_nonces()
+                    .iter_secret_nonces(device_hmac)
                     .skip((coord_nonce_state.index - slot_value.index) as usize);
-
                 let mut signature_shares = vec![];
-                let mut next_prg_state: Option<(u32, ChaChaSeed)> = None;
+                let mut next_prg_state: Option<(u32, [u8; 32])> = None;
 
                 for (secret_share, session) in sessions.into_iter() {
-                    let (current_index, secret_nonce, next_seed) = nonce_iter
+                    let (current_index, secret_nonce, next_seed_material) = nonce_iter
                         .next()
                         .expect("tried to sign with nonces out of range");
                     let next_index = current_index + 1;
-                    next_prg_state = Some((next_index, next_seed));
+                    next_prg_state = Some((next_index, next_seed_material));
                     let signature_share = session.sign(&secret_share, secret_nonce);
                     // TODO: verify the signature share as a sanity check
                     signature_shares.push(signature_share);
@@ -149,13 +150,12 @@ pub trait NonceStreamSlot {
                     panic!("sign sessions must not be empty");
                 }
 
-                let (next_index, next_prg_seed) = next_prg_state.unwrap();
-
+                let (next_index, next_prg_seed_material) = next_prg_state.unwrap();
                 SecretNonceSlot {
                     nonce_stream_id: slot_value.nonce_stream_id,
                     index: next_index,
                     last_used,
-                    ratchet_prg_seed: next_prg_seed,
+                    ratchet_prg_seed_material: next_prg_seed_material,
                     signing_state: Some(SigningState {
                         session_id,
                         signature_shares,
@@ -175,8 +175,8 @@ pub trait NonceStreamSlot {
             .signature_shares;
 
         let implied_coord_nonce_state = coord_nonce_state.after_signing(signature_shares.len());
-        let replenishment = self.reconcile_coord_nonce_stream_state(implied_coord_nonce_state);
-
+        let replenishment =
+            self.reconcile_coord_nonce_stream_state(implied_coord_nonce_state, device_hmac);
         (signature_shares, replenishment)
     }
 }
@@ -205,6 +205,7 @@ impl<S: NonceStreamSlot> AbSlots<S> {
         session_id: SignSessionId,
         coord_nonce_state: CoordNonceStreamState,
         sessions: impl IntoIterator<Item = (PairedSecretShare<EvenY>, PartySignSession)>,
+        device_hmac: &mut impl DeviceHmacKeys,
     ) -> Option<(Vec<SignatureShare>, Option<NonceStreamSegment>)> {
         let last_used = self.last_used + 1;
         let slot = self.get(coord_nonce_state.stream_id)?;
@@ -213,6 +214,7 @@ impl<S: NonceStreamSlot> AbSlots<S> {
             coord_nonce_state,
             last_used,
             sessions,
+            device_hmac,
         );
         self.last_used = last_used;
         Some(out)
@@ -285,65 +287,80 @@ impl<S: NonceStreamSlot> AbSlots<S> {
 }
 
 impl SecretNonceSlot {
-    fn iter_secret_nonces(&self) -> impl Iterator<Item = (u32, binonce::SecretNonce, ChaChaSeed)> {
-        let mut prg_seed = self.ratchet_prg_seed;
+    fn iter_secret_nonces<'a>(
+        &'a self,
+        device_hmac: &'a mut impl DeviceHmacKeys,
+    ) -> impl Iterator<Item = (u32, binonce::SecretNonce, [u8; 32])> + 'a {
+        let mut seed_material = self.ratchet_prg_seed_material;
         let mut index = self.index;
+        let stream_id = self.nonce_stream_id;
+
         core::iter::from_fn(move || {
             if index == u32::MAX {
                 return None;
             }
-            let mut chacha_nonce = [0u8; 12];
+
             let current_index = index;
+
+            // Derive actual nonce seed from material AND eFuse HMAC
+            let domain = format!("frostsnap-nonce-{}-{}", stream_id, current_index);
+            let actual_seed_bytes = device_hmac.derive_nonce_seed(&domain, &seed_material);
+            let actual_seed = ChaChaSeed::from_bytes(actual_seed_bytes);
+
+            let mut chacha_nonce = [0u8; 12];
             chacha_nonce[0..core::mem::size_of_val(&current_index)]
                 .copy_from_slice(current_index.to_le_bytes().as_ref());
-            let mut chacha = ChaCha20::new(prg_seed.as_bytes().into(), &chacha_nonce.into());
-            let mut next_seed = [0u8; 32];
-            chacha.apply_keystream(&mut next_seed);
+            let mut chacha = ChaCha20::new(actual_seed.as_bytes().into(), &chacha_nonce.into());
+
+            // Generate the next seed material (ratchet forward)
+            let mut next_seed_material = [0u8; 32];
+            chacha.apply_keystream(&mut next_seed_material);
+
             let mut secret_nonce_bytes = [0u8; 64];
             chacha.apply_keystream(&mut secret_nonce_bytes);
             let secret_nonce = binonce::SecretNonce::from_bytes(secret_nonce_bytes)
                 .expect("computationally unreachable");
-            let next_prg_seed = ChaChaSeed::from_bytes(next_seed);
-            prg_seed = next_prg_seed;
+
+            seed_material = next_seed_material;
             index += 1;
-            Some((current_index, secret_nonce, next_prg_seed))
+
+            Some((current_index, secret_nonce, next_seed_material))
         })
     }
 
     pub fn are_nonces_available(&self, index: u32, n: u32) -> Result<(), NoncesUnavailable> {
         let current = self.index;
         let requested = index;
-
         if requested < current {
             return Err(NoncesUnavailable::IndexUsed { current, requested });
         }
-
         if index.saturating_add(n) == u32::MAX {
             return Err(NoncesUnavailable::Overflow);
         }
-
         Ok(())
     }
 
-    pub fn nonce_segment(&self, start: Option<u32>, length: usize) -> NonceStreamSegment {
+    pub fn nonce_segment(
+        &self,
+        start: Option<u32>,
+        length: usize,
+        device_hmac: &mut impl DeviceHmacKeys,
+    ) -> NonceStreamSegment {
         let start = start.unwrap_or(self.index);
-
         if start < self.index {
             panic!("can't iterate erased nonces");
         }
         let last = start.saturating_add(length.try_into().expect("length not too big"));
-
         if last == u32::MAX {
             panic!("cannot have an index at u32::MAX");
         }
 
         let nonces = self
-            .iter_pub_nonces()
+            .iter_pub_nonces(device_hmac)
             .skip((start - self.index) as _)
             .map(|(_, nonce)| nonce)
             .take(length)
             .collect::<VecDeque<_>>();
-
         assert_eq!(nonces.len(), length, "there weren't enough nonces for that");
 
         NonceStreamSegment {
@@ -352,11 +369,14 @@ impl SecretNonceSlot {
             nonces,
         }
     }
-
-    pub fn iter_pub_nonces(&self) -> impl Iterator<Item = (u32, binonce::Nonce)> {
-        self.iter_secret_nonces().map(|(index, secret_nonce, _)| {
-            (index, NonceKeyPair::from_secret(secret_nonce).public())
-        })
+    pub fn iter_pub_nonces<'a>(
+        &'a self,
+        device_hmac: &'a mut impl DeviceHmacKeys,
+    ) -> impl Iterator<Item = (u32, binonce::Nonce)> + 'a {
+        self.iter_secret_nonces(device_hmac)
+            .map(|(index, secret_nonce, _)| {
+                (index, NonceKeyPair::from_secret(secret_nonce).public())
+            })
     }
 }
 

--- a/frostsnap_core/tests/common/mod.rs
+++ b/frostsnap_core/tests/common/mod.rs
@@ -83,12 +83,9 @@ impl DeviceHmacKeys for TestDeviceKeyGen {
         TEST_ENCRYPTION_KEY
     }
 
-    fn derive_nonce_seed(&mut self, domain: &str, input: &[u8; 32]) -> [u8; 32] {
+    fn derive_prng_seed(&mut self, input: &[u8; 32]) -> [u8; 32] {
         let mut engine = HmacEngine::<sha256::Hash>::new(&TEST_ENCRYPTION_KEY.0);
-
-        engine.input(domain.as_bytes());
         engine.input(input);
-
         let hmac_result = Hmac::<sha256::Hash>::from_engine(engine);
 
         *hmac_result.as_byte_array()

--- a/frostsnap_core/tests/malicious.rs
+++ b/frostsnap_core/tests/malicious.rs
@@ -66,7 +66,11 @@ fn keygen_maliciously_replace_public_poly() {
                 // receives with a different one generated with different randomness. This should
                 // cause the device to detect the switch and abort.
                 let malicious_messages = shadow_device
-                    .recv_coordinator_message(do_keygen.clone(), &mut other_rng)
+                    .recv_coordinator_message(
+                        do_keygen.clone(),
+                        &mut other_rng,
+                        &mut common::TestDeviceKeyGen,
+                    )
                     .unwrap();
                 let malicious_keygen_response = malicious_messages
                     .into_iter()


### PR DESCRIPTION
This PR enables the devices to use their HMAC EFUSE keys for various secrets.

By using these EFUSE keys, an attacker wanting to extract the secrets would not only have to dump the flash from the device but they would additionally have to extract the relevant key from EFUSE; significantly more difficult (requiring chip decapping/probing or sophisticated sidechannel attacks). 

### Device Keypair
The device keypair is currently used for DeviceId and encryption of keygen shares sent to  other parties.

Since this keypair is created on startup, this call could prove weak to side-channel attacks. Because device keypair compromise only affects device identity and keygen share encryption (rather than signing keys themselves), we choose to use the less critical `fixed-entropy` HMAC for this purpose.

### Nonce secrets

An attacker learning the nonce secret is essentially equivalent to them learning the secret share itself: with a signature and nonce secret they can solve for the secret share. We use the `share-encryption` HMAC to derive nonce-secrets to secure these crucial secrets.