### PR TITLE
Improve backup reminder UX and wallet creation polish

### DIFF
--- a/frostsnapp/lib/backup_workflow.dart
+++ b/frostsnapp/lib/backup_workflow.dart
@@ -739,6 +739,28 @@ class _BackupChecklistState extends State<BackupChecklist> {
                     );
                   },
                 ),
+                if (!allComplete)
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        textStyle: theme.textTheme.bodySmall,
+                      ),
+                      onPressed: () async {
+                        final accessStructureRef = accessStructure
+                            .accessStructureRef();
+                        for (final device in deviceInfoList) {
+                          if (device.complete != true) {
+                            await coord.markBackupComplete(
+                              accessStructureRef: accessStructureRef,
+                              shareIndex: device.shareIndex,
+                            );
+                          }
+                        }
+                      },
+                      child: const Text('Mark backups as complete'),
+                    ),
+                  ),
                 const SizedBox(height: 24),
                 Center(
                   child: allComplete

--- a/frostsnapp/lib/keygen.dart
+++ b/frostsnapp/lib/keygen.dart
@@ -5,11 +5,13 @@ import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
 import 'package:frostsnap/theme.dart';
 
-void showWalletCreatedDialog(
+/// Returns `true` if the user dismissed the dialog (pressed "Later"),
+/// `false` if they chose to secure the wallet.
+Future<bool> showWalletCreatedDialog(
   BuildContext context,
   AccessStructure accessStructure,
 ) async {
-  await showDialog(
+  final dismissed = await showDialog<bool>(
     context: context,
     barrierDismissible: false,
     builder: (BuildContext context) {
@@ -80,7 +82,7 @@ void showWalletCreatedDialog(
           actions: [
             TextButton(
               onPressed: () {
-                Navigator.of(context).pop();
+                Navigator.of(context).pop(true);
               },
               child: const Text('Later'),
             ),
@@ -104,4 +106,5 @@ void showWalletCreatedDialog(
       );
     },
   );
+  return dismissed == true;
 }

--- a/frostsnapp/lib/theme.dart
+++ b/frostsnapp/lib/theme.dart
@@ -11,6 +11,7 @@ import 'package:sliver_tools/sliver_tools.dart';
 final monospaceTextStyle = GoogleFonts.notoSansMono();
 final blurFilter = ImageFilter.blur(sigmaX: 21, sigmaY: 21);
 const seedColor = Color(0xFF1595B2);
+const cautionColor = Colors.amber;
 const double iconSize = 20.0;
 
 /// M3 standard dialog constraints

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:frostsnap/backup_workflow.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/device_list.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
+import 'package:frostsnap/keygen.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/nonce_replenish.dart';
 import 'package:frostsnap/restoration/wallet_recovery_page.dart';
@@ -713,17 +713,37 @@ class WalletBottomBar extends StatelessWidget {
     );
 
     final receiveButton = TextButton.icon(
-      onPressed: () => showBottomSheetOrDialog(
-        context,
-        title: Text('Receive'),
-        builder: (context, scrollController) => walletCtx.wrap(
-          ReceivePage(
-            wallet: walletCtx.wallet,
-            txStream: walletCtx.txStream,
-            scrollController: scrollController,
+      onPressed: () async {
+        // Check if backups are incomplete — if so, show the secure wallet dialog first
+        final backupStream = walletCtx.backupStream;
+        if (backupStream is BehaviorSubject<BackupRun>) {
+          final backupRun = backupStream.valueOrNull;
+          if (backupRun != null &&
+              !backupRun.devices.every((device) => device.complete == true)) {
+            final frostKey = coord.getFrostKey(keyId: walletCtx.keyId);
+            if (frostKey != null) {
+              final accessStructure = frostKey.accessStructures()[0];
+              final dismissed = await showWalletCreatedDialog(
+                context,
+                accessStructure,
+              );
+              if (!dismissed) return;
+            }
+          }
+        }
+        if (!context.mounted) return;
+        showBottomSheetOrDialog(
+          context,
+          title: Text('Receive'),
+          builder: (context, scrollController) => walletCtx.wrap(
+            ReceivePage(
+              wallet: walletCtx.wallet,
+              txStream: walletCtx.txStream,
+              scrollController: scrollController,
+            ),
           ),
-        ),
-      ),
+        );
+      },
       label: Text('Receive', softWrap: false, overflow: TextOverflow.fade),
       icon: Icon(Icons.south_east),
       style: textButtonStyle,
@@ -1208,53 +1228,56 @@ class BackupWarningBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final walletCtx = WalletContext.of(context)!;
     final backupStream = walletCtx.backupStream;
-    final theme = Theme.of(context);
 
-    final button = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      child: IconButton(
-        onPressed: () => onTap(context, walletCtx),
-        icon: Icon(Icons.warning_rounded),
-        style: IconButton.styleFrom(foregroundColor: theme.colorScheme.error),
-        tooltip: 'This wallet has unfinished backups!',
-      ),
-    );
-
-    final banner = ListTile(
-      dense: true,
-      contentPadding: EdgeInsets.symmetric(horizontal: 16),
-      onTap: () => onTap(context, walletCtx),
-      iconColor: theme.colorScheme.error,
-      textColor: theme.colorScheme.error,
-      leading: Icon(Icons.warning_rounded),
-      trailing: Icon(Icons.chevron_right),
-      title: Text('This wallet has unfinished backups!'),
-    );
-
-    final widget = shrink ? button : banner;
-
-    final streamedBanner = StreamBuilder<BackupRun>(
+    return StreamBuilder<BackupRun>(
       stream: backupStream,
-      builder: (context, snapshot) {
-        final backupRun = snapshot.data;
+      builder: (context, backupSnapshot) {
+        final backupRun = backupSnapshot.data;
         final hideBanner = backupRun == null || isBackupDone(backupRun);
-        return hideBanner ? SizedBox.shrink() : widget;
+        if (hideBanner) return SizedBox.shrink();
+
+        return StreamBuilder<TxState>(
+          stream: walletCtx.txStream,
+          builder: (context, txSnapshot) {
+            final txState = txSnapshot.data;
+            final hasFunds =
+                (txState?.balance ?? 0) > 0 ||
+                (txState?.untrustedPendingBalance ?? 0) > 0;
+            final color = hasFunds
+                ? Theme.of(context).colorScheme.error
+                : cautionColor;
+
+            if (shrink) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: IconButton(
+                  onPressed: () => onTap(context, walletCtx),
+                  icon: Icon(Icons.warning_rounded),
+                  style: IconButton.styleFrom(foregroundColor: color),
+                  tooltip: 'This wallet has unfinished backups!',
+                ),
+              );
+            }
+
+            return ListTile(
+              dense: true,
+              contentPadding: EdgeInsets.symmetric(horizontal: 16),
+              onTap: () => onTap(context, walletCtx),
+              iconColor: color,
+              textColor: color,
+              leading: Icon(Icons.warning_rounded),
+              trailing: Icon(Icons.chevron_right),
+              title: Text('This wallet has unfinished backups!'),
+            );
+          },
+        );
       },
     );
-
-    return streamedBanner;
   }
 
   void onTap(BuildContext context, WalletContext walletContext) async {
-    await MaybeFullscreenDialog.show(
-      context: context,
-      child: walletContext.wrap(
-        BackupChecklist(
-          accessStructure: frostKey.accessStructures()[0],
-          showAppBar: true,
-        ),
-      ),
-    );
+    final accessStructure = frostKey.accessStructures()[0];
+    showWalletCreatedDialog(context, accessStructure);
   }
 
   bool isBackupDone(BackupRun backupRun) =>

--- a/frostsnapp/lib/wallet_add.dart
+++ b/frostsnapp/lib/wallet_add.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/global.dart';
-import 'package:frostsnap/keygen.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/restoration.dart';
 import 'package:frostsnap/src/rust/api.dart';
@@ -184,8 +183,6 @@ class WalletAddColumn extends StatelessWidget {
     );
 
     if (!context.mounted || asRef == null) return;
-    final accessStructure = coord.getAccessStructure(asRef: asRef)!;
-    showWalletCreatedDialog(context, accessStructure);
     homeCtx.openNewlyCreatedWallet(asRef.keyId);
   }
 

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -777,7 +777,6 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
       child: ListTile(
         title: Text(
           device.name ?? _controller.form.deviceNames[device.id] ?? '',
-          style: monospaceTextStyle,
         ),
         leading: Icon(Icons.key),
         contentPadding: EdgeInsets.symmetric(
@@ -889,27 +888,34 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
       margin: EdgeInsets.symmetric(vertical: 4),
       color: Theme.of(context).colorScheme.surface,
       clipBehavior: Clip.hardEdge,
-      child: ListTile(
-        leading: Icon(Icons.key),
-        contentPadding: EdgeInsets.symmetric(horizontal: 12),
-        title: TextField(
-          decoration: InputDecoration(
-            hintText: 'Enter device name',
-            border: OutlineInputBorder(
-              borderSide: BorderSide.none,
-              borderRadius: BorderRadius.all(Radius.circular(8)),
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(padding: EdgeInsets.only(top: 12), child: Icon(Icons.key)),
+            SizedBox(width: 12),
+            Expanded(
+              child: TextField(
+                decoration: InputDecoration(
+                  hintText: 'Enter device name',
+                  border: OutlineInputBorder(
+                    borderSide: BorderSide.none,
+                    borderRadius: BorderRadius.all(Radius.circular(8)),
+                  ),
+                  suffixIcon: Icon(Icons.edit_rounded),
+                  filled: true,
+                ),
+                maxLength: DeviceName.maxLength(),
+                inputFormatters: [nameInputFormatter],
+                controller: textController,
+                onChanged: isPart
+                    ? (name) => _controller.setDeviceName(device.id, name)
+                    : null,
+                enabled: isPart,
+              ),
             ),
-            suffixIcon: Icon(Icons.edit_rounded),
-            filled: true,
-          ),
-          maxLength: DeviceName.maxLength(),
-          inputFormatters: [nameInputFormatter],
-          style: monospaceTextStyle,
-          controller: textController,
-          onChanged: isPart
-              ? (name) => _controller.setDeviceName(device.id, name)
-              : null,
-          enabled: isPart,
+          ],
         ),
       ),
     );


### PR DESCRIPTION
  - Backup reminder dialog now intercepts the Receive flow when backups are incomplete — user can dismiss it to proceed or go to the backup screen
  - "Unfinished backups" warning banner is amber by default, upgrades to red when the wallet has funds
  - Added "Mark backups as complete" option on backup keys screen to manually dismiss the notification
  - Removed auto-popup of backup dialog after wallet creation — it now only appears via the warning banner or when opening the receive flow without having completed backups
  - Device name input uses default font and fixes key icon alignment with text fields in wallet creation
