### PR TITLE
[app/coord] Fix ConnectedDevice upgrade eligibility

### DIFF
--- a/frostsnap_coordinator/src/firmware_upgrade.rs
+++ b/frostsnap_coordinator/src/firmware_upgrade.rs
@@ -25,7 +25,7 @@ impl FirmwareUpgradeProtocol {
     ) -> Self {
         // Check if any device has incompatible firmware
         let abort_reason = devices.values().find_map(|fw| {
-            match firmware_bin.check_upgrade_eligibility(&fw.digest) {
+            match firmware_bin.firmware_version().check_upgrade_eligibility(&fw.digest) {
                 FirmwareUpgradeEligibility::CannotUpgrade { reason } => {
                     Some(format!("One of the devices is incompatible with the upgrade. Unplug it to continue or try upgrading the app. Problem: {reason}"))
                 }

--- a/frostsnapp/rust/src/api/device_list.rs
+++ b/frostsnapp/rust/src/api/device_list.rs
@@ -1,4 +1,4 @@
-pub use crate::api::firmware::{FirmwareUpgradeEligibility, FirmwareVersion, ValidatedFirmwareBin};
+pub use crate::api::firmware::{FirmwareUpgradeEligibility, FirmwareVersion};
 use anyhow::Result;
 use flutter_rust_bridge::frb;
 use frostsnap_coordinator::DeviceMode;
@@ -34,11 +34,10 @@ pub struct DeviceListState {
 }
 
 #[derive(Clone, Debug)]
-#[frb(opaque)]
 pub struct ConnectedDevice {
     pub name: Option<String>,
     pub firmware: FirmwareVersion,
-    pub latest_firmware: Option<ValidatedFirmwareBin>,
+    pub latest_firmware: Option<FirmwareVersion>,
     pub id: DeviceId,
     pub recovery_mode: bool,
 }

--- a/frostsnapp/rust/src/api/firmware.rs
+++ b/frostsnapp/rust/src/api/firmware.rs
@@ -73,6 +73,13 @@ impl VersionNumber {
 impl FirmwareVersion {
     #[frb(sync)]
     pub fn version_name(&self) -> String {}
+
+    #[frb(sync)]
+    pub fn check_upgrade_eligibility(
+        &self,
+        _device_digest: &Sha256Digest,
+    ) -> FirmwareUpgradeEligibility {
+    }
 }
 
 #[frb(mirror(Sha256Digest))]

--- a/frostsnapp/rust/src/device_list.rs
+++ b/frostsnapp/rust/src/device_list.rs
@@ -74,19 +74,18 @@ impl DeviceList {
                 firmware_digest,
                 latest_firmware_digest,
             } => {
-                use frostsnap_coordinator::frostsnap_comms::Sha256Digest;
                 use frostsnap_coordinator::FirmwareVersion;
 
-                let connected = self.connected.entry(id).or_insert(api::ConnectedDevice {
-                    firmware: FirmwareVersion::new(Sha256Digest([0u8; 32])),
-                    latest_firmware: crate::FIRMWARE.and_then(|fw| fw.validate().ok()),
-                    name: None,
+                self.connected.insert(
                     id,
-                    recovery_mode: false,
-                });
-
-                connected.firmware = FirmwareVersion::new(firmware_digest);
-                connected.latest_firmware = crate::FIRMWARE.and_then(|fw| fw.validate().ok());
+                    api::ConnectedDevice {
+                        firmware: FirmwareVersion::new(firmware_digest),
+                        latest_firmware: latest_firmware_digest.map(FirmwareVersion::new),
+                        name: None,
+                        id,
+                        recovery_mode: false,
+                    },
+                );
             }
             DeviceChange::NameChange { id, name } => {
                 if let Some(index) = self.index_of(id) {


### PR DESCRIPTION
We should not have been trying to put the entire firmware binary even as an opaque type up to rust. We just needed the version.

In general it's best to avoid opaque types in non-opaque types unless you want to be very careful about doing it. You have to wrap stuff in `RustOpaque` or `RustAutoOpaque` which creates a lot of friction.