### PR TITLE
[app] Keep device displaying address after verify dialog dismissal

### DIFF
--- a/frostsnapp/lib/wallet_receive.dart
+++ b/frostsnapp/lib/wallet_receive.dart
@@ -212,7 +212,7 @@ class _ReceiverPageState extends State<ReceivePage> {
   set focus(ReceivePageFocus v) {
     if (v == _focus || _address == null) return;
     if (v == ReceivePageFocus.verify) {
-      _verifyStreamSub?.cancel();
+      _cancelVerify();
       _verifyStreamSub = coord
           .verifyAddress(
             keyId: widget.wallet.keyId(),
@@ -231,12 +231,17 @@ class _ReceiverPageState extends State<ReceivePage> {
       });
       return;
     }
-    if (_verifyStreamSub != null) coord.cancelProtocol();
-    _verifyStreamSub?.cancel();
-    _verifyStreamSub = null;
     setState(() {
       _focus = v;
     });
+  }
+
+  void _cancelVerify() {
+    if (_verifyStreamSub != null) {
+      coord.cancelProtocol();
+      _verifyStreamSub?.cancel();
+      _verifyStreamSub = null;
+    }
   }
 
   bool get isRevealed => _address?.revealed ?? false;
@@ -318,16 +323,16 @@ class _ReceiverPageState extends State<ReceivePage> {
 
   @override
   void dispose() {
-    if (_focus == ReceivePageFocus.verify) {
-      coord.cancelProtocol();
-    }
-    _verifyStreamSub?.cancel();
+    _cancelVerify();
     txStreamSub.cancel();
     fullscreenDialogController.dispose();
     super.dispose();
   }
 
   void updateToIndex(int index, {ReceivePageFocus? next}) {
+    if (_address != null && _address!.index != index) {
+      _cancelVerify();
+    }
     final addr = wallet.getAddressInfo(index);
     if (mounted) {
       setState(() {


### PR DESCRIPTION
Decouple the verify protocol lifecycle from the UI focus state so that dismissing the verify dialog no longer cancels the protocol on the device. The address stays on the device screen until the user changes the address or leaves the receive flow entirely.

This change is in response to user feedback. Instead of forcing a user to verify the address on the device against an external address by obscuring the address in the app, if the user cancels the verify address dialog then their device will continue to display the address until they exit the receive flow.