### PR TITLE
[coord] Stop panics from keygen canceling

### DIFF
--- a/frostsnap_coordinator/src/keygen.rs
+++ b/frostsnap_coordinator/src/keygen.rs
@@ -71,6 +71,10 @@ impl KeyGen {
         self.state.finished = Some(as_ref);
         self.emit_state()
     }
+
+    pub fn keygen_id(&self) -> KeygenId {
+        self.state.keygen_id
+    }
 }
 
 impl UiProtocol for KeyGen {

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -605,7 +605,24 @@ impl FfiCoordinator {
     }
 
     pub fn cancel_protocol(&self) {
-        if self.ui_stack.lock().unwrap().cancel_all() {
+        // HACK: cancel_protocol only tears down the UI-side protocol wrapper.
+        // For keygen we also need to clear FrostCoordinator::pending_keygens,
+        // otherwise an in-flight device response (Certify/Ack) arriving after
+        // cancel will cause the core to emit a follow-up keygen message that
+        // races the wire Cancel and panics the device. The proper fix is to
+        // replace cancel_protocol with per-protocol handles that own their
+        // own cancel logic; until then we introspect the stack here.
+        let mut coordinator = self.coordinator.lock().unwrap();
+        let mut ui_stack = self.ui_stack.lock().unwrap();
+        let keygen_id = ui_stack
+            .get_mut::<frostsnap_coordinator::keygen::KeyGen>()
+            .map(|k| k.keygen_id());
+        if ui_stack.cancel_all() {
+            if let Some(keygen_id) = keygen_id {
+                coordinator.MUTATE_NO_PERSIST().cancel_keygen(keygen_id);
+            }
+            drop(ui_stack);
+            drop(coordinator);
             self.usb_sender.send_cancel_all();
         }
     }


### PR DESCRIPTION
## Summary

- Canceling a keygen clears the UI-side `KeyGen` protocol but leaves `FrostCoordinator::pending_keygens` untouched. If an in-flight device response (e.g. `Certify` / `Ack`) lands after `cancel_protocol()` was invoked, the core still emits a follow-up keygen message (`CertifyPlease` / `Check`) that races the wire `Cancel`. The device processes the `Cancel` first (`clear_tmp_data`), then receives the stale keygen message and panics at `device/src/esp32_run.rs`'s `.expect("failed to process coordinator message")` because the tmp keygen state is gone.
- Fix: on cancel, introspect the `UiStack` to find a `KeyGen`, read its `keygen_id`, and call `FrostCoordinator::cancel_keygen(id)` under the same lock order the worker thread uses (coordinator → ui_stack) so nothing can interleave between `cancel_all()` and the core cleanup.
- Marked with a `HACK:` comment — the proper fix is per-protocol handles that own their own cancel logic, but that's out of scope here.

## Test plan

- [ ] Start a keygen, hit Cancel at the Security Check dialog, and verify the device does not panic.
- [ ] Cancel a keygen and immediately start a new one; verify both flows complete cleanly.
- [ ] Cancel mid-flight (earlier phases, before Security Check) and confirm no device panic.