### PR TITLE
[core] Drop redundant access_structure_ref from restoration messages

### DIFF
--- a/frostsnap_core/src/coordinator/restoration.rs
+++ b/frostsnap_core/src/coordinator/restoration.rs
@@ -1093,7 +1093,6 @@ impl FrostCoordinator {
             ))?;
         Ok(vec![CoordinatorSend::ToDevice {
             message: CoordinatorToDeviceMessage::Restoration(CoordinatorRestoration::CheckBackup {
-                access_structure_ref,
                 coord_share_decryption_contrib,
                 share_index,
                 root_shared_key,

--- a/frostsnap_core/src/device/restoration.rs
+++ b/frostsnap_core/src/device/restoration.rs
@@ -201,20 +201,14 @@ impl<S: Debug + NonceStreamSlot> FrostSigner<S> {
                 }
             }
             &CoordinatorRestoration::DisplayBackup {
-                access_structure_ref,
+                // Redundant with root_shared_key — ignored, derived below.
+                access_structure_ref: _,
                 coord_share_decryption_contrib,
                 share_index,
                 ref root_shared_key,
             } => {
-                // Verify that the root_shared_key corresponds to the access_structure_ref
-                let expected_ref = AccessStructureRef::from_root_shared_key(root_shared_key);
-                if expected_ref != access_structure_ref {
-                    return Err(Error::signer_invalid_message(
-                        &message,
-                        "root_shared_key doesn't match access_structure_ref",
-                    ));
-                }
-
+                let access_structure_ref =
+                    AccessStructureRef::from_root_shared_key(root_shared_key);
                 let AccessStructureRef {
                     key_id,
                     access_structure_id,
@@ -269,19 +263,12 @@ impl<S: Debug + NonceStreamSlot> FrostSigner<S> {
             }
 
             &CoordinatorRestoration::CheckBackup {
-                access_structure_ref,
                 coord_share_decryption_contrib,
                 share_index,
                 ref root_shared_key,
             } => {
-                let expected_ref = AccessStructureRef::from_root_shared_key(root_shared_key);
-                if expected_ref != access_structure_ref {
-                    return Err(Error::signer_invalid_message(
-                        &message,
-                        "root_shared_key doesn't match access_structure_ref",
-                    ));
-                }
-
+                let access_structure_ref =
+                    AccessStructureRef::from_root_shared_key(root_shared_key);
                 let AccessStructureRef {
                     key_id,
                     access_structure_id,

--- a/frostsnap_core/src/message.rs
+++ b/frostsnap_core/src/message.rs
@@ -57,6 +57,10 @@ pub enum CoordinatorRestoration {
     /// Consolidate the saved secret share backup into a properly encrypted backup.
     Consolidate(Box<ConsolidateBackup>),
     DisplayBackup {
+        /// Redundant: derivable from `root_shared_key` via
+        /// `AccessStructureRef::from_root_shared_key`. Coordinators must still
+        /// set it correctly — devices ignore it but the field is wire-visible
+        /// and kept for backwards compatibility.
         access_structure_ref: AccessStructureRef,
         coord_share_decryption_contrib: CoordShareDecryptionContrib,
         share_index: ShareIndex,
@@ -65,7 +69,6 @@ pub enum CoordinatorRestoration {
     RequestHeldShares,
     SavePhysicalBackup2(Box<HeldShare2>),
     CheckBackup {
-        access_structure_ref: AccessStructureRef,
         coord_share_decryption_contrib: CoordShareDecryptionContrib,
         share_index: ShareIndex,
         root_shared_key: SharedKey,


### PR DESCRIPTION
access_structure_ref can be derived from root_shared_key via AccessStructureRef::from_root_shared_key, so sending both on the wire and validating they match is pure overhead.

Remove the field from CheckBackup (still unreleased enough to change). For DisplayBackup the field is already deployed in released firmware, so keep it on the wire but ignore it on the device and document that coordinators should still set it correctly.