### PR TITLE
fix clippy warnings across workspace

### DIFF
--- a/device/src/frosty_ui.rs
+++ b/device/src/frosty_ui.rs
@@ -411,13 +411,10 @@ impl<'a> UserInteraction for FrostyUi<'a> {
             WidgetTree::KeygenCheck {
                 widget: keygen_check,
                 phase,
-            } => {
-                // Check if confirmed and we still have the phase
-                if keygen_check.is_confirmed() {
-                    // Take the phase (move it out of the Option)
-                    if let Some(phase_data) = phase.take() {
-                        return Some(UiEvent::KeyGenConfirm { phase: phase_data });
-                    }
+            } if keygen_check.is_confirmed() => {
+                // Take the phase (move it out of the Option)
+                if let Some(phase_data) = phase.take() {
+                    return Some(UiEvent::KeyGenConfirm { phase: phase_data });
                 }
             }
             WidgetTree::SignTxPrompt {
@@ -445,52 +442,45 @@ impl<'a> UserInteraction for FrostyUi<'a> {
             }
             WidgetTree::FirmwareUpgradeConfirm {
                 widget, confirmed, ..
-            } => {
-                // Check if the firmware upgrade was confirmed and we haven't sent the event yet
-                if widget.is_confirmed() && !*confirmed {
-                    *confirmed = true; // Mark as confirmed to prevent duplicate events
-                    return Some(UiEvent::UpgradeConfirm);
-                }
+            } if widget.is_confirmed() && !*confirmed => {
+                *confirmed = true;
+                return Some(UiEvent::UpgradeConfirm);
             }
             WidgetTree::DisplayBackup {
                 widget,
                 access_structure_ref,
             } => {
-                if widget.is_finished() {
-                    if let Some(access_structure_ref_data) = access_structure_ref.take() {
-                        return Some(UiEvent::BackupRecorded {
-                            access_structure_ref: access_structure_ref_data,
-                        });
-                    }
+                if !widget.is_finished() {
+                    return None;
+                }
+                if let Some(access_structure_ref_data) = access_structure_ref.take() {
+                    return Some(UiEvent::BackupRecorded {
+                        access_structure_ref: access_structure_ref_data,
+                    });
                 }
             }
             WidgetTree::EnterBackup { widget, phase } => {
-                // Check if backup entry is complete
-                if widget.is_finished() {
-                    if let Some(share_backup) = widget.get_backup() {
-                        if let Some(phase) = phase.take() {
-                            return Some(UiEvent::EnteredShareBackup {
-                                phase,
-                                share_backup,
-                            });
-                        };
-                    }
+                if !widget.is_finished() {
+                    return None;
                 }
+                let share_backup = widget.get_backup()?;
+                let phase = phase.take()?;
+                return Some(UiEvent::EnteredShareBackup {
+                    phase,
+                    share_backup,
+                });
             }
-            WidgetTree::NewNamePrompt { widget, new_name } => {
-                // Check if the name prompt was confirmed and we haven't already sent the event
-                if widget.is_confirmed() {
-                    if let Some(name) = new_name.take() {
-                        return Some(UiEvent::NameConfirm(name));
-                    }
+            WidgetTree::NewNamePrompt { widget, new_name } if widget.is_confirmed() => {
+                if let Some(name) = new_name.take() {
+                    return Some(UiEvent::NameConfirm(name));
                 }
             }
             WidgetTree::EraseDevicePrompt { widget, confirmed } => {
-                // Check if the erase device prompt was confirmed and we haven't already sent the event
-                if widget.is_confirmed() && !*confirmed {
-                    *confirmed = true;
-                    return Some(UiEvent::EraseDataConfirm);
+                if !widget.is_confirmed() || *confirmed {
+                    return None;
                 }
+                *confirmed = true;
+                return Some(UiEvent::EraseDataConfirm);
             }
             _ => {}
         }

--- a/device/src/touch_handler.rs
+++ b/device/src/touch_handler.rs
@@ -28,19 +28,15 @@ pub fn process_all_touch_events<W>(
         // Handle horizontal swipes to switch between widgets
         if is_horizontal_swipe && lift_up {
             match gesture {
-                TouchGesture::SlideLeft => {
-                    // Swipe left: show debug log
-                    if *current_widget_index == 0 {
-                        *current_widget_index = 1;
-                        widget.show_logs();
-                    }
+                // Swipe left: show debug log
+                TouchGesture::SlideLeft if *current_widget_index == 0 => {
+                    *current_widget_index = 1;
+                    widget.show_logs();
                 }
-                TouchGesture::SlideRight => {
-                    // Swipe right: show main widget
-                    if *current_widget_index == 1 {
-                        *current_widget_index = 0;
-                        widget.show_main();
-                    }
+                // Swipe right: show main widget
+                TouchGesture::SlideRight if *current_widget_index == 1 => {
+                    *current_widget_index = 0;
+                    widget.show_main();
                 }
                 _ => {}
             }

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -435,8 +435,8 @@ impl FrostCoordinator {
 
     pub fn iter_access_structures(&self) -> impl Iterator<Item = CoordAccessStructure> + '_ {
         self.keys
-            .iter()
-            .flat_map(|(_, key_data)| key_data.access_structures())
+            .values()
+            .flat_map(|key_data| key_data.access_structures())
     }
 
     pub fn iter_shares(

--- a/frostsnap_core/tests/proptest.rs
+++ b/frostsnap_core/tests/proptest.rs
@@ -446,20 +446,17 @@ impl ReferenceStateMachine for RefState {
                 devices,
                 n_inputs,
             } => match state.finished_keygens.get(*key_index) {
-                Some(keygen) => {
+                Some(keygen)
                     if !keygen.deleted
                         && keygen.do_keygen.devices().is_superset(devices)
-                        && state.available_signing_devices().is_superset(devices)
-                    {
-                        // Check that all devices have enough nonces available for n_inputs
-                        devices.iter().all(|device_id| {
-                            state.max_available_nonces_for_device(*device_id) >= *n_inputs
-                        })
-                    } else {
-                        false
-                    }
+                        && state.available_signing_devices().is_superset(devices) =>
+                {
+                    // Check that all devices have enough nonces available for n_inputs
+                    devices.iter().all(|device_id| {
+                        state.max_available_nonces_for_device(*device_id) >= *n_inputs
+                    })
                 }
-                None => false,
+                _ => false,
             },
             Transition::CSendSignRequest {
                 session_index,

--- a/frostsnap_widgets/src/aa/rounded_rect.rs
+++ b/frostsnap_widgets/src/aa/rounded_rect.rs
@@ -423,11 +423,7 @@ impl<C: ColorInterpolate> AARoundedRectIter<C> {
             if target < cumulative + seg_perim {
                 let within = target - cumulative;
                 let seg_raw = self.seg_sizes[i as usize] as u64;
-                let raw_within = if seg_perim > 0 {
-                    (within * seg_raw) / seg_perim
-                } else {
-                    0
-                };
+                let raw_within = (within * seg_raw).checked_div(seg_perim).unwrap_or(0);
                 return self.segment_start(i) + raw_within as u32;
             }
             cumulative += seg_perim;

--- a/frostsnap_widgets/src/fps.rs
+++ b/frostsnap_widgets/src/fps.rs
@@ -93,9 +93,7 @@ impl Widget for Fps {
         if should_calculate {
             if let Some(last_time) = self.last_fps_time {
                 let elapsed_ms = current_time.saturating_duration_since(last_time);
-                if elapsed_ms > 0 {
-                    // Calculate FPS: frames * 1000 / elapsed_ms
-                    let fps = (self.frame_count as u64 * 1000) / elapsed_ms;
+                if let Some(fps) = (self.frame_count as u64 * 1000).checked_div(elapsed_ms) {
                     self.current_fps = fps as u32;
                 }
             }

--- a/frostsnap_widgets/src/rat.rs
+++ b/frostsnap_widgets/src/rat.rs
@@ -485,11 +485,7 @@ impl Div<u64> for FatRat {
     type Output = FatRat;
 
     fn div(self, rhs: u64) -> Self::Output {
-        if rhs == 0 {
-            FatRat(u64::MAX)
-        } else {
-            FatRat(self.0 / rhs)
-        }
+        FatRat(self.0.checked_div(rhs).unwrap_or(u64::MAX))
     }
 }
 

--- a/tools/stack_check/src/main.rs
+++ b/tools/stack_check/src/main.rs
@@ -120,8 +120,8 @@ fn cmd_stacks(
 
     let mut entries: Vec<(String, u64)> = functions
         .defined
-        .iter()
-        .filter_map(|(_, func)| {
+        .values()
+        .filter_map(|func| {
             let stack = func.stack()?;
             let name = func.names().first().copied().unwrap_or("<unknown>");
             let demangled = format!("{:#}", demangle(name));


### PR DESCRIPTION
Address iter_kv_map, manual_checked_ops and collapsible_match lints flagged by clippy on Rust 1.95.