### PR TITLE
Improve app copy and UX based on user testing

### DIFF
--- a/frostsnapp/lib/backup_workflow.dart
+++ b/frostsnapp/lib/backup_workflow.dart
@@ -463,7 +463,78 @@ class _BackupChecklistState extends State<BackupChecklist> {
                 ),
                 const SizedBox(height: 24),
 
-                // Combined gradient border with device status and progress
+                // Device checklist
+                ...() {
+                  // Group devices by share index
+                  final devicesByShareIndex = <int, List<BackupDevice>>{};
+                  for (final device in deviceInfoList) {
+                    devicesByShareIndex
+                        .putIfAbsent(device.shareIndex, () => [])
+                        .add(device);
+                  }
+
+                  return devicesByShareIndex.entries.map((entry) {
+                    final shareIndex = entry.key;
+                    final devices = entry.value;
+                    final complete = devices.first.complete;
+
+                    return ListTile(
+                      dense: true,
+                      leading: complete == true
+                          ? Icon(
+                              Icons.check_circle,
+                              color: theme.colorScheme.primary,
+                            )
+                          : SizedBox(width: 24),
+                      title: Row(
+                        spacing: 4,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            "Key #$shareIndex",
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          Flexible(
+                            child: Text(
+                              devices
+                                  .map(
+                                    (d) =>
+                                        coord.getDeviceName(id: d.deviceId) ??
+                                        '',
+                                  )
+                                  .join(', '),
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.w500,
+                              ),
+                              softWrap: true,
+                            ),
+                          ),
+                        ],
+                      ),
+                      trailing: complete == true
+                          ? Text(
+                              'Backed up',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.primary,
+                              ),
+                            )
+                          : Text(
+                              'Needs backup',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                    );
+                  }).toList();
+                }(),
+
+                const SizedBox(height: 16),
+
+                // Device connection call-to-action
                 StreamBuilder<DeviceListUpdate>(
                   stream: GlobalStreams.deviceListSubject,
                   builder: (context, deviceListSnapshot) {
@@ -471,29 +542,25 @@ class _BackupChecklistState extends State<BackupChecklist> {
                         deviceListSnapshot.data?.state.devices ?? [];
                     final deviceCount = connectedDevices.length;
 
-                    Widget deviceStatusContent;
+                    Widget statusContent;
                     IconData statusIcon;
                     Color? statusIconColor;
 
                     if (deviceCount > 1) {
-                      // Multiple devices warning
                       statusIcon = Icons.warning_sharp;
                       statusIconColor = theme.colorScheme.primary;
-                      deviceStatusContent = Text(
+                      statusContent = Text(
                         'Multiple devices connected. Connect only one device at a time.',
                       );
                     } else if (deviceCount == 1) {
-                      // Single device - show buttons
                       final connectedDevice = connectedDevices.first;
                       final connectedDeviceId = connectedDevice.id;
 
-                      // Find the share index for the connected device
                       final shareIndex = accessStructure
                           .getDeviceShortShareIndex(
                             deviceId: connectedDeviceId,
                           );
 
-                      // Find backup info for this share index
                       final deviceInfo = shareIndex != null
                           ? deviceInfoList.firstWhereOrNull(
                               (d) => d.shareIndex == shareIndex,
@@ -503,13 +570,13 @@ class _BackupChecklistState extends State<BackupChecklist> {
                       if (deviceInfo == null) {
                         statusIcon = Icons.info_rounded;
                         statusIconColor = null;
-                        deviceStatusContent = Text(
+                        statusContent = Text(
                           'Unknown device connected. Please check your device.',
                         );
                       } else {
                         statusIcon = Icons.usb_rounded;
                         statusIconColor = theme.colorScheme.primary;
-                        deviceStatusContent = Wrap(
+                        statusContent = Wrap(
                           spacing: 16,
                           runSpacing: 8,
                           crossAxisAlignment: WrapCrossAlignment.center,
@@ -567,12 +634,9 @@ class _BackupChecklistState extends State<BackupChecklist> {
                         );
                       }
                     } else {
-                      // No device
                       statusIcon = Icons.usb_rounded;
                       statusIconColor = null;
-                      deviceStatusContent = Text(
-                        'Plug in device to back it up',
-                      );
+                      statusContent = Text('Plug in device to back it up');
                     }
 
                     return AnimatedGradientBorder(
@@ -587,154 +651,24 @@ class _BackupChecklistState extends State<BackupChecklist> {
                         theme.colorScheme.secondary,
                         theme.colorScheme.tertiary,
                       ],
-                      child:
-                          (Widget child) {
-                            return Card.filled(
-                              margin: EdgeInsets.all(0.0),
-                              color: theme.colorScheme.surfaceContainerHigh,
-                              child: child,
-                            );
-                          }(
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                      child: Card.filled(
+                        margin: EdgeInsets.all(0.0),
+                        color: theme.colorScheme.surfaceContainerHigh,
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: ConstrainedBox(
+                            constraints: BoxConstraints(minHeight: 48),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
                               children: [
-                                // Device status section
-                                Padding(
-                                  padding: const EdgeInsets.all(16.0),
-                                  child: ConstrainedBox(
-                                    constraints: BoxConstraints(minHeight: 48),
-                                    child: Row(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.center,
-                                      children: [
-                                        Icon(
-                                          statusIcon,
-                                          color: statusIconColor,
-                                        ),
-                                        const SizedBox(width: 12),
-                                        Expanded(child: deviceStatusContent),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                                Divider(height: 1),
-                                // Device checklist with progress counter
-                                Stack(
-                                  children: [
-                                    Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.stretch,
-                                      children: () {
-                                        // Group devices by share index
-                                        final devicesByShareIndex =
-                                            <int, List<BackupDevice>>{};
-                                        for (final device in deviceInfoList) {
-                                          devicesByShareIndex
-                                              .putIfAbsent(
-                                                device.shareIndex,
-                                                () => [],
-                                              )
-                                              .add(device);
-                                        }
-
-                                        // Create list tiles for each share index
-                                        return devicesByShareIndex.entries.map((
-                                          entry,
-                                        ) {
-                                          final shareIndex = entry.key;
-                                          final devices = entry.value;
-
-                                          // All devices with the same share index have the same completion status
-                                          final complete =
-                                              devices.first.complete;
-
-                                          IconData icon;
-                                          Color color;
-
-                                          if (complete == true) {
-                                            icon = Icons.check_circle;
-                                            color = theme.colorScheme.primary;
-                                          } else {
-                                            icon = Icons.circle_outlined;
-                                            color = theme
-                                                .colorScheme
-                                                .onSurfaceVariant;
-                                          }
-
-                                          return ListTile(
-                                            dense: true,
-                                            leading: Icon(icon, color: color),
-                                            title: Row(
-                                              spacing: 4,
-                                              crossAxisAlignment:
-                                                  CrossAxisAlignment.center,
-                                              mainAxisSize: MainAxisSize.min,
-                                              children: [
-                                                Text(
-                                                  "#$shareIndex",
-                                                  style: theme
-                                                      .textTheme
-                                                      .bodyMedium
-                                                      ?.copyWith(
-                                                        color: theme
-                                                            .colorScheme
-                                                            .onSurfaceVariant,
-                                                        fontWeight:
-                                                            FontWeight.w500,
-                                                      ),
-                                                ),
-                                                Flexible(
-                                                  child: Padding(
-                                                    padding:
-                                                        const EdgeInsets.only(
-                                                          right: 80,
-                                                        ),
-                                                    child: Text(
-                                                      devices
-                                                          .map(
-                                                            (d) =>
-                                                                coord.getDeviceName(
-                                                                  id: d
-                                                                      .deviceId,
-                                                                ) ??
-                                                                '',
-                                                          )
-                                                          .join(', '),
-                                                      style: theme
-                                                          .textTheme
-                                                          .bodyMedium
-                                                          ?.copyWith(
-                                                            fontWeight:
-                                                                FontWeight.w500,
-                                                          ),
-                                                      softWrap: true,
-                                                    ),
-                                                  ),
-                                                ),
-                                              ],
-                                            ),
-                                          );
-                                        }).toList();
-                                      }(),
-                                    ),
-                                    Positioned(
-                                      top: 12,
-                                      right: 16,
-                                      child: Text(
-                                        '${completedDevices.length}/${deviceInfoList.length} complete',
-                                        style: theme.textTheme.bodySmall
-                                            ?.copyWith(
-                                              color: theme
-                                                  .colorScheme
-                                                  .onSurfaceVariant,
-                                            ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
+                                Icon(statusIcon, color: statusIconColor),
+                                const SizedBox(width: 12),
+                                Expanded(child: statusContent),
                               ],
                             ),
                           ),
+                        ),
+                      ),
                     );
                   },
                 ),

--- a/frostsnapp/lib/restoration/enter_backup_view.dart
+++ b/frostsnapp/lib/restoration/enter_backup_view.dart
@@ -46,14 +46,48 @@ class _EnterBackupViewState extends State<EnterBackupView> {
         return Card.filled(
           margin: EdgeInsets.zero,
           color: theme.colorScheme.surfaceContainerHigh,
-          child: ListTile(
-            leading: Icon(Icons.keyboard_rounded),
-            title: Text('Enter backup on ${widget.deviceName ?? "device"}'),
-            subtitle: Text(
-              'Enter the backup on the device screen. The app will continue automatically once complete.',
+          child: Padding(
+            padding: EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'On your device${widget.deviceName != null ? " ${widget.deviceName}" : ""}',
+                  style: theme.textTheme.titleMedium,
+                ),
+                SizedBox(height: 12),
+                Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(
+                        text: '1. Enter the Key Number. ',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      TextSpan(
+                        text:
+                            '\nYou can find this on the inside of your backup card, labeled "Key Number".',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  '2. Enter all 25 seed words in order.',
+                  style: theme.textTheme.bodyMedium,
+                ),
+                SizedBox(height: 8),
+                Text(
+                  'The app will continue automatically once complete.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
             ),
-            isThreeLine: true,
-            contentPadding: EdgeInsets.symmetric(horizontal: 16),
           ),
         );
       },

--- a/frostsnapp/lib/wallet_receive.dart
+++ b/frostsnapp/lib/wallet_receive.dart
@@ -361,13 +361,13 @@ class _ReceiverPageState extends State<ReceivePage> {
     final header = ListTile(
       shape: tileShape,
       contentPadding: tilePadding.copyWith(right: 8),
-      title: Text('Share'),
+      title: Text('Share Address'),
       trailing: TextButton.icon(
         onPressed: _address == null
             ? null
             : () => openAddressPicker(context, _address!),
         label: Text(
-          '#${_address?.index}',
+          'Address #${_address?.index}',
           style: monospaceTextStyle.copyWith(
             decoration: isUsed ? TextDecoration.lineThrough : null,
             decorationThickness: isUsed ? 3.0 : null,
@@ -478,7 +478,7 @@ class _ReceiverPageState extends State<ReceivePage> {
                 children: [
                   ListTile(
                     shape: tileShape,
-                    title: Text('Verify'),
+                    title: Text('Verify Address'),
                     contentPadding: tilePadding,
                     minVerticalPadding: 16,
                   ),
@@ -509,7 +509,7 @@ class _ReceiverPageState extends State<ReceivePage> {
       color: theme.colorScheme.surfaceContainerLow,
       child: ListTile(
         shape: tileShape,
-        title: Text('Verify'),
+        title: Text('Verify Address'),
         contentPadding: tilePadding,
         onTap: () => focus = ReceivePageFocus.verify,
       ),

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -334,19 +334,40 @@ class _WalletSendPageState extends State<WalletSendPage> {
     final availableAmount = state.availableAmount(recipient: 0);
 
     int? amount;
-    String? amountErr;
+    Widget amountDisplay(int sats) {
+      return switch (amountController.unit) {
+        AmountUnit.satoshi => Text('$sats sat'),
+        AmountUnit.bitcoin => SatoshiText(
+          value: sats,
+          hideLeadingWhitespace: true,
+        ),
+      };
+    }
+
+    Widget? amountErr;
     try {
       amount = state.amount(recipient: 0);
     } on AmountError catch (e) {
       amountErr = switch (e) {
-        AmountError_UnspecifiedFeerate() => 'No feerate set.',
-        AmountError_UnspecifiedAmount() => 'No amount set.',
-        AmountError_NoAmountAvailable() => 'No balance available.',
+        AmountError_UnspecifiedFeerate() => Text('No feerate set.'),
+        AmountError_UnspecifiedAmount() => null,
+        AmountError_NoAmountAvailable() => Text('No balance available.'),
         AmountError_TargetExceedsAvailable(:final target, :final available) =>
-          'Exceeds max by ${target - available}sat.',
-        AmountError_UnspecifiedAddress() => 'No recipient address.',
-        AmountError_AmountBelowDust(:final minNonDust) =>
-          'Minimum amount is $minNonDust.',
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Exceeds max by '),
+              amountDisplay(target - available),
+            ],
+          ),
+        AmountError_UnspecifiedAddress() => Text('No recipient address.'),
+        AmountError_AmountBelowDust(:final minNonDust) => Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Minimum amount is '),
+            amountDisplay(minNonDust.toInt()),
+          ],
+        ),
       };
     }
 
@@ -368,7 +389,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
                   filled: false,
                   errorMaxLines: 2,
                   hintText: 'Amount',
-                  errorText: amountErr,
+                  error: amountErr,
                 ),
               ),
             Row(

--- a/frostsnapp/lib/wallet_send_controllers.dart
+++ b/frostsnapp/lib/wallet_send_controllers.dart
@@ -308,11 +308,20 @@ class AmountInput extends StatelessWidget {
         controller: model.textEditingController,
         style: TextStyle(fontFamily: monospaceTextStyle.fontFamily),
         decoration: (decoration ?? InputDecoration()).copyWith(
-          errorText: model.error,
-          suffixText: model.unit.suffixText,
-          suffixIcon: IconButton(
+          error: model.error != null ? Text(model.error!) : null,
+          suffixIcon: TextButton.icon(
             onPressed: onUnitButtonPressed,
-            icon: Icon(Icons.swap_vert),
+            iconAlignment: IconAlignment.end,
+            icon: Icon(
+              Icons.swap_vert,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            label: Text(
+              model.unit.suffixText.trim(),
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
           ),
           border: defaultTextInputBorder,
         ),


### PR DESCRIPTION
- Backup entry: Replace vague instructions with step-by-step guidance for entering key number and seed words on the device
  - Send flow: Fix amount field showing "No amount set" error immediately on focus; display amount errors in the user's selected unit (sats/bitcoin); keep unit label and swap icon always visible and prevent them turning red on error
  - Receive flow: Rename section headers to "Share Address", "Verify Address" for clarity; show "Address #N" instead of "#N" in picker
  - Backup flow: Pull device checklist out of the highlighted connection box so users notice it; remove misleading circle icon that looked like a checkbox; add "Key #N" prefix and "Needs backup" / "Backed up" status labels