### PR TITLE
[comms] Fixed length DeviceName and key name

### DIFF
--- a/device/src/frosty_ui.rs
+++ b/device/src/frosty_ui.rs
@@ -1,4 +1,4 @@
-use alloc::boxed::Box;
+use alloc::{boxed::Box, string::ToString};
 use embedded_graphics::prelude::*;
 use esp_hal::prelude::*;
 use frostsnap_cst816s::interrupt::TouchReceiver;
@@ -123,7 +123,7 @@ impl<'a> UserInteraction for FrostyUi<'a> {
                 WidgetTree::DeviceNaming(ref mut device_name_screen),
                 Workflow::NamingDevice { ref new_name },
             ) => {
-                device_name_screen.set_name(new_name.clone());
+                device_name_screen.set_name(new_name.to_string());
                 return;
             }
 
@@ -163,7 +163,7 @@ impl<'a> UserInteraction for FrostyUi<'a> {
             Workflow::Standby {
                 device_name,
                 held_share,
-            } => WidgetTree::Standby(Box::new(Standby::new(device_name, held_share))),
+            } => WidgetTree::Standby(Box::new(Standby::new(device_name.to_string(), held_share))),
             Workflow::UserPrompt(prompt) => {
                 match prompt {
                     Prompt::KeyGen { phase } => {
@@ -317,7 +317,7 @@ impl<'a> UserInteraction for FrostyUi<'a> {
             }
 
             Workflow::NamingDevice { new_name } => {
-                let device_name_screen = DeviceNameScreen::new(new_name);
+                let device_name_screen = DeviceNameScreen::new(new_name.to_string());
                 WidgetTree::DeviceNaming(Box::new(device_name_screen))
             }
 

--- a/device/src/ui.rs
+++ b/device/src/ui.rs
@@ -1,7 +1,7 @@
 // Imports removed - legacy screens are not used in stateless Workflow
 use alloc::{boxed::Box, string::String};
 use frost_backup::ShareBackup;
-use frostsnap_comms::Sha256Digest;
+use frostsnap_comms::{DeviceName, Sha256Digest};
 use frostsnap_core::{
     device::{
         restoration::{BackupDisplayPhase, EnterBackupPhase},
@@ -50,12 +50,12 @@ impl<T: UserInteraction + ?Sized> UserInteraction for Box<T> {
 pub enum Workflow {
     None,
     Standby {
-        device_name: String,
+        device_name: DeviceName,
         held_share: HeldShare,
     },
     UserPrompt(Prompt),
     NamingDevice {
-        new_name: String,
+        new_name: DeviceName,
     },
     DisplayBackup {
         key_name: String,
@@ -92,8 +92,8 @@ pub enum Prompt {
         phase: Box<SignPhase1>,
     },
     NewName {
-        old_name: Option<String>,
-        new_name: String,
+        old_name: Option<DeviceName>,
+        new_name: DeviceName,
     },
     DisplayBackupRequest {
         phase: Box<BackupDisplayPhase>,
@@ -129,7 +129,7 @@ pub enum UiEvent {
     SigningConfirm {
         phase: Box<SignPhase1>,
     },
-    NameConfirm(String),
+    NameConfirm(frostsnap_comms::DeviceName),
     EnteredShareBackup {
         phase: EnterBackupPhase,
         share_backup: ShareBackup,

--- a/device/src/widget_tree.rs
+++ b/device/src/widget_tree.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, string::String};
+use alloc::boxed::Box;
 use embedded_graphics::pixelcolor::Rgb565;
 use frostsnap_core::device::{
     restoration::{BackupDisplayPhase, EnterBackupPhase},
@@ -69,7 +69,7 @@ pub enum WidgetTree {
     /// New name confirmation prompt
     NewNamePrompt {
         widget: Box<HoldToConfirm<Text<U8g2TextStyle<Rgb565>>>>,
-        new_name: Option<String>,
+        new_name: Option<frostsnap_comms::DeviceName>,
     },
 
     /// Device wipe confirmation prompt  

--- a/frostsnap_comms/src/fixed_string.rs
+++ b/frostsnap_comms/src/fixed_string.rs
@@ -1,0 +1,229 @@
+use alloc::string::{String, ToString};
+use core::fmt;
+use core::ops::Deref;
+use core::str::FromStr;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FixedString<const N: usize> {
+    inner: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StringTooLong {
+    pub max_len: usize,
+    pub actual_len: usize,
+}
+
+impl fmt::Display for StringTooLong {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "String too long: max length is {} but got {}",
+            self.max_len, self.actual_len
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for StringTooLong {}
+
+impl<const N: usize> FixedString<N> {
+    pub fn new(s: String) -> Result<Self, StringTooLong> {
+        let char_count = s.chars().count();
+        if char_count > N {
+            Err(StringTooLong {
+                max_len: N,
+                actual_len: char_count,
+            })
+        } else {
+            Ok(Self { inner: s })
+        }
+    }
+
+    pub fn truncate(s: String) -> Self {
+        let char_count = s.chars().count();
+        if char_count > N {
+            // Truncate to N characters, respecting UTF-8 boundaries
+            let truncated: String = s.chars().take(N).collect();
+            Self { inner: truncated }
+        } else {
+            Self { inner: s }
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+
+    pub fn into_string(self) -> String {
+        self.inner
+    }
+
+    pub fn max_length() -> usize {
+        N
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.chars().count()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+impl<const N: usize> Deref for FixedString<N> {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<const N: usize> AsRef<str> for FixedString<N> {
+    fn as_ref(&self) -> &str {
+        &self.inner
+    }
+}
+
+impl<const N: usize> fmt::Display for FixedString<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl<const N: usize> TryFrom<String> for FixedString<N> {
+    type Error = StringTooLong;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<const N: usize> FromStr for FixedString<N> {
+    type Err = StringTooLong;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s.to_string())
+    }
+}
+
+impl<const N: usize> TryFrom<&str> for FixedString<N> {
+    type Error = StringTooLong;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_str(value)
+    }
+}
+
+impl<const N: usize> Default for FixedString<N> {
+    fn default() -> Self {
+        Self {
+            inner: String::new(),
+        }
+    }
+}
+
+impl<const N: usize> bincode::Encode for FixedString<N> {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        self.inner.encode(encoder)
+    }
+}
+
+impl<const N: usize, Context> bincode::Decode<Context> for FixedString<N> {
+    fn decode<D: bincode::de::Decoder>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let s = String::decode(decoder)?;
+        // Truncate if too long instead of returning an error
+        Ok(Self::truncate(s))
+    }
+}
+
+impl<'de, const N: usize, C> bincode::BorrowDecode<'de, C> for FixedString<N> {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let s = String::borrow_decode(decoder)?;
+        Ok(Self::truncate(s))
+    }
+}
+
+pub const DEVICE_NAME_MAX_LENGTH: usize = 14;
+pub const KEY_NAME_MAX_LENGTH: usize = 15;
+
+pub type DeviceName = FixedString<DEVICE_NAME_MAX_LENGTH>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fixed_string_creation() {
+        let s = FixedString::<10>::from_str("hello").unwrap();
+        assert_eq!(s.as_str(), "hello");
+        assert_eq!(s.len(), 5);
+
+        let err = FixedString::<3>::from_str("hello").unwrap_err();
+        assert_eq!(err.max_len, 3);
+        assert_eq!(err.actual_len, 5);
+    }
+
+    #[test]
+    fn test_truncate() {
+        let s = FixedString::<3>::truncate("hello".to_string());
+        assert_eq!(s.as_str(), "hel");
+    }
+
+    #[test]
+    fn test_bincode_roundtrip() {
+        let s = FixedString::<10>::from_str("test").unwrap();
+        let encoded = bincode::encode_to_vec(&s, bincode::config::standard()).unwrap();
+        let decoded: FixedString<10> =
+            bincode::decode_from_slice(&encoded, bincode::config::standard())
+                .unwrap()
+                .0;
+        assert_eq!(decoded, s);
+    }
+
+    #[test]
+    fn test_bincode_decode_too_long() {
+        let s = "hello world this is too long";
+        let encoded = bincode::encode_to_vec(s, bincode::config::standard()).unwrap();
+        let result: FixedString<10> =
+            bincode::decode_from_slice(&encoded, bincode::config::standard())
+                .unwrap()
+                .0;
+        // Should truncate to 10 characters
+        assert_eq!(result.as_str(), "hello worl");
+    }
+
+    #[test]
+    fn test_unicode_character_counting() {
+        // Test with emoji and non-ASCII characters
+        let emoji_string = "Hello 👋 世界".to_string();
+        // This string has 10 characters: H-e-l-l-o-space-👋-space-世-界
+        assert_eq!(emoji_string.chars().count(), 10);
+        assert!(emoji_string.len() > 10); // More bytes than characters
+
+        let fixed = FixedString::<10>::new(emoji_string.clone()).unwrap();
+        assert_eq!(fixed.len(), 10);
+        assert_eq!(fixed.as_str(), "Hello 👋 世界");
+
+        // Test truncation with Unicode
+        let long_unicode = "Hello 👋 世界 🎉 Test".to_string();
+        let truncated = FixedString::<8>::truncate(long_unicode);
+        assert_eq!(truncated.len(), 8);
+        assert_eq!(truncated.as_str(), "Hello 👋 ");
+
+        // Test "ServerRoomCafé" which has 14 characters (the é is one character)
+        let server_room = "ServerRoomCafé".to_string();
+        assert_eq!(server_room.chars().count(), 14);
+        let server_fixed = FixedString::<14>::new(server_room.clone()).unwrap();
+        assert_eq!(server_fixed.len(), 14);
+        assert_eq!(server_fixed.as_str(), "ServerRoomCafé");
+    }
+}

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -6,6 +6,7 @@ extern crate std;
 #[macro_use]
 extern crate alloc;
 pub mod factory;
+pub mod fixed_string;
 pub mod genuine_certificate;
 use alloc::boxed::Box;
 use alloc::string::ToString;
@@ -14,6 +15,11 @@ use alloc::{collections::BTreeSet, string::String};
 use bincode::{de::read::Reader, enc::write::Writer, Decode, Encode};
 use core::marker::PhantomData;
 use frostsnap_core::{DeviceId, Gist};
+
+pub use fixed_string::{
+    DeviceName, FixedString, StringTooLong, DEVICE_NAME_MAX_LENGTH, KEY_NAME_MAX_LENGTH,
+};
+
 use genuine_certificate::Certificate;
 
 pub const FACTORY_PUBLIC_KEY: [u8; 32] = [
@@ -253,8 +259,8 @@ pub enum CoordinatorUpgradeMessage {
 
 #[derive(Encode, Decode, Debug, Clone)]
 pub enum NameCommand {
-    Preview(String),
-    Prompt(String),
+    Preview(DeviceName),
+    Prompt(DeviceName),
 }
 
 impl Gist for CoordinatorSendBody {
@@ -398,7 +404,7 @@ pub enum DeviceSendBody {
         firmware_digest: Sha256Digest,
     },
     SetName {
-        name: String,
+        name: DeviceName,
     },
     DisconnectDownstream,
     NeedName,
@@ -431,7 +437,7 @@ pub enum WireDeviceSendBody {
     _Core,
     Debug { message: String },
     Announce { firmware_digest: Sha256Digest },
-    SetName { name: String },
+    SetName { name: DeviceName },
     DisconnectDownstream,
     NeedName,
     _LegacyAckUpgradeMode, // Used by earliest devices

--- a/frostsnap_widgets/src/standby.rs
+++ b/frostsnap_widgets/src/standby.rs
@@ -2,7 +2,7 @@ use crate::{
     bitmap::EncodedImage, device_name::DeviceName, icons::IconWidget, image::Image,
     palette::PALETTE, prelude::*, share_index::ShareIndexWidget, vec_framebuffer::VecFramebuffer,
 };
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use embedded_graphics::pixelcolor::{BinaryColor, Rgb565};
 use embedded_iconoir::prelude::IconoirNewIcon;
 use frostsnap_core::message::HeldShare;
@@ -53,7 +53,7 @@ impl Standby {
         let wallet_icon = IconWidget::new(embedded_iconoir::icons::size24px::finance::Wallet::new(
             PALETTE.on_surface_variant,
         ));
-        let key_text = Text::new(held_share.key_name.clone(), key_style);
+        let key_text = Text::new(held_share.key_name.to_string(), key_style);
 
         let key_row = Row::builder().push(wallet_icon).gap(8).push(key_text);
 

--- a/frostsnapp/lib/device_action_name.dart
+++ b/frostsnapp/lib/device_action_name.dart
@@ -55,7 +55,7 @@ class DeviceActionNameDialogController with ChangeNotifier {
       return name;
     }
 
-    await coord.finishNaming(id: id, name: name);
+    await coord.finishNaming(id: id, name: name.trim());
 
     final confirmedName = await Stream<String?>.fromFutures([
       GlobalStreams.deviceListChangeStream

--- a/frostsnapp/lib/device_setup.dart
+++ b/frostsnapp/lib/device_setup.dart
@@ -97,6 +97,7 @@ class _DeviceNameField extends State<DeviceNameField> {
               border: OutlineInputBorder(),
               labelText: 'Device name',
             ),
+            inputFormatters: [nameInputFormatter],
             onSubmitted: (name) => _onSubmitted(context, name),
             onChanged: (value) async =>
                 await coord.updateNamePreview(id: widget.id, name: value),

--- a/frostsnapp/lib/device_setup.dart
+++ b/frostsnapp/lib/device_setup.dart
@@ -3,6 +3,7 @@ import 'package:frostsnap/device_action_name.dart';
 
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/src/rust/api/name.dart';
 
 enum DeviceNameMode {
   /// The name field renames the device and prompts the user for confirmation.
@@ -91,7 +92,7 @@ class _DeviceNameField extends State<DeviceNameField> {
         children: [
           TextField(
             controller: _controller,
-            maxLength: 20,
+            maxLength: DeviceName.maxLength(),
             decoration: InputDecoration(
               border: OutlineInputBorder(),
               labelText: 'Device name',

--- a/frostsnapp/lib/global.dart
+++ b/frostsnapp/lib/global.dart
@@ -10,9 +10,32 @@ late Coordinator coord;
 late Api api;
 late HostPortHandler? globalHostPortHandler;
 
-final nameInputFormatter = FilteringTextInputFormatter.allow(
-  RegExp(r"[a-zA-Z0-9_\-']"),
-);
+final nameInputFormatter = TextInputFormatter.withFunction((
+  oldValue,
+  newValue,
+) {
+  final text = newValue.text;
+
+  // Allow empty string
+  if (text.isEmpty) return newValue;
+
+  // reject leading spaces (always wrong)
+  if (text.startsWith(' ')) {
+    return oldValue;
+  }
+
+  // reject double spaces
+  if (text.contains('  ')) {
+    return oldValue;
+  }
+
+  // reject disallowed characters
+  if (!RegExp(r"^[a-zA-Z0-9_\-' ]+$").hasMatch(text)) {
+    return oldValue;
+  }
+
+  return newValue;
+});
 
 class GlobalStreams {
   /// Gets new updates from the device list

--- a/frostsnapp/lib/global.dart
+++ b/frostsnapp/lib/global.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
 import 'package:frostsnap/src/rust/api/device_list.dart';
@@ -8,6 +9,10 @@ import 'serialport.dart';
 late Coordinator coord;
 late Api api;
 late HostPortHandler? globalHostPortHandler;
+
+final nameInputFormatter = FilteringTextInputFormatter.allow(
+  RegExp(r"[a-zA-Z0-9_\-']"),
+);
 
 class GlobalStreams {
   /// Gets new updates from the device list

--- a/frostsnapp/lib/restoration.dart
+++ b/frostsnapp/lib/restoration.dart
@@ -15,6 +15,7 @@ import 'package:frostsnap/snackbar.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/device_list.dart';
+import 'package:frostsnap/src/rust/api/name.dart';
 import 'package:frostsnap/src/rust/api/nonce_replenish.dart';
 import 'package:frostsnap/src/rust/api/recovery.dart';
 import 'package:frostsnap/stream_ext.dart';
@@ -514,7 +515,7 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
       restorationId = widget.continuing!;
       final state = coord.getRestorationState(restorationId: restorationId!)!;
       threshold = state.accessStructure.threshold;
-      walletName = state.keyName;
+      walletName = state.keyName.toString();
       bitcoinNetwork =
           state.keyPurpose.bitcoinNetwork() ?? BitcoinNetwork.bitcoin;
     } else if (widget.existing != null) {
@@ -1307,6 +1308,7 @@ class _EnterWalletNameViewState extends State<_EnterWalletNameView> {
           const SizedBox(height: 24),
           TextFormField(
             controller: _walletNameController,
+            maxLength: keyNameMaxLength(),
             decoration: const InputDecoration(
               labelText: 'Wallet Name',
               border: OutlineInputBorder(),

--- a/frostsnapp/lib/restoration.dart
+++ b/frostsnapp/lib/restoration.dart
@@ -1309,6 +1309,7 @@ class _EnterWalletNameViewState extends State<_EnterWalletNameView> {
           TextFormField(
             controller: _walletNameController,
             maxLength: keyNameMaxLength(),
+            inputFormatters: [nameInputFormatter],
             decoration: const InputDecoration(
               labelText: 'Wallet Name',
               border: OutlineInputBorder(),

--- a/frostsnapp/lib/restoration.dart
+++ b/frostsnapp/lib/restoration.dart
@@ -1277,7 +1277,10 @@ class _EnterWalletNameViewState extends State<_EnterWalletNameView> {
 
   void _submitForm() {
     if (_isButtonEnabled && _formKey.currentState!.validate()) {
-      widget.onWalletNameEntered(_walletNameController.text, bitcoinNetwork);
+      widget.onWalletNameEntered(
+        _walletNameController.text.trim(),
+        bitcoinNetwork,
+      );
     }
   }
 

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -13,6 +13,7 @@ import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/device_list.dart';
 import 'package:frostsnap/src/rust/api/keygen.dart';
+import 'package:frostsnap/src/rust/api/name.dart';
 import 'package:frostsnap/src/rust/api/nonce_replenish.dart';
 import 'package:frostsnap/nonce_replenish.dart';
 import 'package:frostsnap/stream_ext.dart';
@@ -69,8 +70,9 @@ class WalletCreateController extends ChangeNotifier {
             nameError = 'Wallet name required';
             return;
           }
-          if (name.length > 21) {
-            nameError = 'Wallet name cannot be over 21 chars';
+          if (name.length > keyNameMaxLength()) {
+            nameError =
+                'Wallet name cannot be over ${keyNameMaxLength()} chars';
             return;
           }
         } else if (name.isNotEmpty) {
@@ -557,7 +559,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
           border: OutlineInputBorder(),
           errorText: _controller.nameError,
         ),
-        maxLength: 21,
+        maxLength: keyNameMaxLength(),
         textCapitalization: TextCapitalization.words,
         onSubmitted: (_) {
           _controller.next(context);
@@ -751,6 +753,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
                   border: OutlineInputBorder(),
                   labelText: 'Device Name',
                 ),
+                maxLength: DeviceName.maxLength(),
                 initialValue: _controller.form.deviceNames[device.id],
                 onChanged: (name) => _controller.setDeviceName(device.id, name),
                 onFieldSubmitted: (_) => Navigator.pop(context),
@@ -799,6 +802,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
             suffixIcon: Icon(Icons.edit_rounded),
             filled: true,
           ),
+          maxLength: DeviceName.maxLength(),
           style: monospaceTextStyle,
           controller: textController,
           onChanged: isPart

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -273,7 +273,7 @@ class WalletCreateController extends ChangeNotifier {
     if (_step != WalletCreateStep.nonceReplenish && !canGoNext) return false;
     switch (_step) {
       case WalletCreateStep.name:
-        _form.name = _nameController.text;
+        _form.name = _nameController.text.trim();
         return true;
       case WalletCreateStep.deviceCount:
         _form.selectedDevices.clear();
@@ -499,10 +499,11 @@ class WalletCreateController extends ChangeNotifier {
   };
 
   void setDeviceName(DeviceId id, String name) async {
-    if (name.isNotEmpty) {
-      _form.deviceNames[id] = name;
+    final trimmedName = name.trim();
+    if (trimmedName.isNotEmpty) {
+      _form.deviceNames[id] = trimmedName;
       notifyListeners();
-      await coord.updateNamePreview(id: id, name: name);
+      await coord.updateNamePreview(id: id, name: trimmedName);
     } else {
       _form.deviceNames.remove(id);
       notifyListeners();

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -560,6 +560,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
           errorText: _controller.nameError,
         ),
         maxLength: keyNameMaxLength(),
+        inputFormatters: [nameInputFormatter],
         textCapitalization: TextCapitalization.words,
         onSubmitted: (_) {
           _controller.next(context);
@@ -754,6 +755,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
                   labelText: 'Device Name',
                 ),
                 maxLength: DeviceName.maxLength(),
+                inputFormatters: [nameInputFormatter],
                 initialValue: _controller.form.deviceNames[device.id],
                 onChanged: (name) => _controller.setDeviceName(device.id, name),
                 onFieldSubmitted: (_) => Navigator.pop(context),
@@ -803,6 +805,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
             filled: true,
           ),
           maxLength: DeviceName.maxLength(),
+          inputFormatters: [nameInputFormatter],
           style: monospaceTextStyle,
           controller: textController,
           onChanged: isPart

--- a/frostsnapp/rust/src/api/coordinator.rs
+++ b/frostsnapp/rust/src/api/coordinator.rs
@@ -37,7 +37,7 @@ impl FrostKey {
 
     #[frb(sync)]
     pub fn key_name(&self) -> String {
-        self.0.key_name.clone()
+        self.0.key_name.to_string()
     }
 
     #[frb(sync)]
@@ -142,11 +142,11 @@ impl Coordinator {
         self.0.start()
     }
 
-    pub fn update_name_preview(&self, id: DeviceId, name: String) {
-        self.0.update_name_preview(id, &name);
+    pub fn update_name_preview(&self, id: DeviceId, name: String) -> Result<()> {
+        self.0.update_name_preview(id, &name)
     }
 
-    pub fn finish_naming(&self, id: DeviceId, name: String) {
+    pub fn finish_naming(&self, id: DeviceId, name: String) -> Result<()> {
         self.0.finish_naming(id, &name)
     }
 

--- a/frostsnapp/rust/src/api/mod.rs
+++ b/frostsnapp/rust/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod firmware_upgrade;
 pub mod init;
 pub mod keygen;
 pub mod log;
+pub mod name;
 pub mod nonce_replenish;
 pub mod port;
 pub mod psbt_manager;

--- a/frostsnapp/rust/src/api/name.rs
+++ b/frostsnapp/rust/src/api/name.rs
@@ -1,0 +1,16 @@
+use flutter_rust_bridge::frb;
+pub use frostsnap_coordinator::frostsnap_comms::DeviceName;
+
+#[frb(sync, type_64bit_int)]
+pub fn key_name_max_length() -> usize {
+    frostsnap_coordinator::frostsnap_comms::KEY_NAME_MAX_LENGTH
+}
+
+#[frb(external)]
+impl DeviceName {
+    #[frb(sync)]
+    pub fn to_string(&self) -> String {}
+
+    #[frb(sync, type_64bit_int)]
+    pub fn max_length() -> usize {}
+}


### PR DESCRIPTION
This enforces string length limits for device names at the type level. It doesn't do key names because that's part of frostsnap_core but soft limits are in place.

Longer device names will stilld decode they'll just be truncated.