### PR TITLE
Fix app logging

### DIFF
--- a/frostsnapp/lib/stream_ext.dart
+++ b/frostsnapp/lib/stream_ext.dart
@@ -12,19 +12,13 @@ extension StreamToBehaviorSubjectExtension<T> on Stream<T> {
         : BehaviorSubject<T>();
 
     // Listen to the original stream and forward events to the BehaviorSubject
-    late StreamSubscription<T> subscription;
-    subscription = listen(
+    listen(
       (data) => subject.add(data),
       onError: (error) => subject.addError(error),
       onDone: () {
         subject.close();
       },
     );
-
-    // Cancel subscription when subject is closed to prevent memory leaks
-    subject.onCancel = () {
-      subscription.cancel();
-    };
 
     return subject;
   }
@@ -40,19 +34,13 @@ extension StreamToBehaviorSubjectExtension<T> on Stream<T> {
         : ReplaySubject<T>();
 
     // Listen to the original stream and forward events to the ReplaySubject
-    late StreamSubscription<T> subscription;
-    subscription = listen(
+    listen(
       (data) => subject.add(data),
       onError: (error) => subject.addError(error),
       onDone: () {
         subject.close();
       },
     );
-
-    // Cancel subscription when subject is closed to prevent memory leaks
-    subject.onCancel = () {
-      subscription.cancel();
-    };
 
     return subject;
   }


### PR DESCRIPTION
The onCancel callbacks were incorrectly cancelling the underlying stream subscription whenever any listener unsubscribed. This broke logging because temporary listeners (like .first) would kill the entire stream.

RxDart subjects handle cleanup automatically, so manual subscription cancellation in onCancel is unnecessary.

I should have scrutinized this change on https://github.com/frostsnap/frostsnap/pull/271 more strongly.