### PR TITLE
[device] Change backlight from 30% to 100%

### DIFF
--- a/device/src/peripherals.rs
+++ b/device/src/peripherals.rs
@@ -264,7 +264,7 @@ impl<'a> DevicePeripherals<'a> {
 
         // Clear display and turn on backlight
         let _ = display.clear(Rgb565::BLACK);
-        backlight.start_duty_fade(0, 30, 500).unwrap();
+        backlight.start_duty_fade(0, 100, 500).unwrap();
 
         // Initialize other crypto peripherals
         let efuse = EfuseController::new(&mut peripherals.EFUSE);


### PR DESCRIPTION
New device screens are dimmer than prototype screens.

Increasing backlight from 30% to 100% makes new device screens roughly equivalent in brightness to prototype screens at 30%.

We can look at feature gating by screen batch and adjusting during factory calibration later