### PR TITLE
[widget] Hold-to-confirm widget

### DIFF
--- a/frostsnap_widgets/src/checkmark.rs
+++ b/frostsnap_widgets/src/checkmark.rs
@@ -51,6 +51,14 @@ impl<C: PixelColor> Checkmark<C> {
         checkmark
     }
 
+    pub fn set_color(&mut self, color: C) {
+        if self.color != color {
+            self.color = color;
+            // Re-record pixels with new color
+            self.record_pixels();
+        }
+    }
+
     pub fn start_drawing(&mut self) {
         self.enabled = true;
         self.progress = Frac::ZERO;
@@ -217,11 +225,7 @@ impl<C: PixelColor> crate::DynWidget for Checkmark<C> {
     }
 
     fn sizing(&self) -> crate::Sizing {
-        crate::Sizing {
-            width: self.check_width,
-            height: self.check_height,
-            ..Default::default()
-        }
+        Size::new(self.check_width, self.check_height).into()
     }
 
     fn handle_touch(

--- a/frostsnap_widgets/src/hold_to_confirm.rs
+++ b/frostsnap_widgets/src/hold_to_confirm.rs
@@ -18,7 +18,12 @@ pub struct HoldToConfirm<W>
 where
     W: Widget<Color = Rgb565>,
 {
-    content: Box<HoldToConfirmBorder<Container<Center<Column<(W, Fader<CircleButton>)>>>, Rgb565>>,
+    content: Box<
+        HoldToConfirmBorder<
+            Container<Center<Column<(W, Fader<CircleButton>, SizedBox<Rgb565>)>>>,
+            Rgb565,
+        >,
+    >,
     last_update: Option<crate::Instant>,
     hold_duration_ms: u32,
     completed: bool,
@@ -35,11 +40,15 @@ where
         let button = CircleButton::new();
         let faded_button = Fader::new(button);
 
-        // Create column with the widget (flex) and faded button
+        // Create a 10px spacer beneath the button
+        let bottom_spacer = SizedBox::<Rgb565>::new(Size::new(1, 10));
+
+        // Create column with the widget (flex), faded button, and spacer
         let column = Column::builder()
             .push(widget)
             .flex(1)
             .push(faded_button)
+            .push(bottom_spacer)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween);
 
         // Center the column, then put it in an expanded container to fill available space
@@ -68,10 +77,28 @@ where
         self
     }
 
+    /// Builder method to set custom colors for border and button
+    ///
+    /// # Arguments
+    /// * `border_color` - Color for the progress border
+    /// * `button_fill_color` - Fill color for the button when pressed
+    /// * `button_stroke_color` - Stroke color for the button when pressed
+    pub fn with_custom_colors(
+        mut self,
+        border_color: Rgb565,
+        button_fill_color: Rgb565,
+        button_stroke_color: Rgb565,
+    ) -> Self {
+        self.content.set_border_color(border_color);
+        self.button_mut()
+            .set_pressed_colors(button_fill_color, button_stroke_color);
+        self
+    }
+
     /// Fade in the button
     pub fn fade_in_button(&mut self) {
         if self.button_fader_mut().is_faded_out() {
-            self.button_fader_mut().start_fade_in(300);
+            self.button_fader_mut().start_fade_in(300); // 300ms fade duration
         }
     }
 

--- a/frostsnap_widgets/src/hold_to_confirm_border.rs
+++ b/frostsnap_widgets/src/hold_to_confirm_border.rs
@@ -84,6 +84,16 @@ where
         self.border_width
     }
 
+    pub fn set_border_color(&mut self, color: C) {
+        self.border_color = color;
+        // Force redraw with new color
+        self.last_drawn_progress = Frac::from_ratio(u32::MAX, u32::MAX); // Force redraw
+    }
+
+    pub fn set_background_color(&mut self, color: C) {
+        self.background_color = color;
+    }
+
     pub fn start_fade_out(&mut self, duration_ms: u64) {
         self.is_fading = true;
         self.fade_duration_ms = duration_ms;


### PR DESCRIPTION
Enhances hold-to-confirm widget system with color customization:
- Add customizable colors to CircleButton (idle stroke, pressed fill/stroke, checkmark)
- Add set_border_color() and set_background_color() to HoldToConfirmBorder
- Add with_custom_colors() builder method to HoldToConfirm
- Add 10px bottom spacer for improved visual spacing
- Add set_color() method to Checkmark for dynamic color updates
