### PR TITLE
[app,coord] filter out invalid PSBTs

### DIFF
--- a/frostsnap_coordinator/src/bitcoin.rs
+++ b/frostsnap_coordinator/src/bitcoin.rs
@@ -3,6 +3,8 @@ pub mod psbt;
 pub mod wallet;
 mod wallet_persist;
 
+pub use wallet::PsbtValidationError;
+
 use bdk_chain::{
     bitcoin::{
         self,

--- a/frostsnap_coordinator/src/persist.rs
+++ b/frostsnap_coordinator/src/persist.rs
@@ -262,8 +262,6 @@ pub struct SqlPsbt(pub bdk_chain::bitcoin::Psbt);
 impl FromSql for SqlPsbt {
     fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
         use bdk_chain::bitcoin::Psbt;
-        let bytes = value.as_bytes()?;
-        println!("PSBT size: {}", bytes.len());
         let psbt =
             Psbt::deserialize(value.as_bytes()?).map_err(|e| FromSqlError::Other(Box::new(e)))?;
         Ok(SqlPsbt(psbt))

--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -244,6 +244,13 @@ impl TransactionTemplate {
             .filter_map(|(i, output)| Some((i, output, output.owner.local_owner()?)))
     }
 
+    /// Returns true if this transaction has any inputs that need signing by this wallet.
+    pub fn has_any_inputs_to_sign(&self) -> bool {
+        self.inputs
+            .iter()
+            .any(|input| input.owner.local_owner().is_some())
+    }
+
     pub fn fee(&self) -> Option<u64> {
         self.inputs
             .iter()

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -1378,11 +1378,17 @@ impl ActiveSignSession {
 
     pub fn received_from(&self) -> impl Iterator<Item = DeviceId> + '_ {
         // all sessions make progress at the same time
-        self.progress[0].received_from()
+        self.progress
+            .first()
+            .into_iter()
+            .flat_map(|p| p.received_from())
     }
 
     pub fn has_received_from(&self, device_id: DeviceId) -> bool {
-        self.progress[0].signature_shares.contains_key(&device_id)
+        self.progress
+            .first()
+            .map(|p| p.signature_shares.contains_key(&device_id))
+            .unwrap_or(false)
     }
 
     pub fn session_id(&self) -> SignSessionId {

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -76,6 +76,10 @@ impl WireSignTask {
                     });
                 }
 
+                if !tx_template.has_any_inputs_to_sign() {
+                    return Err(SignTaskError::NothingToSign);
+                }
+
                 if tx_template.fee().is_none() {
                     return Err(SignTaskError::InvalidBitcoinTransaction);
                 }
@@ -170,6 +174,7 @@ pub enum SignTaskError {
     },
     WrongPurpose,
     InvalidBitcoinTransaction,
+    NothingToSign,
 }
 
 impl core::fmt::Display for SignTaskError {
@@ -181,6 +186,9 @@ impl core::fmt::Display for SignTaskError {
             ),
             SignTaskError::InvalidBitcoinTransaction => {
                 write!(f, "Bitcoin transaction input value was less than outputs")
+            }
+            SignTaskError::NothingToSign => {
+                write!(f, "Transaction has no inputs that belong to this wallet")
             }
             SignTaskError::WrongPurpose => {
                 write!(

--- a/frostsnapp/lib/psbt.dart
+++ b/frostsnapp/lib/psbt.dart
@@ -51,8 +51,13 @@ class LoadPsbtPageState extends State<LoadPsbtPage> {
     try {
       psbt = Psbt.deserialize(bytes: psbtBytes);
     } catch (e) {
-      if (context.mounted)
-        showErrorSnackbar(context, "Cannot deserialize PSBT: $e");
+      if (context.mounted) {
+        await showExceptionDialog(
+          context,
+          subtitle: 'Invalid PSBT',
+          exception: e,
+        );
+      }
       return false;
     }
 
@@ -61,9 +66,14 @@ class LoadPsbtPageState extends State<LoadPsbtPage> {
         psbt: psbt,
         masterAppkey: wallet.masterAppkey,
       );
-    } catch (e) {
-      if (context.mounted)
-        showErrorSnackbar(context, "Cannot extract tx from PSBT: $e");
+    } on PsbtValidationError catch (e) {
+      if (context.mounted) {
+        await showExceptionDialog(
+          context,
+          subtitle: 'Unable to process PSBT',
+          exception: e,
+        );
+      }
       return false;
     }
 

--- a/frostsnapp/lib/theme.dart
+++ b/frostsnapp/lib/theme.dart
@@ -1,7 +1,10 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
+import 'package:frostsnap/snackbar.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:sliver_tools/sliver_tools.dart';
 
@@ -84,6 +87,153 @@ Future<T?> showBottomSheetOrDialog<T>(
   // is to make a stateful widget that handles this.
   result.whenComplete(scrollController.dispose);
   return result;
+}
+
+/// Shows a Material Design 3 error dialog
+///
+/// Uses error color scheme to clearly indicate something is wrong.
+/// Follows Material Design 3 guidelines with max width of 560dp.
+/// See: https://m3.material.io/components/dialogs/guidelines
+Future<void> showErrorDialog(
+  BuildContext context, {
+  required Widget title,
+  required Widget content,
+  String actionLabel = 'OK',
+  VoidCallback? onAction,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (context) {
+      final theme = Theme.of(context);
+      final colorScheme = theme.colorScheme;
+
+      return AlertDialog(
+        // Material Design 3 spec: dialogs have a maximal width of 560dp
+        // https://m3.material.io/components/dialogs/guidelines
+        // Note: AlertDialog doesn't enforce this by default
+        // See: https://github.com/flutter/flutter/issues/163709
+        constraints: const BoxConstraints(maxWidth: 560),
+        icon: Icon(Icons.error_outline, color: colorScheme.error, size: 24),
+        iconPadding: const EdgeInsets.only(top: 24),
+        title: DefaultTextStyle(
+          style: theme.textTheme.headlineSmall!.copyWith(
+            color: colorScheme.onSurface,
+          ),
+          child: title,
+        ),
+        content: DefaultTextStyle(
+          style: theme.textTheme.bodyMedium!.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+          child: content,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              onAction?.call();
+            },
+            child: Text(actionLabel),
+          ),
+        ],
+      );
+    },
+  );
+}
+
+/// Shows a Material Design 3 error dialog for exceptions
+///
+/// Displays exception details with scrollable content and a copy button
+/// for reporting. Handles AnyhowException specially by extracting the message.
+Future<void> showExceptionDialog(
+  BuildContext context, {
+  required String subtitle,
+  required Object exception,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (context) {
+      final theme = Theme.of(context);
+      final colorScheme = theme.colorScheme;
+      final scrollController = ScrollController();
+
+      // Extract error message based on exception type
+      final String errorMessage;
+      if (exception is AnyhowException) {
+        errorMessage = exception.message;
+      } else {
+        errorMessage = exception.toString();
+      }
+
+      return AlertDialog(
+        constraints: const BoxConstraints(maxWidth: 560),
+        title: Text(
+          'Error',
+          style: theme.textTheme.headlineSmall?.copyWith(
+            color: colorScheme.onSurface,
+          ),
+        ),
+        content: Container(
+          decoration: BoxDecoration(
+            color: colorScheme.errorContainer,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline,
+                color: colorScheme.onErrorContainer,
+                size: 32,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                subtitle,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: colorScheme.onErrorContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 16),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 300),
+                child: Scrollbar(
+                  controller: scrollController,
+                  thumbVisibility: true,
+                  child: SingleChildScrollView(
+                    controller: scrollController,
+                    child: SelectableText(
+                      errorMessage,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onErrorContainer,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton.icon(
+            onPressed: () async {
+              await Clipboard.setData(ClipboardData(text: errorMessage));
+              if (context.mounted) {
+                showMessageSnackbar(context, 'Error message copied');
+              }
+            },
+            icon: const Icon(Icons.copy),
+            label: const Text('Copy'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      );
+    },
+  );
 }
 
 String spacedHex(String input, {int groupSize = 4, int? groupsPerLine}) {

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -537,16 +537,10 @@ class _WalletSendPageState extends State<WalletSendPage> {
       value: amount,
       feerate: feerate,
     );
-    unsignedTxFut.then(
-      (unsignedTx) {
-        this.unsignedTx = unsignedTx;
-        nextPageOrPop(null);
-      },
-      onError: (e) => amountModel.customError = e.toString().replaceFirst(
-        'FrbAnyhowException(',
-        '',
-      ),
-    );
+    unsignedTxFut.then((unsignedTx) {
+      this.unsignedTx = unsignedTx;
+      nextPageOrPop(null);
+    }, onError: (e) => amountModel.customError = e.toString());
   }
 
   recipientDone(BuildContext context) {

--- a/frostsnapp/lib/wallet_send_feerate_picker.dart
+++ b/frostsnapp/lib/wallet_send_feerate_picker.dart
@@ -118,12 +118,7 @@ class _FeeRatePickerDialogState extends State<FeeRatePickerDialog> {
       if (context.mounted) setState(() => _feeAmount = fee);
     } catch (e) {
       if (context.mounted) {
-        setState(
-          () => _feeAmountError = e
-              .toString()
-              .replaceAll('FrbAnyhowException(', '')
-              .replaceAll(')', ''),
-        );
+        setState(() => _feeAmountError = e.toString());
       }
     }
   }

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -8,6 +8,7 @@ use bitcoin::Txid;
 pub use bitcoin::{Address, Network as BitcoinNetwork, Psbt};
 use flutter_rust_bridge::frb;
 pub use frostsnap_coordinator::bitcoin::wallet::AddressInfo;
+pub use frostsnap_coordinator::bitcoin::wallet::PsbtValidationError;
 pub use frostsnap_coordinator::bitcoin::{chain_sync::ChainClient, wallet::CoordSuperWallet};
 pub use frostsnap_coordinator::verify_address::VerifyAddressProtocolState;
 
@@ -26,6 +27,12 @@ pub struct TxState {
     pub txs: Vec<Transaction>,
     pub balance: i64,
     pub untrusted_pending_balance: i64,
+}
+
+#[frb(external)]
+impl PsbtValidationError {
+    #[frb(sync)]
+    pub fn to_string(&self) -> String {}
 }
 
 #[derive(Clone)]
@@ -259,7 +266,7 @@ impl SuperWallet {
         &self,
         psbt: &Psbt,
         master_appkey: MasterAppkey,
-    ) -> Result<UnsignedTx> {
+    ) -> Result<UnsignedTx, PsbtValidationError> {
         let template = self
             .inner
             .lock()


### PR DESCRIPTION
Where we don't have anything that we can sign. Previously if you added a PSBT that has nothing to sign the app will never start up again.

Also tried to add a generic error dialog that we can iterate on.