### PR TITLE
[device] Remove embedded-text dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,17 +1343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-text"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005680edc0d075af5e02d5788ca291737bd9aba7fc404ae031cc9dfa715e5f7d"
-dependencies = [
- "az",
- "embedded-graphics",
- "object-chain",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,7 +1810,6 @@ dependencies = [
  "embedded-hal-nb",
  "embedded-iconoir",
  "embedded-storage",
- "embedded-text",
  "esp-alloc",
  "esp-hal",
  "esp-partition-table",
@@ -1893,7 +1881,6 @@ dependencies = [
  "bitcoin",
  "embedded-graphics",
  "embedded-iconoir",
- "embedded-text",
  "esp-alloc",
  "frost_backup",
  "frostsnap_core",
@@ -3135,12 +3122,6 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "object-chain"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41af26158b0f5530f7b79955006c2727cd23d0d8e7c3109dc316db0a919784dd"
 
 [[package]]
 name = "once_cell"

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -40,7 +40,6 @@ display-interface = { version = "0.5.0" }
 display-interface-spi = { version = "0.5.0" }
 mipidsi = { version = "0.8.0", features = ["batch"] }
 embedded-graphics = "0.8.1"
-embedded-text = "0.7.0"
 u8g2-fonts = { version = "0.3.0", features = ["embedded_graphics_textstyle"] }
 rand_chacha = { workspace = true }
 frostsnap_cst816s = { workspace = true }

--- a/frostsnap_widgets/Cargo.toml
+++ b/frostsnap_widgets/Cargo.toml
@@ -11,7 +11,6 @@ std = []
 embedded-graphics = "0.8.1"
 u8g2-fonts = { version = "0.3.0", features = ["embedded_graphics_textstyle"] }
 embedded-iconoir = { version = "0.2.3", features = ["24px", "32px", "48px", "96px"] }
-embedded-text = "0.7.0"
 micromath = "0.2"
 frost_backup = { workspace = true, features = [ "bincode" ] }
 frostsnap_core = { workspace = true }


### PR DESCRIPTION
It's not used by anything except for factory initialization which doesn't seem to really need it either. It is also breaking some things in other branches when you enabled the fixed point arithmetic in embedded_graphics.