### PR TITLE
[device] Reduce baudrate to 19_200 to stop overflows

### DIFF
--- a/cst816s/src/lib.rs
+++ b/cst816s/src/lib.rs
@@ -313,8 +313,10 @@ pub mod interrupt {
             // Read a touch event from the i2c registers.
             // We don't need to read them all, if there's any left over we'll get re-interupted.
             if let Some(event) = cst.read_one_touch_event(
-                // The pin should be low since we just got the interrupt.
-                false,
+                // The pin should be low since we just got the interrupt...But
+                // if interrupts were frozen for a while the controller might have dropped the event.
+                // Reading events when the pin isn't low causes the screen to freeze 😞
+                true,
             ) {
                 let producer = (&raw mut PRODUCER).as_mut().unwrap().as_mut().unwrap();
                 // Try to enqueue the event (drops if queue is full)

--- a/device/src/ota.rs
+++ b/device/src/ota.rs
@@ -229,18 +229,10 @@ impl FirmwareUpgradeMode<'_> {
                         let mut finished = false;
                         let last_sector_index = partition.n_sectors() - 1;
                         /// So we erase multiple sectors poll (otherwise it's slow).
-                        const ERASE_CHUNK_SIZE: usize = 32;
+                        const ERASE_CHUNK_SIZE: usize = 1;
                         for _ in 0..ERASE_CHUNK_SIZE {
-                            // it's faster to read and check if it's already erased than just to go
-                            // and erase it
-                            if partition
-                                .read_sector(*seq)
-                                .unwrap()
-                                .iter()
-                                .any(|byte| *byte != 0xff)
-                            {
-                                partition.erase_sector(*seq).expect("must erase sector");
-                            }
+                            partition.erase_sector(*seq).expect("must erase sector");
+
                             *seq += 1;
                             if *seq == last_sector_index {
                                 finished = true;

--- a/device/src/uart_interrupt.rs
+++ b/device/src/uart_interrupt.rs
@@ -12,7 +12,7 @@ pub const QUEUE_CAPACITY: usize = 8192;
 
 /// Type alias for the UART byte receiver
 pub type UartReceiver = Consumer<'static, u8, QUEUE_CAPACITY>;
-pub const RX_FIFO_THRESHOLD: u16 = 96;
+pub const RX_FIFO_THRESHOLD: u16 = 32;
 
 /// Number of UARTs supported
 const NUM_UARTS: usize = 2;

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -21,7 +21,10 @@ pub const FACTORY_PUBLIC_KEY: [u8; 32] = [
     0x7c, 0x4f, 0x70, 0x0c, 0x38, 0xfa, 0xe4, 0xeb, 0xac, 0x03, 0x40, 0x9d, 0x7d, 0x46, 0xea, 0x0b,
 ];
 
-pub const BAUDRATE: u32 = 115_200;
+/// We choose this baudrate because esp32c3 freezes interrupts during flash
+/// erase cycles somtimes ~30ms. This is slow enough that the 128 byte uart
+/// FIFOs don't overlfow in that time.
+pub const BAUDRATE: u32 = 19_200;
 /// Magic bytes are 7 bytes in length so when the bincode prefixes it with `00` it is 8 bytes long.
 /// A nice round number here is desirable (but not strictly necessary) because TX and TX buffers
 /// will be some multiple of 8 and so it should overflow the ring buffers neatly.


### PR DESCRIPTION
There is some kind of hardware bug in esp32c3 that stops interrupts working properly during flash erases. Note that interrupts *are* disabled by default during flash erases in esp-storage but even if you turn that off,  1 in every 10 or so erases will be a "bad" erase that disables interrupts anyway. Note this has nothing to do with the content of the interrupt i.e. if it's in IRAM or not. I have no idea how this happens it seems very random.

So reducing the baudrate to this level means it takes around 67ms to transmit 128bytes to fill the FIFO which gives plenty of room.

To give an idea about how much this slows things down. It takes around 66ms to produce a nonce and around 34ms to transmit it at this baud rate so the majority of time is still spent doing multiplications rather than transmission.