### PR TITLE
[device] Enable stack guard panic handler

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["nickfarrow <nick@nickfarrow.com>"]
 edition = "2021"
 
 [features]
-default = ["v2", "read_protect_hmac_key"]
+default = ["v2", "read_protect_hmac_key", "stack_guard"]
 v2 = ["dep:display-interface-spi", "dep:mipidsi"]
 mem_debug = []
 read_protect_hmac_key = []
+# turns on the esp32c3 hardware stack guard
+stack_guard = []
 
 [dependencies]
 frostsnap_core = { workspace = true }

--- a/device/src/bin/v2.rs
+++ b/device/src/bin/v2.rs
@@ -103,6 +103,8 @@ fn main() -> ! {
         config.cpu_clock = CpuClock::max();
         config
     });
+    #[cfg(feature = "stack_guard")]
+    frostsnap_device::stack_guard::enable_stack_guard(peripherals.ASSIST_DEBUG);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let timg1 = TimerGroup::new(peripherals.TIMG1);
     let timer0 = timg0.timer0;

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -20,6 +20,7 @@ pub mod io;
 pub mod ota;
 pub mod panic;
 pub mod partitions;
+pub mod stack_guard;
 pub mod ui;
 
 #[derive(Debug, Clone)]

--- a/device/src/stack_guard.rs
+++ b/device/src/stack_guard.rs
@@ -1,0 +1,23 @@
+#![allow(dead_code)]
+use esp_hal::{
+    assist_debug::DebugAssist, macros::handler, peripherals::ASSIST_DEBUG,
+    InterruptConfigurable as _,
+};
+
+extern "C" {
+    static _stack_start: u32;
+    static _stack_end: u32;
+}
+
+pub fn enable_stack_guard(assist_debug: ASSIST_DEBUG) {
+    let mut da = DebugAssist::new(assist_debug);
+    da.set_interrupt_handler(interrupt_handler);
+    let stack_top = unsafe { &_stack_start as *const u32 as u32 };
+    let stack_bottom = unsafe { &_stack_end as *const u32 as u32 };
+    da.enable_sp_monitor(stack_bottom, stack_top);
+}
+
+#[handler(priority = esp_hal::interrupt::Priority::min())]
+fn interrupt_handler() {
+    panic!("stack guard tripped");
+}


### PR DESCRIPTION
 See: https://docs.espressif.com/projects/esp-idf/en/stable/esp32c3/api-guides/fatal-errors.html#hardware-stack-guard

I spent the whole day with an overflowed stack not being able to figure out what it was because there's no panic -- it just corrupts stuff in memory. With the stack guard it panics. Performance impact of turning it on doesn't seem to be much since the checking is done in hardware but I made it a feature flag in case you want to test without it. 