### PR TITLE
Add camera entitlement for hardened runtime

### DIFF
--- a/frostsnapp/macos/Runner/Release.entitlements
+++ b/frostsnapp/macos/Runner/Release.entitlements
@@ -18,5 +18,7 @@
 	<true/>
 	<key>com.apple.security.device.usb</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds `com.apple.security.device.camera` entitlement to Release.entitlements
