### PR TITLE
[app] Backup Reminder UX

### DIFF
--- a/frostsnapp/lib/backup_workflow.dart
+++ b/frostsnapp/lib/backup_workflow.dart
@@ -11,6 +11,18 @@ import 'package:frostsnap/src/rust/api/device_list.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:glowy_borders/glowy_borders.dart';
 
+extension BackupDeviceX on BackupDevice {
+  /// A share counts as backed up when it has been explicitly marked
+  /// complete, OR when there is no tracking record at all (legacy wallets
+  /// created before backup-run tracking existed). Only `complete == false`
+  /// means a backup run is in progress and this share still needs recording.
+  bool get isBackedUp => complete != false;
+}
+
+extension BackupRunX on BackupRun {
+  bool get isComplete => devices.every((d) => d.isBackedUp);
+}
+
 class BackupConfirmationDialogContent extends StatelessWidget {
   final int threshold;
   final int totalDevices;
@@ -398,9 +410,7 @@ class _BackupChecklistState extends State<BackupChecklist> {
             // Devices are already sorted by share index and contain all metadata
             final deviceInfoList = backupRun.devices;
 
-            final allComplete = deviceInfoList.every(
-              (d) => d.complete != false,
-            );
+            final allComplete = backupRun.isComplete;
 
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -474,12 +484,10 @@ class _BackupChecklistState extends State<BackupChecklist> {
                   return devicesByShareIndex.entries.map((entry) {
                     final shareIndex = entry.key;
                     final devices = entry.value;
-                    final complete = devices.first.complete;
-                    final isComplete = complete != false;
+                    final isComplete = devices.first.isBackedUp;
 
                     return ListTile(
                       dense: true,
-                      leading: SizedBox(width: 24),
                       title: Row(
                         spacing: 4,
                         crossAxisAlignment: CrossAxisAlignment.center,
@@ -587,7 +595,7 @@ class _BackupChecklistState extends State<BackupChecklist> {
                                 ),
                               ],
                             ),
-                            if (deviceInfo.complete != false)
+                            if (deviceInfo.isBackedUp)
                               Row(
                                 mainAxisSize: MainAxisSize.min,
                                 spacing: 8,

--- a/frostsnapp/lib/backup_workflow.dart
+++ b/frostsnapp/lib/backup_workflow.dart
@@ -398,11 +398,9 @@ class _BackupChecklistState extends State<BackupChecklist> {
             // Devices are already sorted by share index and contain all metadata
             final deviceInfoList = backupRun.devices;
 
-            final completedDevices = deviceInfoList
-                .where((d) => d.complete == true)
-                .toList();
-            final allComplete =
-                completedDevices.length == deviceInfoList.length;
+            final allComplete = deviceInfoList.every(
+              (d) => d.complete != false,
+            );
 
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -477,15 +475,11 @@ class _BackupChecklistState extends State<BackupChecklist> {
                     final shareIndex = entry.key;
                     final devices = entry.value;
                     final complete = devices.first.complete;
+                    final isComplete = complete != false;
 
                     return ListTile(
                       dense: true,
-                      leading: complete == true
-                          ? Icon(
-                              Icons.check_circle,
-                              color: theme.colorScheme.primary,
-                            )
-                          : SizedBox(width: 24),
+                      leading: SizedBox(width: 24),
                       title: Row(
                         spacing: 4,
                         crossAxisAlignment: CrossAxisAlignment.center,
@@ -515,19 +509,11 @@ class _BackupChecklistState extends State<BackupChecklist> {
                           ),
                         ],
                       ),
-                      trailing: complete == true
-                          ? Text(
-                              'Backed up',
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: theme.colorScheme.primary,
-                              ),
-                            )
-                          : Text(
-                              'Needs backup',
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                              ),
-                            ),
+                      trailing: _BackupStatusTrailing(
+                        isComplete: isComplete,
+                        shareIndex: shareIndex,
+                        accessStructure: accessStructure,
+                      ),
                     );
                   }).toList();
                 }(),
@@ -636,7 +622,9 @@ class _BackupChecklistState extends State<BackupChecklist> {
                     } else {
                       statusIcon = Icons.usb_rounded;
                       statusIconColor = null;
-                      statusContent = Text('Plug in device to back it up');
+                      statusContent = Text(
+                        'Plug in a device to record or check a backup',
+                      );
                     }
 
                     return AnimatedGradientBorder(
@@ -703,4 +691,85 @@ class _BackupChecklistState extends State<BackupChecklist> {
       ],
     );
   }
+}
+
+class _BackupStatusTrailing extends StatelessWidget {
+  final bool isComplete;
+  final int shareIndex;
+  final AccessStructure accessStructure;
+
+  const _BackupStatusTrailing({
+    required this.isComplete,
+    required this.shareIndex,
+    required this.accessStructure,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          isComplete ? 'Backed up' : 'Not backed up',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        isComplete
+            ? Padding(
+                padding: const EdgeInsets.all(8),
+                child: Icon(
+                  Icons.check_circle,
+                  size: 18,
+                  color: theme.colorScheme.primary,
+                ),
+              )
+            : IconButton(
+                tooltip: 'Mark as backed up',
+                icon: const Icon(Icons.radio_button_unchecked, size: 18),
+                color: theme.colorScheme.primary,
+                visualDensity: VisualDensity.compact,
+                onPressed: () async {
+                  final confirmed = await _confirmMarkBackupComplete(
+                    context,
+                    shareIndex,
+                  );
+                  if (!confirmed) return;
+                  if (!context.mounted) return;
+                  await coord.markBackupComplete(
+                    accessStructureRef: accessStructure.accessStructureRef(),
+                    shareIndex: shareIndex,
+                  );
+                },
+              ),
+      ],
+    );
+  }
+}
+
+Future<bool> _confirmMarkBackupComplete(
+  BuildContext context,
+  int shareIndex,
+) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: const Text('Mark as backed up?'),
+      content: Text(
+        'Only do this if you have already recorded the backup for Key #$shareIndex somewhere safe.\n\nIf you mark a key as backed up without actually having the backup, you risk permanently losing access to this wallet.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: const Text('I have the backup'),
+        ),
+      ],
+    ),
+  );
+  return result == true;
 }

--- a/frostsnapp/lib/device_action_backup_check.dart
+++ b/frostsnapp/lib/device_action_backup_check.dart
@@ -17,10 +17,6 @@ class DeviceActionBackupCheckController with ChangeNotifier {
 
   DeviceId? get activeDeviceId => _dialogController?.actionsNeeded.firstOrNull;
 
-  String? get walletName => coord
-      .getFrostKey(keyId: accessStructure.accessStructureRef().keyId)
-      ?.keyName();
-
   DeviceActionBackupCheckController({required this.accessStructure});
 
   @override
@@ -47,17 +43,11 @@ class DeviceActionBackupCheckController with ChangeNotifier {
       devices: [id],
       title: 'Check Backup on Device',
       body: (context) {
-        final deviceIndex = accessStructure.getDeviceShortShareIndex(
-          deviceId: id,
-        )!;
-        return Card(
-          margin: EdgeInsets.zero,
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: InfoRow.toColumn(context, [
-              InfoRow('For key', '#$deviceIndex'),
-              InfoRow('Of wallet', walletName ?? ''),
-            ]),
+        final theme = Theme.of(context);
+        return Text(
+          'Check your physical backup by entering it on the device screen.',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
           ),
         );
       },

--- a/frostsnapp/lib/keygen.dart
+++ b/frostsnapp/lib/keygen.dart
@@ -5,14 +5,29 @@ import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
 import 'package:frostsnap/theme.dart';
 
-void showWalletCreatedDialog(
+enum SecureWalletChoice {
+  /// User chose "Later" — caller should proceed with whatever it was going
+  /// to do (e.g. opening the receive sheet).
+  later,
+
+  /// User chose "Secure Wallet" — the backup checklist has been opened and
+  /// the caller should not proceed.
+  secure,
+
+  /// User backed out (system back button). Caller should do nothing.
+  cancelled,
+}
+
+/// Shows a reminder that backups are incomplete and offers to open the
+/// backup checklist.
+Future<SecureWalletChoice> showSecureWalletDialog(
   BuildContext context,
   AccessStructure accessStructure,
 ) async {
-  await showDialog(
+  final choice = await showDialog<SecureWalletChoice>(
     context: context,
     barrierDismissible: false,
-    builder: (BuildContext context) {
+    builder: (BuildContext dialogContext) {
       return BackdropFilter(
         filter: blurFilter,
         child: AlertDialog(
@@ -20,7 +35,7 @@ void showWalletCreatedDialog(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: const [
               Text(
-                'Wallet created!\nNow let\'s secure it.',
+                'Secure your wallet',
                 style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
               ),
               Icon(Icons.checklist, size: 40),
@@ -31,11 +46,11 @@ void showWalletCreatedDialog(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                'Before receiving any Bitcoin, you should backup and distribute your Frostsnaps.',
+                'Before receiving any Bitcoin, you should backup and distribute your Frostsnap devices.',
               ),
               SizedBox(height: 16),
               Text(
-                'With each of your Frostsnaps you will:',
+                'With each device you should:',
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               SizedBox(height: 8),
@@ -46,7 +61,7 @@ void showWalletCreatedDialog(
                   SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      'Travel to a location where you will store it.',
+                      'Travel to the secure location where you will store it.',
                     ),
                   ),
                 ],
@@ -59,7 +74,7 @@ void showWalletCreatedDialog(
                   SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      'Record the backup on the provided backup sheet (~5 mins).',
+                      'Record the backup on the provided backup card (~5 mins).',
                     ),
                   ),
                 ],
@@ -71,7 +86,9 @@ void showWalletCreatedDialog(
                   Icon(Icons.lock),
                   SizedBox(width: 8),
                   Expanded(
-                    child: Text('Securely store the Frostsnap and its backup.'),
+                    child: Text(
+                      'Safely store your Frostsnap device and its backup.',
+                    ),
                   ),
                 ],
               ),
@@ -79,24 +96,13 @@ void showWalletCreatedDialog(
           ),
           actions: [
             TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
+              onPressed: () =>
+                  Navigator.of(dialogContext).pop(SecureWalletChoice.later),
               child: const Text('Later'),
             ),
             FilledButton(
-              onPressed: () async {
-                Navigator.popUntil(context, (r) => r.isFirst);
-                final superCtx = SuperWalletContext.of(context)!;
-
-                await MaybeFullscreenDialog.show(
-                  context: context,
-                  child: superCtx.tryWrapInWalletContext(
-                    keyId: accessStructure.masterAppkey().keyId(),
-                    child: BackupChecklist(accessStructure: accessStructure),
-                  ),
-                );
-              },
+              onPressed: () =>
+                  Navigator.of(dialogContext).pop(SecureWalletChoice.secure),
               child: const Text('Secure Wallet'),
             ),
           ],
@@ -104,4 +110,19 @@ void showWalletCreatedDialog(
       );
     },
   );
+
+  if (choice != SecureWalletChoice.secure) {
+    return choice ?? SecureWalletChoice.cancelled;
+  }
+
+  if (!context.mounted) return SecureWalletChoice.cancelled;
+  final superCtx = SuperWalletContext.of(context)!;
+  await MaybeFullscreenDialog.show(
+    context: context,
+    child: superCtx.tryWrapInWalletContext(
+      keyId: accessStructure.masterAppkey().keyId(),
+      child: BackupChecklist(accessStructure: accessStructure),
+    ),
+  );
+  return SecureWalletChoice.secure;
 }

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -718,10 +718,7 @@ class WalletBottomBar extends StatelessWidget {
     final receiveButton = TextButton.icon(
       onPressed: () async {
         final backupRun = coord.getBackupRun(keyId: walletCtx.wallet.keyId());
-        final backupsIncomplete = backupRun.devices.any(
-          (device) => device.complete == false,
-        );
-        if (backupsIncomplete) {
+        if (!backupRun.isComplete) {
           final frostKey = walletCtx.wallet.frostKey();
           if (frostKey != null) {
             final accessStructure = frostKey.accessStructures()[0];
@@ -1236,7 +1233,7 @@ class BackupWarningBanner extends StatelessWidget {
       stream: backupStream,
       builder: (context, backupSnapshot) {
         final backupRun = backupSnapshot.data;
-        final hideBanner = backupRun == null || isBackupDone(backupRun);
+        final hideBanner = backupRun == null || backupRun.isComplete;
         if (hideBanner) return SizedBox.shrink();
 
         return StreamBuilder<TxState>(
@@ -1289,7 +1286,4 @@ class BackupWarningBanner extends StatelessWidget {
       ),
     );
   }
-
-  bool isBackupDone(BackupRun backupRun) =>
-      backupRun.devices.every((device) => device.complete != false);
 }

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -5,6 +5,7 @@ import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/device_list.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
+import 'package:frostsnap/keygen.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/nonce_replenish.dart';
 import 'package:frostsnap/restoration/wallet_recovery_page.dart';
@@ -715,17 +716,35 @@ class WalletBottomBar extends StatelessWidget {
     );
 
     final receiveButton = TextButton.icon(
-      onPressed: () => showBottomSheetOrDialog(
-        context,
-        title: Text('Receive'),
-        builder: (context, scrollController) => walletCtx.wrap(
-          ReceivePage(
-            wallet: walletCtx.wallet,
-            txStream: walletCtx.txStream,
-            scrollController: scrollController,
+      onPressed: () async {
+        final backupRun = coord.getBackupRun(keyId: walletCtx.wallet.keyId());
+        final backupsIncomplete = backupRun.devices.any(
+          (device) => device.complete == false,
+        );
+        if (backupsIncomplete) {
+          final frostKey = walletCtx.wallet.frostKey();
+          if (frostKey != null) {
+            final accessStructure = frostKey.accessStructures()[0];
+            final choice = await showSecureWalletDialog(
+              context,
+              accessStructure,
+            );
+            if (choice != SecureWalletChoice.later) return;
+          }
+        }
+        if (!context.mounted) return;
+        showBottomSheetOrDialog(
+          context,
+          title: Text('Receive'),
+          builder: (context, scrollController) => walletCtx.wrap(
+            ReceivePage(
+              wallet: walletCtx.wallet,
+              txStream: walletCtx.txStream,
+              scrollController: scrollController,
+            ),
           ),
-        ),
-      ),
+        );
+      },
       label: Text('Receive', softWrap: false, overflow: TextOverflow.fade),
       icon: Icon(Icons.south_east),
       style: textButtonStyle,
@@ -1212,41 +1231,51 @@ class BackupWarningBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final walletCtx = WalletContext.of(context)!;
     final backupStream = walletCtx.backupStream;
-    final theme = Theme.of(context);
 
-    final button = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      child: IconButton(
-        onPressed: () => onTap(context, walletCtx),
-        icon: Icon(Icons.warning_rounded),
-        style: IconButton.styleFrom(foregroundColor: theme.colorScheme.error),
-        tooltip: 'This wallet has unfinished backups!',
-      ),
-    );
-
-    final banner = ListTile(
-      dense: true,
-      contentPadding: EdgeInsets.symmetric(horizontal: 16),
-      onTap: () => onTap(context, walletCtx),
-      iconColor: theme.colorScheme.error,
-      textColor: theme.colorScheme.error,
-      leading: Icon(Icons.warning_rounded),
-      trailing: Icon(Icons.chevron_right),
-      title: Text('This wallet has unfinished backups!'),
-    );
-
-    final widget = shrink ? button : banner;
-
-    final streamedBanner = StreamBuilder<BackupRun>(
+    return StreamBuilder<BackupRun>(
       stream: backupStream,
-      builder: (context, snapshot) {
-        final backupRun = snapshot.data;
+      builder: (context, backupSnapshot) {
+        final backupRun = backupSnapshot.data;
         final hideBanner = backupRun == null || isBackupDone(backupRun);
-        return hideBanner ? SizedBox.shrink() : widget;
+        if (hideBanner) return SizedBox.shrink();
+
+        return StreamBuilder<TxState>(
+          stream: walletCtx.txStream,
+          builder: (context, txSnapshot) {
+            final txState = txSnapshot.data;
+            final hasFunds =
+                (txState?.balance ?? 0) > 0 ||
+                (txState?.untrustedPendingBalance ?? 0) > 0;
+            final color = hasFunds
+                ? Theme.of(context).colorScheme.error
+                : cautionColor;
+
+            if (shrink) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: IconButton(
+                  onPressed: () => onTap(context, walletCtx),
+                  icon: Icon(Icons.warning_rounded),
+                  style: IconButton.styleFrom(foregroundColor: color),
+                  tooltip: 'This wallet has unfinished backups!',
+                ),
+              );
+            }
+
+            return ListTile(
+              dense: true,
+              contentPadding: EdgeInsets.symmetric(horizontal: 16),
+              onTap: () => onTap(context, walletCtx),
+              iconColor: color,
+              textColor: color,
+              leading: Icon(Icons.warning_rounded),
+              trailing: Icon(Icons.chevron_right),
+              title: Text('This wallet has unfinished backups!'),
+            );
+          },
+        );
       },
     );
-
-    return streamedBanner;
   }
 
   void onTap(BuildContext context, WalletContext walletContext) async {

--- a/frostsnapp/lib/wallet_add.dart
+++ b/frostsnapp/lib/wallet_add.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/global.dart';
-import 'package:frostsnap/keygen.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/restoration.dart';
 import 'package:frostsnap/src/rust/api.dart';
@@ -185,12 +184,9 @@ class WalletAddColumn extends StatelessWidget {
 
     if (!context.mounted || asRef == null) return;
     // Wallet-create page has popped. Wait for the user to unplug the
-    // devices (no-op if nothing is connected) before showing the
-    // "Now let's secure it" dialog and opening the new wallet.
+    // devices (no-op if nothing is connected) before opening the new wallet.
     await showUnplugDevicesDialog(context);
     if (!context.mounted) return;
-    final accessStructure = coord.getAccessStructure(asRef: asRef)!;
-    showWalletCreatedDialog(context, accessStructure);
     homeCtx.openNewlyCreatedWallet(asRef.keyId);
   }
 


### PR DESCRIPTION
Moves the backup reminder from a post-creation popup into the moments that matter — when the user opens Receive, and via a persistent banner.             
                                                                                                                                                            
  - Tapping Receive on a wallet with incomplete backups shows a reminder dialog. User can dismiss to proceed, open the backup checklist, or cancel.         
  - "Unfinished backups" banner is amber by default, turns red once the wallet has funds.
  - Tapping the banner opens the backup checklist directly.                                                                                                 
  - No more auto-popup after wallet creation.                                                                                                               
  - On the backup checklist, each share has a circular check icon — outlined when incomplete. Tapping opens a confirmation dialog to mark that share as backed up (for users who already recorded their backup outside the app).        
