### PR TITLE
Fix typo in Rust cache key template

### DIFF
--- a/.github/actions/cache-rust-target/action.yml
+++ b/.github/actions/cache-rust-target/action.yml
@@ -24,6 +24,6 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ inputs.path }}
-        key: "${{ runner.os }}-${{ inputs.key }}-rust-target-${{steps.rust-toolchain.outputs-cachekey}}-${{ hashFiles('**/Cargo.lock') }}"
+        key: "${{ runner.os }}-${{ inputs.key }}-rust-target-${{steps.rust-toolchain.outputs.cachekey}}-${{ hashFiles('**/Cargo.lock') }}"
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.key }}-rust-target-${{steps.rust-toolchain.outputs-cachekey}}-
+          ${{ runner.os }}-${{ inputs.key }}-rust-target-${{steps.rust-toolchain.outputs.cachekey}}-


### PR DESCRIPTION
outputs-cachekey → outputs.cachekey