### PR TITLE
[app] Show receive address and share index in tx details

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -19,7 +19,7 @@ use frostsnap_core::{
     tweak::BitcoinAccount,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     ops::RangeBounds,
     str::FromStr,
     sync::{Arc, Mutex},
@@ -123,10 +123,14 @@ impl CoordSuperWallet {
     }
 
     pub fn is_spk_mine(&self, master_appkey: MasterAppkey, spk: ScriptBuf) -> bool {
+        self.spk_index(master_appkey, spk).is_some()
+    }
+
+    pub fn spk_index(&self, master_appkey: MasterAppkey, spk: ScriptBuf) -> Option<u32> {
         self.tx_graph
             .index
             .index_of_spk(spk)
-            .is_some_and(|((key, _), _)| *key == master_appkey)
+            .and_then(|((key, _), index)| (*key == master_appkey).then_some(*index))
     }
 
     fn descriptors_for_key(
@@ -347,9 +351,15 @@ impl CoordSuperWallet {
                     .output
                     .iter()
                     .chain(prevouts.values())
-                    .map(|txout| txout.script_pubkey.clone())
-                    .filter(|spk| self.is_spk_mine(master_appkey, spk.clone()))
-                    .collect::<HashSet<ScriptBuf>>();
+                    .filter_map(|txout| {
+                        let spk = txout.script_pubkey.clone();
+                        self.tx_graph
+                            .index
+                            .index_of_spk(spk.clone())
+                            .filter(|((key, _), _)| *key == master_appkey)
+                            .map(|((_, _), index)| (spk, *index))
+                    })
+                    .collect::<HashMap<ScriptBuf, u32>>();
                 if is_mine.is_empty() {
                     None
                 } else {
@@ -899,7 +909,8 @@ pub struct Transaction {
     pub last_seen: Option<u64>,
 
     pub prevouts: HashMap<OutPoint, TxOut>,
-    pub is_mine: HashSet<ScriptBuf>,
+    /// Maps owned script pubkeys to their derivation index.
+    pub is_mine: HashMap<ScriptBuf, u32>,
 }
 
 #[derive(Clone, Debug)]

--- a/frostsnapp/lib/wallet_tx_details.dart
+++ b/frostsnapp/lib/wallet_tx_details.dart
@@ -541,68 +541,79 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
     );
   }
 
-  Widget buildSignaturesNeededColumn(BuildContext context) => Column(
-    crossAxisAlignment: CrossAxisAlignment.stretch,
-    children: [
-      ListTile(
-        title: Text('Signatures Needed'),
-        subtitle: Text('Connect a device to sign'),
-        trailing: Stack(
-          alignment: AlignmentDirectional.center,
-          children: [
-            CircularProgressIndicator(
-              value:
-                  (signingState?.gotShares.length ?? 0) /
-                  (signingState?.neededFrom.length ?? 1),
-              backgroundColor: Theme.of(
-                context,
-              ).colorScheme.surfaceContainerHighest,
-              strokeCap: StrokeCap.round,
-            ),
-            Text(
-              '${signingState?.gotShares.length}/${signingState?.neededFrom.length}',
-            ),
-          ],
-        ),
-      ),
-      ...((signingState?.neededFrom) ?? []).map((deviceId) {
-        final deviceName = coord.getDeviceName(id: deviceId) ?? '<no-name>';
-        final isConnected = connectedDevices.contains(deviceId);
-        final Widget trailing;
-        if (signingState!.gotShares.any(
-          (gotSharesFrom) => deviceIdEquals(deviceId, gotSharesFrom),
-        )) {
-          trailing = AnimatedCheckCircle();
-        } else {
-          trailing = Text(
-            isConnected ? 'Requesting Signature' : '',
-            style: TextStyle(
-              color: isConnected ? Theme.of(context).colorScheme.primary : null,
-            ),
-          );
-        }
-        return ListTile(
-          enabled: isConnected,
-          title: Text(deviceName),
-          trailing: trailing,
-        );
-      }),
-      Divider(height: 0.0),
-      Align(
-        alignment: AlignmentDirectional.centerStart,
-        child: Padding(
-          padding: EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
-          child: TextButton(
-            onPressed: () async => showCancelSigningDialog(context),
-            style: TextButton.styleFrom(
-              foregroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: Text('Cancel'),
+  Widget buildSignaturesNeededColumn(BuildContext context) {
+    final theme = Theme.of(context);
+    final asRef = widget.signingParams?.accessStructureRef;
+    final accessStruct = asRef != null
+        ? coord.getAccessStructure(asRef: asRef)
+        : null;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListTile(
+          title: Text('Signatures Needed'),
+          subtitle: Text('Connect a device to sign'),
+          trailing: Stack(
+            alignment: AlignmentDirectional.center,
+            children: [
+              CircularProgressIndicator(
+                value:
+                    (signingState?.gotShares.length ?? 0) /
+                    (signingState?.neededFrom.length ?? 1),
+                backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                strokeCap: StrokeCap.round,
+              ),
+              Text(
+                '${signingState?.gotShares.length}/${signingState?.neededFrom.length}',
+              ),
+            ],
           ),
         ),
-      ),
-    ],
-  );
+        ...((signingState?.neededFrom) ?? []).map((deviceId) {
+          final deviceName = coord.getDeviceName(id: deviceId) ?? '<no-name>';
+          final isConnected = connectedDevices.contains(deviceId);
+          final shareIndex = accessStruct?.getDeviceShortShareIndex(
+            deviceId: deviceId,
+          );
+          final label = shareIndex != null
+              ? '#$shareIndex $deviceName'
+              : deviceName;
+          final Widget trailing;
+          if (signingState!.gotShares.any(
+            (gotSharesFrom) => deviceIdEquals(deviceId, gotSharesFrom),
+          )) {
+            trailing = AnimatedCheckCircle();
+          } else {
+            trailing = Text(
+              isConnected ? 'Requesting Signature' : '',
+              style: TextStyle(
+                color: isConnected ? theme.colorScheme.primary : null,
+              ),
+            );
+          }
+          return ListTile(
+            enabled: isConnected,
+            title: Text(label),
+            trailing: trailing,
+          );
+        }),
+        Divider(height: 0.0),
+        Align(
+          alignment: AlignmentDirectional.centerStart,
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
+            child: TextButton(
+              onPressed: () async => showCancelSigningDialog(context),
+              style: TextButton.styleFrom(
+                foregroundColor: theme.colorScheme.error,
+              ),
+              child: Text('Cancel'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
 
   Widget buildBroadcastNeededColumn(BuildContext context) {
     final psbt = this.psbt;
@@ -655,28 +666,29 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
 
   Widget buildSignAndBroadcastCard(BuildContext context) {
     final theme = Theme.of(context);
+    final signingActive = widget.signingParams != null;
+    final signingColumn = Card.filled(
+      margin: EdgeInsets.all(0.0),
+      color: theme.colorScheme.surfaceContainerHigh,
+      child: buildSignaturesNeededColumn(context),
+    );
     return AnimatedCrossFade(
-      firstChild: AnimatedGradientBorder(
-        stretchAlongAxis: true,
-        borderSize: 1.0,
-        glowSize: 5.0,
-        animationTime: 6,
-        borderRadius: BorderRadius.circular(12.0),
-        gradientColors: [
-          theme.colorScheme.outlineVariant,
-          theme.colorScheme.primary,
-          theme.colorScheme.secondary,
-          theme.colorScheme.tertiary,
-        ],
-        child: (Widget child) {
-          final theme = Theme.of(context);
-          return Card.filled(
-            margin: EdgeInsets.all(0.0),
-            color: theme.colorScheme.surfaceContainerHigh,
-            child: child,
-          );
-        }(buildSignaturesNeededColumn(context)),
-      ),
+      firstChild: signingActive
+          ? AnimatedGradientBorder(
+              stretchAlongAxis: true,
+              borderSize: 1.0,
+              glowSize: 5.0,
+              animationTime: 6,
+              borderRadius: BorderRadius.circular(12.0),
+              gradientColors: [
+                theme.colorScheme.outlineVariant,
+                theme.colorScheme.primary,
+                theme.colorScheme.secondary,
+                theme.colorScheme.tertiary,
+              ],
+              child: signingColumn,
+            )
+          : signingColumn,
       secondChild: Card.filled(
         color: Colors.transparent,
         margin: EdgeInsets.all(0.0),
@@ -869,6 +881,36 @@ Widget buildDetailsColumn(
                 title: SatoshiText(value: info.amount, showSign: false),
                 onTap: () =>
                     copyAction(context, 'Recipient amount', '${info.amount}'),
+              ),
+            ],
+          );
+        }),
+      if (!txDetails.isSend)
+        ...txDetails.tx.recipients().where((info) => info.isMine).map((info) {
+          final address = info.address(network: walletCtx.network)?.toString();
+          final idx = info.derivationIndex;
+          return Column(
+            children: [
+              ListTile(
+                dense: dense,
+                contentPadding: contentPadding,
+                leading: Text('Received at${idx != null ? ' #$idx' : ''}'),
+                title: Text(
+                  spacedHex(address ?? '<unknown>'),
+                  style: monospaceTextStyle,
+                  textAlign: TextAlign.end,
+                ),
+                onTap: address == null
+                    ? null
+                    : () => copyAction(context, 'Receiving address', address),
+              ),
+              ListTile(
+                dense: dense,
+                contentPadding: contentPadding,
+                leading: Text('\u2570 Amount'),
+                title: SatoshiText(value: info.amount, showSign: false),
+                onTap: () =>
+                    copyAction(context, 'Received amount', '${info.amount}'),
               ),
             ],
           );

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -14,7 +14,6 @@ use frostsnap_core::message::EncodedSignature;
 use tracing::{event, Level};
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::ops::Deref;
 use std::{
     path::{Path, PathBuf},
@@ -185,7 +184,7 @@ pub struct Transaction {
     pub confirmation_time: Option<ConfirmationTime>,
     pub last_seen: Option<u64>,
     pub prevouts: HashMap<bitcoin::OutPoint, bitcoin::TxOut>,
-    pub is_mine: HashSet<bitcoin::ScriptBuf>,
+    pub is_mine: HashMap<bitcoin::ScriptBuf, u32>,
 }
 
 impl Transaction {
@@ -194,13 +193,13 @@ impl Transaction {
         let txid = tx_temp.txid();
         let is_mine = tx_temp
             .iter_locally_owned_inputs()
-            .map(|(_, _, spk)| spk.spk())
+            .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index))
             .chain(
                 tx_temp
                     .iter_locally_owned_outputs()
-                    .map(|(_, _, spk)| spk.spk()),
+                    .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index)),
             )
-            .collect::<HashSet<_>>();
+            .collect::<HashMap<_, _>>();
         let prevouts = tx_temp
             .inputs()
             .iter()
@@ -243,7 +242,7 @@ impl Transaction {
                     Some(txout) => txout,
                     None => return false,
                 };
-                self.is_mine.contains(&prev_txout.script_pubkey)
+                self.is_mine.contains_key(&prev_txout.script_pubkey)
             })
             .map(|(vin, _)| vin)
     }
@@ -281,7 +280,7 @@ impl Transaction {
 
     /// Computes the sum of all inputs, or only those whose previous output script pubkey is in
     /// `filter`, if provided. The result is `None` if any input is missing a previous output.
-    fn _sum_inputs(&self, filter: Option<&HashSet<bitcoin::ScriptBuf>>) -> Option<u64> {
+    fn _sum_inputs(&self, filter: Option<&HashMap<bitcoin::ScriptBuf, u32>>) -> Option<u64> {
         let prevouts = self
             .inner
             .input
@@ -293,7 +292,7 @@ impl Transaction {
                 .into_iter()
                 .filter(|prevout| {
                     match &filter {
-                        Some(filter) => filter.contains(prevout.script_pubkey.as_script()),
+                        Some(filter) => filter.contains_key(prevout.script_pubkey.as_script()),
                         // No filter.
                         None => true,
                     }
@@ -305,13 +304,13 @@ impl Transaction {
 
     /// Computes the sum of all outputs, or only those whose script pubkey is in `filter`, if
     /// provided.
-    fn _sum_outputs(&self, filter: Option<&HashSet<bitcoin::ScriptBuf>>) -> u64 {
+    fn _sum_outputs(&self, filter: Option<&HashMap<bitcoin::ScriptBuf, u32>>) -> u64 {
         self.inner
             .output
             .iter()
             .filter(|txout| {
                 match &filter {
-                    Some(filter) => filter.contains(txout.script_pubkey.as_script()),
+                    Some(filter) => filter.contains_key(txout.script_pubkey.as_script()),
                     // No filter.
                     None => true,
                 }
@@ -351,13 +350,15 @@ impl Transaction {
     /// Returns `None` if any input is missing a previous output.
     #[frb(sync, type_64bit_int)]
     pub fn sum_inputs_spending_spk(&self, spk: &bitcoin::ScriptBuf) -> Option<u64> {
-        self._sum_inputs(Some(&[spk.as_script().to_owned()].into()))
+        let filter = HashMap::from([(spk.as_script().to_owned(), 0)]);
+        self._sum_inputs(Some(&filter))
     }
 
     /// Computes the total value of outputs that send to the given script pubkey.
     #[frb(sync, type_64bit_int)]
     pub fn sum_outputs_to_spk(&self, spk: &bitcoin::ScriptBuf) -> u64 {
-        self._sum_outputs(Some(&[spk.as_script().to_owned()].into()))
+        let filter = HashMap::from([(spk.as_script().to_owned(), 0)]);
+        self._sum_outputs(Some(&filter))
     }
 
     /// Computes the net change in our owned balance: owned outputs minus owned inputs.
@@ -405,11 +406,15 @@ impl Transaction {
             .output
             .iter()
             .zip(0_u32..)
-            .map(|(txout, vout)| TxOutInfo {
-                vout,
-                amount: txout.value.to_sat(),
-                script_pubkey: txout.script_pubkey.clone(),
-                is_mine: self.is_mine.contains(&txout.script_pubkey),
+            .map(|(txout, vout)| {
+                let derivation_index = self.is_mine.get(&txout.script_pubkey).copied();
+                TxOutInfo {
+                    vout,
+                    amount: txout.value.to_sat(),
+                    script_pubkey: txout.script_pubkey.clone(),
+                    is_mine: derivation_index.is_some(),
+                    derivation_index,
+                }
             })
             .collect()
     }
@@ -437,6 +442,7 @@ pub struct TxOutInfo {
     pub amount: u64,
     pub script_pubkey: bitcoin::ScriptBuf,
     pub is_mine: bool,
+    pub derivation_index: Option<u32>,
 }
 
 impl TxOutInfo {

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -6,7 +6,6 @@ use super::{
 use crate::{frb_generated::StreamSink, sink_wrap::SinkWrap};
 use anyhow::{anyhow, Result};
 use bitcoin::hex::DisplayHex;
-use bitcoin::ScriptBuf;
 use flutter_rust_bridge::frb;
 pub use frostsnap_coordinator::signing::SigningState;
 pub use frostsnap_core::bitcoin_transaction::TransactionTemplate;
@@ -115,13 +114,13 @@ impl ActiveSignSessionExt for ActiveSignSession {
                 let txid = raw_tx.compute_txid();
                 let is_mine = tx_temp
                     .iter_locally_owned_inputs()
-                    .map(|(_, _, spk)| spk.spk())
+                    .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index))
                     .chain(
                         tx_temp
                             .iter_locally_owned_outputs()
-                            .map(|(_, _, spk)| spk.spk()),
+                            .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index)),
                     )
-                    .collect::<HashSet<_>>();
+                    .collect::<HashMap<_, _>>();
                 let prevouts = tx_temp
                     .inputs()
                     .iter()
@@ -188,9 +187,13 @@ impl UnsignedTx {
                         .get_prevouts(raw_tx.input.iter().map(|txin| txin.previous_output))
                         .values(),
                 )
-                .map(|txout| txout.script_pubkey.clone())
-                .filter(|spk| super_wallet.is_spk_mine(master_appkey, spk.clone()))
-                .collect::<HashSet<ScriptBuf>>(),
+                .filter_map(|txout| {
+                    let spk = txout.script_pubkey.clone();
+                    super_wallet
+                        .spk_index(master_appkey, spk.clone())
+                        .map(|index| (spk, index))
+                })
+                .collect::<HashMap<_, _>>(),
             inner: raw_tx,
         }
     }


### PR DESCRIPTION
Incoming txs now display the receive address they landed on (with its derivation index) in the details column. The signing progress list prefixes each device with its short share index (e.g. "#1 Alice").