### PR TITLE
[ci] Fix cache key to distinguish between Ubuntu versions

### DIFF
--- a/.github/actions/install-cargo-bins/action.yml
+++ b/.github/actions/install-cargo-bins/action.yml
@@ -26,7 +26,7 @@ runs:
           ~/.cargo/bin
           ~/.cargo/.crates.toml
           ~/.cargo/.crates2.json
-        key: ${{ runner.os }}-rust-bins-${{ inputs.version }}-${{ steps.hash_rust_bins.outputs.hash }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ runner.image }}-rust-bins-v0-${{ inputs.version }}-${{ steps.hash_rust_bins.outputs.hash }}
 
     - name: Setup Rust Toolchain
       if: steps.cache-rust-bins.outputs.cache-hit != 'true'


### PR DESCRIPTION
The cargo binaries cache was using only runner.os which doesn't distinguish between ubuntu-latest (24.04) and ubuntu-22.04. This caused GLIBC version mismatches when binaries built on 24.04 (requiring GLIBC 2.39) were used on 22.04 (which only has GLIBC 2.35).

Added runner.arch and runner.image to the cache key to ensure binaries are cached separately for different Ubuntu versions.