### PR TITLE
[app] In-place copy feedback instead of bottom snackbars

### DIFF
--- a/frostsnapp/lib/copy_feedback.dart
+++ b/frostsnapp/lib/copy_feedback.dart
@@ -1,0 +1,446 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:frostsnap/global.dart';
+import 'package:frostsnap/theme.dart';
+
+const _chipTotalDuration = Duration(milliseconds: 990);
+const _chipRevertDelay = Duration(milliseconds: 1200);
+const _chipInFraction = 0.22;
+const _chipOutFraction = 0.22;
+
+Future<bool> _writeClipboard(String data) async {
+  HapticFeedback.selectionClick();
+  try {
+    await Clipboard.setData(ClipboardData(text: data));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Copies [data] without the floating chip. Use when surrounding UI already
+/// provides feedback (e.g. a snackbar's Copy action button or an inline
+/// label flip). Still announces "Copied" to screen readers by default, since
+/// the sighted label flip isn't read unless focus happens to be on the
+/// changed widget.
+Future<bool> copyToClipboardQuietly(String data, {bool announce = true}) async {
+  final ok = await _writeClipboard(data);
+  if (ok && announce) _announceCopied();
+  return ok;
+}
+
+void _announceCopied() {
+  final overlay = rootNavKey.currentState?.overlay;
+  if (overlay == null) return;
+  SemanticsService.sendAnnouncement(
+    View.of(overlay.context),
+    'Copied',
+    Directionality.of(overlay.context),
+  );
+}
+
+/// Writes [data] to the clipboard, fires a haptic, announces to screen
+/// readers, and shows a transient "COPIED" chip anchored to the tap
+/// location. Returns `true` if the clipboard write succeeded.
+///
+/// Safe to invoke even if [context] is disposed during the async gap:
+/// the chip is inserted into the root overlay directly, not via [context].
+Future<bool> copyToClipboard(
+  String data, {
+  Offset? tapPosition,
+  GlobalKey? anchorKey,
+}) async {
+  final anchorRect = _resolveAnchor(tapPosition, anchorKey);
+  final ok = await _writeClipboard(data);
+  if (!ok) return false;
+  _showCopiedChip(anchorRect);
+  return true;
+}
+
+Rect? _resolveAnchor(Offset? tapPosition, GlobalKey? anchorKey) {
+  if (tapPosition != null) {
+    return Rect.fromCenter(center: tapPosition, width: 1, height: 1);
+  }
+  final ctx = anchorKey?.currentContext;
+  if (ctx == null) return null;
+  final box = ctx.findRenderObject();
+  if (box is! RenderBox || !box.attached || !box.hasSize) return null;
+  return box.localToGlobal(Offset.zero) & box.size;
+}
+
+void _showCopiedChip(Rect? anchorRect) {
+  final overlay = rootNavKey.currentState?.overlay;
+  if (overlay == null) return;
+  _announceCopied();
+  late OverlayEntry entry;
+  entry = OverlayEntry(builder: (_) => _CopiedChip(anchorRect: anchorRect));
+  overlay.insert(entry);
+  Timer(_chipTotalDuration, () {
+    if (entry.mounted) entry.remove();
+  });
+}
+
+/// Copy icon that swaps instantly to a check when [checked] flips to `true`.
+/// The parent owns the notifier's lifetime.
+class CopyIcon extends StatelessWidget {
+  const CopyIcon({
+    super.key,
+    required this.checked,
+    this.size = iconSize,
+    this.color,
+    this.icon = Icons.copy_rounded,
+  });
+
+  final ValueListenable<bool> checked;
+  final double size;
+  final Color? color;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: checked,
+      builder: (context, showCheck, _) => showCheck
+          ? Icon(
+              Icons.check_rounded,
+              size: size,
+              color: Theme.of(context).colorScheme.primary,
+            )
+          : Icon(icon, size: size, color: color),
+    );
+  }
+}
+
+class CopyIconButton extends StatefulWidget {
+  const CopyIconButton({
+    super.key,
+    required this.data,
+    this.tooltip = 'Copy',
+    this.size = iconSize,
+    this.color,
+    this.icon = Icons.copy_rounded,
+    this.onCopy,
+  });
+
+  final String? data;
+  final String? tooltip;
+  final double size;
+  final Color? color;
+  final IconData icon;
+  final VoidCallback? onCopy;
+
+  @override
+  State<CopyIconButton> createState() => _CopyIconButtonState();
+}
+
+class _CopyIconButtonState extends State<CopyIconButton> {
+  final _checked = ValueNotifier<bool>(false);
+  final _anchorKey = GlobalKey();
+  Timer? _revertTimer;
+  Offset? _lastTap;
+
+  @override
+  void dispose() {
+    _revertTimer?.cancel();
+    _checked.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onPressed() async {
+    final data = widget.data;
+    if (data == null) return;
+    final tapPos = _lastTap;
+    _lastTap = null;
+    final ok = await copyToClipboard(
+      data,
+      tapPosition: tapPos,
+      anchorKey: _anchorKey,
+    );
+    if (!ok || !mounted) return;
+    _checked.value = true;
+    _revertTimer?.cancel();
+    _revertTimer = Timer(_chipRevertDelay, () {
+      if (mounted) _checked.value = false;
+    });
+    widget.onCopy?.call();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: (e) => _lastTap = e.position,
+      child: IconButton(
+        key: _anchorKey,
+        tooltip: widget.tooltip,
+        onPressed: widget.data == null ? null : _onPressed,
+        icon: CopyIcon(
+          checked: _checked,
+          size: widget.size,
+          color: widget.color,
+          icon: widget.icon,
+        ),
+      ),
+    );
+  }
+}
+
+/// Wraps any tappable widget and plumbs the whole copy flow to the builder.
+/// The builder receives:
+///   * `onCopy` — invoke to perform the copy. `null` iff [data] is `null`,
+///     so `onTap: onCopy` on a ListTile gracefully disables the row.
+///   * `checked` — drives a [CopyIcon] inside the child, if any.
+class CopyTapTarget extends StatefulWidget {
+  const CopyTapTarget({super.key, required this.data, required this.builder});
+
+  final String? data;
+  final Widget Function(
+    BuildContext context,
+    VoidCallback? onCopy,
+    ValueListenable<bool> checked,
+  )
+  builder;
+
+  @override
+  State<CopyTapTarget> createState() => _CopyTapTargetState();
+}
+
+class _CopyTapTargetState extends State<CopyTapTarget> {
+  final _checked = ValueNotifier<bool>(false);
+  Timer? _revertTimer;
+  Offset? _lastTap;
+
+  @override
+  void dispose() {
+    _revertTimer?.cancel();
+    _checked.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onCopy() async {
+    final data = widget.data;
+    if (data == null) return;
+    final tapPos = _lastTap;
+    _lastTap = null;
+    final ok = await copyToClipboard(data, tapPosition: tapPos);
+    if (!ok || !mounted) return;
+    _checked.value = true;
+    _revertTimer?.cancel();
+    _revertTimer = Timer(_chipRevertDelay, () {
+      if (mounted) _checked.value = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final onCopy = widget.data == null ? null : _onCopy;
+    return Listener(
+      onPointerDown: (e) => _lastTap = e.position,
+      child: widget.builder(context, onCopy, _checked),
+    );
+  }
+}
+
+/// `ListTile` that copies [data] to the clipboard when tapped.
+///
+/// Null [data] disables the row. If [showCopyIcon] is true and [trailing] is
+/// not supplied, a morphing [CopyIcon] is placed in the trailing slot — omit
+/// it for rows that don't advertise a visible copy affordance.
+class CopyListTile extends StatelessWidget {
+  const CopyListTile({
+    super.key,
+    required this.data,
+    this.leading,
+    this.title,
+    this.subtitle,
+    this.trailing,
+    this.contentPadding,
+    this.dense,
+    this.showCopyIcon = false,
+  });
+
+  final String? data;
+  final Widget? leading;
+  final Widget? title;
+  final Widget? subtitle;
+  final Widget? trailing;
+  final EdgeInsetsGeometry? contentPadding;
+  final bool? dense;
+  final bool showCopyIcon;
+
+  @override
+  Widget build(BuildContext context) {
+    return CopyTapTarget(
+      data: data,
+      builder: (_, onCopy, checked) {
+        final effectiveTrailing =
+            trailing ??
+            (showCopyIcon && onCopy != null
+                ? CopyIcon(checked: checked)
+                : null);
+        return ListTile(
+          leading: leading,
+          title: title,
+          subtitle: subtitle,
+          trailing: effectiveTrailing,
+          contentPadding: contentPadding,
+          dense: dense,
+          onTap: onCopy,
+        );
+      },
+    );
+  }
+}
+
+class _CopiedChip extends StatefulWidget {
+  const _CopiedChip({required this.anchorRect});
+  final Rect? anchorRect;
+
+  @override
+  State<_CopiedChip> createState() => _CopiedChipState();
+}
+
+class _CopiedChipState extends State<_CopiedChip>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ac = AnimationController(
+    vsync: this,
+    duration: _chipTotalDuration,
+  )..forward();
+
+  @override
+  void dispose() {
+    _ac.dispose();
+    super.dispose();
+  }
+
+  ({double opacity, double translateY, double scale}) _stageValues(double t) {
+    const holdEnd = 1.0 - _chipOutFraction;
+    if (t < _chipInFraction) {
+      final p = Curves.easeOutCubic.transform(t / _chipInFraction);
+      return (opacity: p, translateY: 8 * (1 - p), scale: 0.85 + 0.15 * p);
+    } else if (t < holdEnd) {
+      final p = (t - _chipInFraction) / (holdEnd - _chipInFraction);
+      return (opacity: 1.0, translateY: -10 * p, scale: 1.0);
+    } else {
+      final p = Curves.easeInCubic.transform((t - holdEnd) / _chipOutFraction);
+      return (opacity: 1.0 - p, translateY: -10, scale: 1.0);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final mq = MediaQuery.of(context);
+    final fg = theme.colorScheme.onInverseSurface;
+    final screen = mq.size;
+
+    final chip = ExcludeSemantics(
+      child: Material(
+        color: theme.colorScheme.inverseSurface,
+        elevation: 6,
+        borderRadius: BorderRadius.circular(999),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.check_rounded, size: 18, color: fg),
+              const SizedBox(width: 8),
+              Text(
+                'COPIED',
+                style: TextStyle(
+                  color: fg,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1.6,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    return AnimatedBuilder(
+      animation: _ac,
+      builder: (context, _) {
+        final v = _stageValues(_ac.value);
+        return CustomSingleChildLayout(
+          delegate: _ChipLayoutDelegate(
+            anchorRect: widget.anchorRect,
+            safeTop: mq.viewPadding.top + 4,
+            safeLeft: mq.viewPadding.left + 12,
+            safeRight: screen.width - mq.viewPadding.right - 12,
+            safeBottom: screen.height - mq.viewPadding.bottom - 80,
+            gap: 10,
+            fadeOffsetY: v.translateY,
+          ),
+          child: Opacity(
+            opacity: v.opacity,
+            child: Transform.scale(
+              scale: v.scale,
+              child: IgnorePointer(child: chip),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ChipLayoutDelegate extends SingleChildLayoutDelegate {
+  _ChipLayoutDelegate({
+    required this.anchorRect,
+    required this.safeTop,
+    required this.safeLeft,
+    required this.safeRight,
+    required this.safeBottom,
+    required this.gap,
+    required this.fadeOffsetY,
+  });
+
+  final Rect? anchorRect;
+  final double safeTop;
+  final double safeLeft;
+  final double safeRight;
+  final double safeBottom;
+  final double gap;
+  final double fadeOffsetY;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    return BoxConstraints(maxWidth: (safeRight - safeLeft).clamp(0, 360));
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    final anchor = anchorRect;
+    double top;
+    double left;
+
+    if (anchor != null) {
+      final above = anchor.top - childSize.height - gap;
+      final below = anchor.bottom + gap;
+      top = above > safeTop ? above : below;
+      left = anchor.center.dx - childSize.width / 2;
+    } else {
+      top = safeBottom - childSize.height;
+      left = (size.width - childSize.width) / 2;
+    }
+
+    final maxLeft = math.max(safeLeft, safeRight - childSize.width);
+    final maxTop = math.max(safeTop, safeBottom - childSize.height);
+    left = left.clamp(safeLeft, maxLeft);
+    top = top.clamp(safeTop, maxTop);
+
+    return Offset(left, top + fadeOffsetY);
+  }
+
+  @override
+  bool shouldRelayout(_ChipLayoutDelegate old) =>
+      old.anchorRect != anchorRect || old.fadeOffsetY != fadeOffsetY;
+}

--- a/frostsnapp/lib/device.dart
+++ b/frostsnapp/lib/device.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/src/rust/api.dart';
@@ -133,7 +133,8 @@ class _DeviceDetailsState extends State<DeviceDetails> {
     ];
 
     final nonEmptyRows = [
-      ListTile(
+      CopyListTile(
+        data: deviceName,
         contentPadding: EdgeInsets.symmetric(horizontal: 16),
         title: Text('Device Name'),
         subtitle: Text(
@@ -143,9 +144,6 @@ class _DeviceDetailsState extends State<DeviceDetails> {
           ),
         ),
         leading: Icon(Icons.label_rounded),
-        onTap: deviceName == null
-            ? null
-            : () => copyAction(context, 'Device name', deviceName),
       ),
       ListTile(
         contentPadding: EdgeInsets.symmetric(horizontal: 16),
@@ -168,7 +166,8 @@ class _DeviceDetailsState extends State<DeviceDetails> {
     ];
 
     final advancedHidden = [
-      ListTile(
+      CopyListTile(
+        data: device.id.toHex(),
         contentPadding: EdgeInsets.symmetric(horizontal: 16),
         title: Text('Device ID'),
         subtitle: Text(
@@ -177,16 +176,14 @@ class _DeviceDetailsState extends State<DeviceDetails> {
           style: monospaceTextStyle,
         ),
         leading: Icon(Icons.fingerprint_rounded),
-        onTap: () => copyAction(context, 'Device ID', device.id.toHex()),
       ),
       if (!isEmpty)
-        ListTile(
+        CopyListTile(
+          data: '$noncesAvailable',
           contentPadding: EdgeInsets.symmetric(horizontal: 16),
           title: Text('Nonces'),
           subtitle: Text('$noncesAvailable'),
           leading: Icon(Icons.numbers_rounded),
-          onTap: () =>
-              copyAction(context, 'Remaining nonces', '$noncesAvailable'),
         ),
       if (!isEmpty)
         ListTile(
@@ -231,7 +228,8 @@ class _DeviceDetailsState extends State<DeviceDetails> {
       mainAxisSize: MainAxisSize.min,
       children: [
         ...(isEmpty ? emptyRows : nonEmptyRows),
-        ListTile(
+        CopyListTile(
+          data: device.firmware.digest.toString(),
           contentPadding: EdgeInsets.symmetric(horizontal: 16),
           leading: Icon(Icons.system_update_rounded),
           title: Row(
@@ -296,22 +294,10 @@ class _DeviceDetailsState extends State<DeviceDetails> {
               ),
             ),
           ),
-          onTap: () => copyAction(
-            context,
-            "Device firmware",
-            device.firmware.digest.toString(),
-          ),
         ),
         ...advancedRows,
       ],
     );
-  }
-
-  copyAction(BuildContext context, String what, String data) {
-    Clipboard.setData(ClipboardData(text: data));
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text('$what copied to clipboard')));
   }
 
   void showEraseDialog(BuildContext context, DeviceId id) async {

--- a/frostsnapp/lib/logs.dart
+++ b/frostsnapp/lib/logs.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/theme.dart';
 
 class LogPane extends StatefulWidget {
@@ -95,20 +95,7 @@ class _LogPane extends State<LogPane> {
             ),
           ),
           SizedBox(height: 16),
-          IconButton(
-            icon: const Icon(Icons.content_copy),
-            onPressed: () {
-              final String combinedLogs = _logs.map((log) => log).join('\n');
-              Clipboard.setData(ClipboardData(text: combinedLogs));
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('Logs copied to clipboard!'),
-                  duration: Duration(seconds: 1),
-                ),
-              );
-            },
-            tooltip: 'Copy All Logs',
-          ),
+          CopyIconButton(data: _logs.join('\n'), icon: Icons.content_copy),
         ],
       ),
     );

--- a/frostsnapp/lib/main.dart
+++ b/frostsnapp/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/serialport.dart';
@@ -340,21 +341,9 @@ class _StartupErrorWidgetState extends State<StartupErrorWidget> {
                   child: SelectableText(_combinedErrorWithLogs),
                 ),
                 SizedBox(height: 20),
-                IconButton(
-                  icon: Icon(Icons.content_copy),
-                  onPressed: () {
-                    Clipboard.setData(
-                      ClipboardData(text: _combinedErrorWithLogs),
-                    );
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                          "Copied! Only send this to the Frostsnap team.",
-                        ),
-                      ),
-                    );
-                  },
-                  tooltip: 'Copy to Clipboard',
+                CopyIconButton(
+                  data: _combinedErrorWithLogs,
+                  icon: Icons.content_copy,
                 ),
               ],
             ),

--- a/frostsnapp/lib/psbt.dart
+++ b/frostsnapp/lib/psbt.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:frostsnap/camera/camera.dart';
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/sign_message.dart';
@@ -294,26 +295,12 @@ Future<void> saveOrBroadcastSignedPsbtDialog(
                 SizedBox(height: 20),
                 showQr,
                 SizedBox(height: 20),
-                IconButton(
-                  icon: Icon(Icons.content_copy),
-                  onPressed: () {
-                    Clipboard.setData(
-                      ClipboardData(
-                        text: psbt
-                            .serialize()
-                            .map(
-                              (byte) => byte.toRadixString(16).padLeft(2, '0'),
-                            )
-                            .join(),
-                      ),
-                    );
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Error message copied to clipboard!'),
-                      ),
-                    );
-                  },
-                  tooltip: 'Copy to Clipboard',
+                CopyIconButton(
+                  data: psbt
+                      .serialize()
+                      .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+                      .join(),
+                  icon: Icons.content_copy,
                 ),
               ],
             ),

--- a/frostsnapp/lib/restoration/error_view.dart
+++ b/frostsnapp/lib/restoration/error_view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/restoration/recovery_flow.dart';
 import 'package:frostsnap/dialog_content_with_actions.dart';
 
@@ -91,12 +91,13 @@ class _ErrorViewState extends State<ErrorView> {
       ),
       actions: [
         if (!widget.isWarning)
-          OutlinedButton.icon(
-            icon: Icon(Icons.copy),
-            label: Text('Copy Error'),
-            onPressed: () {
-              Clipboard.setData(ClipboardData(text: widget.message));
-            },
+          CopyTapTarget(
+            data: widget.message,
+            builder: (ctx, onCopy, checked) => OutlinedButton.icon(
+              icon: CopyIcon(checked: checked),
+              label: Text('Copy Error'),
+              onPressed: onCopy,
+            ),
           ),
         if (widget.onRetry != null)
           FilledButton.icon(

--- a/frostsnapp/lib/settings.dart
+++ b/frostsnapp/lib/settings.dart
@@ -3,12 +3,12 @@ import 'dart:io' show Platform;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:frostsnap/address.dart';
 import 'package:frostsnap/access_structures.dart';
 import 'package:frostsnap/backup_workflow.dart';
 import 'package:frostsnap/bullet_list.dart';
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/electrum_server_settings.dart';
 import 'package:frostsnap/global.dart';
@@ -559,19 +559,13 @@ class _ExportDescriptorPageState extends State<ExportDescriptorPage>
                     ),
                   ),
                   SizedBox(height: 16.0),
-                  ElevatedButton.icon(
-                    icon: Icon(Icons.copy),
-                    label: Text('Copy to Clipboard'),
-                    onPressed: () {
-                      Clipboard.setData(
-                        ClipboardData(text: widget.walletDescriptor),
-                      );
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('Descriptor copied to clipboard'),
-                        ),
-                      );
-                    },
+                  CopyTapTarget(
+                    data: widget.walletDescriptor,
+                    builder: (ctx, onCopy, checked) => ElevatedButton.icon(
+                      icon: CopyIcon(checked: checked),
+                      label: Text('Copy to Clipboard'),
+                      onPressed: onCopy,
+                    ),
                   ),
                 ],
               ),
@@ -1313,23 +1307,12 @@ class AboutPage extends StatelessWidget {
                 defaultValue: 'unknown',
               );
 
-              return ListTile(
+              return CopyListTile(
+                data: buildVersion == 'unknown' ? null : buildVersion,
                 leading: Icon(Icons.info_outline),
                 title: Text('App version'),
                 subtitle: Text(buildVersion, style: monospaceTextStyle),
-                trailing: buildVersion != 'unknown'
-                    ? Icon(Icons.copy, size: 20)
-                    : null,
-                onTap: buildVersion != 'unknown'
-                    ? () {
-                        Clipboard.setData(ClipboardData(text: buildVersion));
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text('Copied version to clipboard'),
-                          ),
-                        );
-                      }
-                    : null,
+                showCopyIcon: true,
               );
             },
           ),
@@ -1338,9 +1321,9 @@ class AboutPage extends StatelessWidget {
               final firmwareVersion =
                   coord.upgradeFirmwareVersionName() ?? "No firmware bundled";
               final firmwareHash = coord.upgradeFirmwareDigest();
-              final canCopy = firmwareHash != null;
 
-              return ListTile(
+              return CopyListTile(
+                data: firmwareHash,
                 leading: Icon(Icons.memory),
                 title: Text('Bundled firmware version'),
                 subtitle: Column(
@@ -1357,17 +1340,7 @@ class AboutPage extends StatelessWidget {
                     ],
                   ],
                 ),
-                trailing: canCopy ? Icon(Icons.copy, size: 20) : null,
-                onTap: canCopy
-                    ? () {
-                        Clipboard.setData(ClipboardData(text: firmwareHash));
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text('Copied firmware hash to clipboard'),
-                          ),
-                        );
-                      }
-                    : null,
+                showCopyIcon: true,
               );
             },
           ),
@@ -1396,22 +1369,18 @@ class AboutPage extends StatelessWidget {
                             child: Column(
                               mainAxisSize: MainAxisSize.min,
                               children: [
-                                ListTile(
-                                  leading: Icon(Icons.copy),
-                                  title: Text('Copy commit hash'),
-                                  onTap: () {
-                                    Clipboard.setData(
-                                      ClipboardData(text: buildCommit),
-                                    );
-                                    Navigator.pop(context);
-                                    ScaffoldMessenger.of(context).showSnackBar(
-                                      SnackBar(
-                                        content: Text(
-                                          'Copied commit hash to clipboard',
-                                        ),
-                                      ),
-                                    );
-                                  },
+                                CopyTapTarget(
+                                  data: buildCommit,
+                                  builder: (ctx, onCopy, checked) => ListTile(
+                                    leading: CopyIcon(checked: checked),
+                                    title: Text('Copy commit hash'),
+                                    onTap: onCopy == null
+                                        ? null
+                                        : () {
+                                            onCopy();
+                                            Navigator.pop(context);
+                                          },
+                                  ),
                                 ),
                                 ListTile(
                                   leading: Icon(Icons.open_in_new),

--- a/frostsnapp/lib/snackbar.dart
+++ b/frostsnapp/lib/snackbar.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/global.dart';
 
 void showMessageSnackbar(
@@ -44,11 +44,10 @@ void showErrorSnackbar(BuildContext context, String errorMessage) {
     context,
     errorMessage,
     action: () {
-      Clipboard.setData(ClipboardData(text: errorMessage));
       rootScaffoldMessengerKey.currentState?.hideCurrentSnackBar(
         reason: SnackBarClosedReason.action,
       );
-      showMessageSnackbar(context, 'Copied to clipboard');
+      copyToClipboardQuietly(errorMessage);
     },
     actionText: 'Copy',
   );

--- a/frostsnapp/lib/theme.dart
+++ b/frostsnapp/lib/theme.dart
@@ -1,10 +1,9 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
-import 'package:frostsnap/snackbar.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:sliver_tools/sliver_tools.dart';
 
@@ -229,15 +228,13 @@ Future<void> showExceptionDialog(
           ),
         ),
         actions: [
-          TextButton.icon(
-            onPressed: () async {
-              await Clipboard.setData(ClipboardData(text: errorMessage));
-              if (context.mounted) {
-                showMessageSnackbar(context, 'Error message copied');
-              }
-            },
-            icon: const Icon(Icons.copy),
-            label: const Text('Copy'),
+          CopyTapTarget(
+            data: errorMessage,
+            builder: (ctx, onCopy, checked) => TextButton.icon(
+              onPressed: onCopy,
+              icon: CopyIcon(checked: checked),
+              label: const Text('Copy'),
+            ),
           ),
           FilledButton(
             onPressed: () => Navigator.of(context).pop(),

--- a/frostsnapp/lib/udev_setup.dart
+++ b/frostsnapp/lib/udev_setup.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/settings.dart';
 import 'package:frostsnap/theme.dart';
 
@@ -268,12 +268,7 @@ class _UdevSetupPageState extends State<UdevSetupPage>
                 _buildCodeBlock(
                   theme,
                   _manualCommandsDisplay,
-                  onCopy: () {
-                    Clipboard.setData(ClipboardData(text: _manualCommandsCopy));
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Copied to clipboard')),
-                    );
-                  },
+                  copyData: _manualCommandsCopy,
                 ),
                 const SizedBox(height: 12),
                 Text(
@@ -288,7 +283,7 @@ class _UdevSetupPageState extends State<UdevSetupPage>
     );
   }
 
-  Widget _buildCodeBlock(ThemeData theme, String code, {VoidCallback? onCopy}) {
+  Widget _buildCodeBlock(ThemeData theme, String code, {String? copyData}) {
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(
@@ -301,15 +296,11 @@ class _UdevSetupPageState extends State<UdevSetupPage>
             padding: const EdgeInsets.all(16),
             child: SelectableText(code, style: monospaceTextStyle),
           ),
-          if (onCopy != null)
+          if (copyData != null)
             Positioned(
               top: 4,
               right: 4,
-              child: IconButton(
-                icon: const Icon(Icons.copy, size: 18),
-                onPressed: onCopy,
-                tooltip: 'Copy',
-              ),
+              child: CopyIconButton(data: copyData, size: 18),
             ),
         ],
       ),

--- a/frostsnapp/lib/wallet_more.dart
+++ b/frostsnapp/lib/wallet_more.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:frostsnap/address.dart';
 import 'package:frostsnap/backup_workflow.dart';
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/psbt.dart';
 import 'package:frostsnap/settings.dart';
 import 'package:frostsnap/sign_message.dart';
-import 'package:frostsnap/snackbar.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';
 
@@ -259,20 +258,20 @@ void showExportWalletDialog(BuildContext context, String descriptor) async {
   qrCode.addData(descriptor);
   final qr = PrettyQrView(qrImage: QrImage(qrCode));
 
-  final descriptorButton = TextButton.icon(
-    onPressed: () async {
-      await Clipboard.setData(ClipboardData(text: descriptor));
-      showMessageSnackbar(context, "Descriptor copied");
-    },
-    icon: Icon(Icons.copy),
-    label: Text(
-      descriptor,
-      style: TextStyle(
-        fontFamily: monospaceTextStyle.fontFamily,
-        color: theme.colorScheme.onSurface,
+  final descriptorButton = CopyTapTarget(
+    data: descriptor,
+    builder: (ctx, onCopy, checked) => TextButton.icon(
+      onPressed: onCopy,
+      icon: CopyIcon(checked: checked),
+      label: Text(
+        descriptor,
+        style: TextStyle(
+          fontFamily: monospaceTextStyle.fontFamily,
+          color: theme.colorScheme.onSurface,
+        ),
       ),
+      style: TextButton.styleFrom(alignment: Alignment.centerLeft),
     ),
-    style: TextButton.styleFrom(alignment: Alignment.centerLeft),
   );
 
   final doneButton = FilledButton(

--- a/frostsnapp/lib/wallet_receive.dart
+++ b/frostsnapp/lib/wallet_receive.dart
@@ -5,6 +5,7 @@ import 'dart:ui';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/super_wallet.dart';
@@ -210,6 +211,8 @@ class _ReceiverPageState extends State<ReceivePage> {
   bool verificationSuccess = false;
 
   ReceivePageFocus _focus = ReceivePageFocus.share;
+  bool _copyJustHit = false;
+  Timer? _copyRevertTimer;
   ReceivePageFocus get focus => _focus;
   set focus(ReceivePageFocus v) {
     if (v == _focus || _address == null) return;
@@ -340,6 +343,7 @@ class _ReceiverPageState extends State<ReceivePage> {
     _verifyStreamSub?.cancel();
     txStreamSub.cancel();
     _fullscreenDialogController?.dispose();
+    _copyRevertTimer?.cancel();
     super.dispose();
   }
 
@@ -421,9 +425,33 @@ class _ReceiverPageState extends State<ReceivePage> {
                 child: FilledButton.tonalIcon(
                   onPressed: _address == null
                       ? null
-                      : () => copyAddress(context, _address!),
-                  label: Text('Copy'),
-                  icon: Icon(Icons.copy_rounded),
+                      : () async {
+                          const beforeVerify = Duration(milliseconds: 300);
+                          // Outlasts beforeVerify + cross-fade to avoid mid-transition flip.
+                          const copyRevert = Duration(milliseconds: 800);
+                          setState(() => _copyJustHit = true);
+                          _copyRevertTimer?.cancel();
+                          _copyRevertTimer = Timer(copyRevert, () {
+                            if (mounted) {
+                              setState(() => _copyJustHit = false);
+                            }
+                          });
+                          await copyToClipboardQuietly(
+                            _address!.address.toString(),
+                          );
+                          if (!mounted) return;
+                          markAddressShared(context, _address!);
+                          await Future.delayed(beforeVerify);
+                          if (!mounted) return;
+                          focus = ReceivePageFocus.verify;
+                        },
+                  label: Text(_copyJustHit ? 'Copied' : 'Copy'),
+                  icon: Icon(
+                    _copyJustHit ? Icons.check_rounded : Icons.copy_rounded,
+                    color: _copyJustHit
+                        ? Theme.of(context).colorScheme.primary
+                        : null,
+                  ),
                 ),
               ),
               Expanded(
@@ -642,12 +670,6 @@ class _ReceiverPageState extends State<ReceivePage> {
     final walletCtx = WalletContext.of(context)!;
     await walletCtx.wallet.markAddressShared(address.index);
     updateToIndex(address.index);
-  }
-
-  void copyAddress(BuildContext context, AddressInfo address) {
-    copyAction(context, 'AddressInfo', address.address.toString());
-    markAddressShared(context, address);
-    focus = ReceivePageFocus.verify;
   }
 
   void showAddressQr(BuildContext context, AddressInfo address) async {

--- a/frostsnapp/lib/wallet_tx_details.dart
+++ b/frostsnapp/lib/wallet_tx_details.dart
@@ -5,9 +5,9 @@ import 'package:collection/collection.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:frostsnap/animated_check.dart';
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
@@ -861,7 +861,8 @@ Widget buildDetailsColumn(
           final address = info.address(network: walletCtx.network)?.toString();
           return Column(
             children: [
-              ListTile(
+              CopyListTile(
+                data: address,
                 dense: dense,
                 contentPadding: contentPadding,
                 leading: Text('Recipient #${info.vout}'),
@@ -870,17 +871,13 @@ Widget buildDetailsColumn(
                   style: monospaceTextStyle,
                   textAlign: TextAlign.end,
                 ),
-                onTap: address == null
-                    ? null
-                    : () => copyAction(context, 'Recipient address', address),
               ),
-              ListTile(
+              CopyListTile(
+                data: '${info.amount}',
                 dense: dense,
                 contentPadding: contentPadding,
                 leading: Text('\u2570 Amount'),
                 title: SatoshiText(value: info.amount, showSign: false),
-                onTap: () =>
-                    copyAction(context, 'Recipient amount', '${info.amount}'),
               ),
             ],
           );
@@ -891,7 +888,8 @@ Widget buildDetailsColumn(
           final idx = info.derivationIndex;
           return Column(
             children: [
-              ListTile(
+              CopyListTile(
+                data: address,
                 dense: dense,
                 contentPadding: contentPadding,
                 leading: Text('Received at${idx != null ? ' #$idx' : ''}'),
@@ -900,23 +898,20 @@ Widget buildDetailsColumn(
                   style: monospaceTextStyle,
                   textAlign: TextAlign.end,
                 ),
-                onTap: address == null
-                    ? null
-                    : () => copyAction(context, 'Receiving address', address),
               ),
-              ListTile(
+              CopyListTile(
+                data: '${info.amount}',
                 dense: dense,
                 contentPadding: contentPadding,
                 leading: Text('\u2570 Amount'),
                 title: SatoshiText(value: info.amount, showSign: false),
-                onTap: () =>
-                    copyAction(context, 'Received amount', '${info.amount}'),
               ),
             ],
           );
         }),
       if (txDetails.isSend)
-        ListTile(
+        CopyListTile(
+          data: '$fee',
           dense: dense,
           contentPadding: contentPadding,
           leading: Row(
@@ -939,10 +934,10 @@ Widget buildDetailsColumn(
             ],
           ),
           title: fee == null ? Text('Unknown') : SatoshiText(value: fee),
-          onTap: () => copyAction(context, 'Fee amount', '$fee'),
         ),
       if (showConfirmations)
-        ListTile(
+        CopyListTile(
+          data: '${txDetails.confirmations}',
           dense: dense,
           contentPadding: contentPadding,
           leading: Text('Confirmations'),
@@ -952,13 +947,9 @@ Widget buildDetailsColumn(
                 : 'None',
             textAlign: TextAlign.end,
           ),
-          onTap: () => copyAction(
-            context,
-            'Confirmation count',
-            '${txDetails.confirmations}',
-          ),
         ),
-      ListTile(
+      CopyListTile(
+        data: txDetails.tx.txid,
         dense: dense,
         contentPadding: contentPadding,
         leading: Text('Txid'),
@@ -967,16 +958,9 @@ Widget buildDetailsColumn(
           style: monospaceTextStyle,
           textAlign: TextAlign.end,
         ),
-        onTap: () => copyAction(context, 'Txid', txDetails.tx.txid),
       ),
     ],
   );
-}
-
-void copyAction(BuildContext context, String what, String data) async {
-  await Clipboard.setData(ClipboardData(text: data));
-  if (context.mounted)
-    showMessageSnackbar(context, '$what copied to clipboard');
 }
 
 Future<void> rebroadcastAction(


### PR DESCRIPTION
## Summary

- Every copy-to-clipboard used to confirm with a 4-second bottom snackbar ("X copied to clipboard"). Replaced with a quick local reaction: haptic tick, the tapped icon morphs into a check, and a small floating "COPIED" pill blooms from the tap position for ~1 second. No more toasts travelling from the opposite end of the screen.
- Unifies two parallel snackbar code paths (raw `ScaffoldMessenger` and `showMessageSnackbar`) and two duplicate `copyAction` helpers (in `wallet_tx_details.dart` and `device.dart`) into one primitive in `lib/copy_feedback.dart`.
- Drive-by fix: "Copy Error" in `restoration/error_view.dart` previously had no feedback on tap; it now gets the same treatment as everything else.

## What's in `copy_feedback.dart`

- `copyToClipboard(data, {tapPosition, anchorKey})` — writes clipboard, fires haptic + screen-reader announce, inserts the chip into the root Overlay. Safe to invoke even if the caller's context is disposed during the async gap (anchor rect is resolved pre-await; chip lifetime is a `Timer` on the root overlay, not tied to the caller).
- `copyToClipboardQuietly(data)` — same write + haptic, no chip. Used inside `showErrorSnackbar`'s Copy action where the snackbar already provides the feedback surface.
- `CopyIcon` — stateless icon driven by a `ValueListenable<bool>`. Flips between `Icons.copy_rounded` and the existing `AnimatedCheckCircle` via `AnimatedSwitcher`.
- `CopyIconButton`, `CopyTapTarget`, `CopyListTile` — three wrapper widgets covering plain IconButtons, arbitrary buttons (FilledButton/TextButton/etc.), and ListTiles respectively. Each owns its own `ValueNotifier`, captures `onPointerDown` position, and handles the morph lifecycle.

## Test plan

- [ ] Receive screen → "Copy" button: button icon morphs to teal check-with-circle, pill rises above the button.
- [ ] Transaction details → tap any row (Recipient / Amount / Fee / Confirmations / Txid): pill appears at the tap location, no button morph (no visible copy icon on those rows).
- [ ] Settings → About → App version and Firmware hash rows: trailing copy icon morphs to check, pill appears.
- [ ] Settings → About → Build commit → bottom sheet "Copy commit hash": sheet pops and the pill still renders at the tap location (chip outlives the sheet).
- [ ] Exception dialog "Copy" button: chip escapes the dialog scrim (rendered in root overlay).
- [ ] Restoration error view "Copy Error" button: previously silent, now shows feedback.
- [ ] Logs page copy IconButton, main.dart error-copy IconButton, psbt.dart unsigned-PSBT copy IconButton: pill above button, icon morphs.
- [ ] Screen reader (TalkBack/VoiceOver): hears "Copied" once (not twice).
- [ ] Copy button near top of viewport: chip flips below the button instead of clipping.
- [ ] On a narrow split-screen/foldable: chip horizontally clamped inside safe area, no layout crash.