### PR TITLE
Make "Add another key" the primary action during restoration

### DIFF
--- a/frostsnapp/lib/restoration/wallet_recovery_page.dart
+++ b/frostsnapp/lib/restoration/wallet_recovery_page.dart
@@ -159,11 +159,11 @@ class WalletRecoveryPage extends StatelessWidget {
                     ),
                   ),
                   Flexible(
-                    child: FilledButton.icon(
-                      icon: const Icon(Icons.check_rounded),
-                      label: const Text('Restore'),
-                      onPressed: isReady
-                          ? () async {
+                    child: isReady
+                        ? FilledButton.icon(
+                            icon: const Icon(Icons.check_rounded),
+                            label: const Text('Restore'),
+                            onPressed: () async {
                               try {
                                 final encryptionKey =
                                     await SecureKeyProvider.getEncryptionKey();
@@ -183,9 +183,18 @@ class WalletRecoveryPage extends StatelessWidget {
                                   );
                                 }
                               }
-                            }
-                          : null,
-                    ),
+                            },
+                          )
+                        : FilledButton.icon(
+                            icon: const Icon(Icons.add),
+                            label: const Text('Add another key'),
+                            onPressed: () {
+                              continueWalletRecoveryFlowDialog(
+                                context,
+                                restorationId: restorationState.restorationId,
+                              );
+                            },
+                          ),
                   ),
                 ],
               ),
@@ -400,20 +409,20 @@ class WalletRecoveryPage extends StatelessWidget {
                       ),
                       const SizedBox(height: 8),
                       devicesColumn,
-                      const SizedBox(height: 8),
-                      Align(
-                        alignment: AlignmentDirectional.centerEnd,
-                        child: TextButton.icon(
-                          icon: const Icon(Icons.add),
-                          label: const Text('Add another key'),
-                          onPressed: () {
-                            continueWalletRecoveryFlowDialog(
-                              context,
-                              restorationId: restorationState.restorationId,
-                            );
-                          },
+                      if (isReady)
+                        Align(
+                          alignment: AlignmentDirectional.centerEnd,
+                          child: TextButton.icon(
+                            icon: const Icon(Icons.add),
+                            label: const Text('Add another key'),
+                            onPressed: () {
+                              continueWalletRecoveryFlowDialog(
+                                context,
+                                restorationId: restorationState.restorationId,
+                              );
+                            },
+                          ),
                         ),
-                      ),
                       SizedBox(height: 16),
                       progressActionCard,
                     ],

--- a/frostsnapp/lib/restoration/wallet_recovery_page.dart
+++ b/frostsnapp/lib/restoration/wallet_recovery_page.dart
@@ -35,6 +35,14 @@ class WalletRecoveryPage extends StatelessWidget {
         ? shareCount.needed! - shareCount.got!
         : null;
     final isReady = isRecovered && !hasIncompatibleShares;
+    final isBlockedByIncompatibleShares = isRecovered && hasIncompatibleShares;
+
+    void openAddKeyDialog() {
+      continueWalletRecoveryFlowDialog(
+        context,
+        restorationId: restorationState.restorationId,
+      );
+    }
 
     final IconData cardIcon;
     final String cardTitle;
@@ -185,15 +193,16 @@ class WalletRecoveryPage extends StatelessWidget {
                               }
                             },
                           )
+                        : isBlockedByIncompatibleShares
+                        ? FilledButton.icon(
+                            icon: const Icon(Icons.check_rounded),
+                            label: const Text('Restore'),
+                            onPressed: null,
+                          )
                         : FilledButton.icon(
                             icon: const Icon(Icons.add),
                             label: const Text('Add another key'),
-                            onPressed: () {
-                              continueWalletRecoveryFlowDialog(
-                                context,
-                                restorationId: restorationState.restorationId,
-                              );
-                            },
+                            onPressed: openAddKeyDialog,
                           ),
                   ),
                 ],
@@ -409,20 +418,17 @@ class WalletRecoveryPage extends StatelessWidget {
                       ),
                       const SizedBox(height: 8),
                       devicesColumn,
-                      if (isReady)
+                      if (isReady) ...[
+                        const SizedBox(height: 8),
                         Align(
                           alignment: AlignmentDirectional.centerEnd,
                           child: TextButton.icon(
                             icon: const Icon(Icons.add),
                             label: const Text('Add another key'),
-                            onPressed: () {
-                              continueWalletRecoveryFlowDialog(
-                                context,
-                                restorationId: restorationState.restorationId,
-                              );
-                            },
+                            onPressed: openAddKeyDialog,
                           ),
                         ),
+                      ],
                       SizedBox(height: 16),
                       progressActionCard,
                     ],


### PR DESCRIPTION
Make "Add another key" the primary action during restoration unti la threshold of devices has been added, then switch to "Restore". "Add another key" then becomes a secondary button if the user wants to keep adding keys before restoring.

Users were unable to find the "Add another key" button during the restore flow during user testing. Now the main action button shows "Add another key" until enough keys are present, then switches to "Restore".
