### PR TITLE
[core] Allow repeating the same sign requests

### DIFF
--- a/frostsnap_core/tests/malicious.rs
+++ b/frostsnap_core/tests/malicious.rs
@@ -94,6 +94,7 @@ fn keygen_maliciously_replace_public_poly() {
 /// Send different signing requests with the same nonces twice.
 /// The device should reject signing the second request.
 #[test]
+#[should_panic(expected = "Attempt to reuse nonces")]
 fn send_sign_req_with_same_nonces_but_different_message() {
     let mut test_rng = ChaCha20Rng::from_seed([42u8; 32]);
     let mut run = Run::start_after_keygen_and_nonces(
@@ -137,15 +138,7 @@ fn send_sign_req_with_same_nonces_but_different_message() {
     };
 
     run.extend(sign_req);
-    let sign_request_result = run.run_until_finished(&mut DefaultTestEnv, &mut test_rng);
-
-    assert!(matches!(
-        sign_request_result,
-        Err(frostsnap_core::Error::InvalidMessage { .. })
-    ));
-
-    assert!(sign_request_result
-        .expect_err("should be error")
-        .to_string()
-        .contains("Attempt to reuse nonces!"))
+    // This will panic when sign_ack tries to reuse nonces
+    run.run_until_finished(&mut DefaultTestEnv, &mut test_rng)
+        .unwrap();
 }


### PR DESCRIPTION
We had a system to cache a signature we've just produced such that if we get asked to sign again we can just return it. But there were checks that returned errors before the cache was hit. We remove the errors. This means that attempts to reuse nonces are only caught after the user has confirmed.