### PR TITLE
[core] Accept multiple coordinator keys in keygen wire format

### DIFF
--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -641,13 +641,17 @@ impl FrostCoordinator {
                             ),
                         )?;
 
+                        // Input-generator indices: [0..n_coordinators) are coordinators;
+                        // [n_coordinators..n_coordinators + n_devices) are devices in
+                        // share-index order. Share indices are 1-based, hence the `- 1`.
+                        let n_coordinators = state.coordinator_public_keys.len() as u32;
+                        let input_gen_index = u32::from(*share_index) - 1 + n_coordinators;
+
                         state
                             .input_aggregator
                             .add_input(
                                 &schnorr_fun::new_with_deterministic_nonces::<Sha256>(),
-                                // we use the share index as the input generator index. The input
-                                // generator at index 0 is the coordinator itself.
-                                (*share_index).into(),
+                                input_gen_index,
                                 *response.input,
                             )
                             .map_err(|e| Error::coordinator_invalid_message(message_kind, e))?;
@@ -672,7 +676,7 @@ impl FrostCoordinator {
                             let mut certifier = certpedpop::Certifier::new(
                                 cert_scheme,
                                 agg_input.clone(),
-                                &[state.my_keypair.public_key()],
+                                &state.coordinator_public_keys,
                             );
 
                             certifier
@@ -977,9 +981,12 @@ impl FrostCoordinator {
             .map(|(device, share_index)| (ShareIndex::from(*share_index), device.pubkey()))
             .collect::<BTreeMap<_, _>>();
         let schnorr = schnorr_fun::new_with_deterministic_nonces::<Sha256>();
+
+        let coordinator_public_keys = vec![coordinator_keypair.public_key()];
+
         let mut input_aggregator = certpedpop::Coordinator::new(
             threshold.into(),
-            (n_devices + 1) as u32,
+            1 + n_devices as u32,
             &share_receivers_enckeys,
         );
         let (contributer, input) = certpedpop::Contributor::gen_keygen_input(
@@ -1003,6 +1010,7 @@ impl FrostCoordinator {
                 purpose,
                 contributer: Box::new(contributer),
                 my_keypair: coordinator_keypair,
+                coordinator_public_keys: coordinator_public_keys.clone(),
             }),
         );
 
@@ -1013,7 +1021,7 @@ impl FrostCoordinator {
             key_name,
             purpose,
             keygen_id,
-            coordinator_public_key: coordinator_keypair.public_key(),
+            coordinator_public_keys,
         };
 
         Ok(SendBeginKeygen(begin_message))
@@ -1668,6 +1676,7 @@ pub struct KeyGenWaitingForResponses {
     pub purpose: KeyPurpose,
     pub contributer: Box<certpedpop::Contributor>,
     pub my_keypair: KeyPair,
+    pub coordinator_public_keys: Vec<Point>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/frostsnap_core/src/device.rs
+++ b/frostsnap_core/src/device.rs
@@ -147,7 +147,7 @@ pub struct KeyGenPhase1 {
     pub threshold: u16,
     pub key_name: String,
     pub key_purpose: KeyPurpose,
-    pub coordinator_public_key: Point,
+    coordinator_public_keys: Vec<Point>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -158,7 +158,7 @@ pub struct KeyGenPhase2 {
     agg_input: certpedpop::AggKeygenInput,
     key_name: String,
     key_purpose: KeyPurpose,
-    pub coordinator_public_key: Point,
+    coordinator_public_keys: Vec<Point>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -407,11 +407,14 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                                 )
                             })?;
 
+                    let n_coordinators = begin.coordinator_public_keys.len() as u32;
+                    let input_gen_index = u32::from(*my_index) - 1 + n_coordinators;
+
                     let (input_state, keygen_input) = certpedpop::Contributor::gen_keygen_input(
                         &schnorr,
                         begin.threshold as u32,
                         &share_receivers_enckeys,
-                        (*my_index).into(),
+                        input_gen_index,
                         rng,
                     );
                     self.tmp_keygen_phase1.insert(
@@ -422,7 +425,7 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                             threshold: begin.threshold,
                             key_name: begin.key_name.clone(),
                             key_purpose: begin.purpose,
-                            coordinator_public_key: begin.coordinator_public_key,
+                            coordinator_public_keys: begin.coordinator_public_keys,
                         },
                     );
                     Ok(vec![DeviceSend::ToCoordinator(Box::new(
@@ -497,7 +500,7 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                             agg_input,
                             key_name: phase1.key_name.clone(),
                             key_purpose: phase1.key_purpose,
-                            coordinator_public_key: phase1.coordinator_public_key,
+                            coordinator_public_keys: phase1.coordinator_public_keys,
                         },
                     );
                     Ok(vec![DeviceSend::ToCoordinator(Box::new(
@@ -526,7 +529,7 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                     let mut certifier = certpedpop::Certifier::new(
                         cert_scheme,
                         phase2.agg_input.clone(),
-                        &[phase2.coordinator_public_key],
+                        &phase2.coordinator_public_keys,
                     );
 
                     // Add all certificates to the certifier

--- a/frostsnap_core/src/message/keygen.rs
+++ b/frostsnap_core/src/message/keygen.rs
@@ -34,7 +34,7 @@ pub struct Begin {
     pub threshold: u16,
     pub key_name: String,
     pub purpose: KeyPurpose,
-    pub coordinator_public_key: Point,
+    pub coordinator_public_keys: Vec<Point>,
 }
 
 impl From<Begin> for Keygen {


### PR DESCRIPTION
Minimal change to let the keygen protocol carry a Vec<Point> of coordinator public keys instead of a single scalar. Device and coordinator still operate in the single-coordinator case (coordinator is always at index 0), but the on-wire Begin message and internal phase state now carry the list so multi-coordinator support can be layered on without another wire break.

Contributor slot indices are partitioned [0..n_coordinators) for coordinators and [n_coordinators..) for devices.