### PR TITLE
Fix blank screen issue on restart by adding delay to usb

### DIFF
--- a/cst816s/src/lib.rs
+++ b/cst816s/src/lib.rs
@@ -83,8 +83,9 @@ where
         self.pin_rst.set_low().map_err(Error::Pin)?;
         delay_source.delay_us(20_000);
         self.pin_rst.set_high().map_err(Error::Pin)?;
-        // ❗ This used to 400_000 but this seems to work in practice.
-        delay_source.delay_us(50_000);
+        // ❗ This probably doesn't need to be so long. We changed it and
+        // started to get issues with other things (not the touch sensor).
+        delay_source.delay_us(400_000);
 
         Ok(())
     }
@@ -238,9 +239,9 @@ impl core::convert::From<u8> for TouchGesture {
 /// Global interrupt handling support for ESP32C3
 pub mod interrupt {
     use super::*;
-    use esp_hal::InterruptConfigurable;
     use esp_hal::gpio::Input;
     use esp_hal::macros::handler;
+    use esp_hal::InterruptConfigurable;
     use heapless::spsc::{Consumer, Producer, Queue};
 
     /// Default queue capacity for touch events

--- a/cst816s/src/lib.rs
+++ b/cst816s/src/lib.rs
@@ -239,9 +239,9 @@ impl core::convert::From<u8> for TouchGesture {
 /// Global interrupt handling support for ESP32C3
 pub mod interrupt {
     use super::*;
+    use esp_hal::InterruptConfigurable;
     use esp_hal::gpio::Input;
     use esp_hal::macros::handler;
-    use esp_hal::InterruptConfigurable;
     use heapless::spsc::{Consumer, Producer, Queue};
 
     /// Default queue capacity for touch events

--- a/frostsnapp/android/app/src/main/kotlin/com/frostsnap/CdcAcmPlugin.kt
+++ b/frostsnapp/android/app/src/main/kotlin/com/frostsnap/CdcAcmPlugin.kt
@@ -105,6 +105,9 @@ class CdcAcmPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun openAndDupFd(device: UsbDevice): Int? {
+        // Sleep so that we don't open the usb port immediately
+        // This resolved an issue with screens not turning on when reset or unplugged/replugged
+        Thread.sleep(1000);
         val connection = usbManager.openDevice(device) ?: return null
 
         val origFd = connection.fileDescriptor


### PR DESCRIPTION
When restarting after a firmware update or after plugging in device to android coordinator, often the screen on the first device was blank.

When it is the first time the device has been plugged in the android jtag notice/accept caused a delay which resulted in screens operating fine

Restoring the delay for the touchscreen initalisation from 50ms to 400ms and also adding a 1000ms delay before opening the usb port from the android coordinator eliminated the blank screen issue.