### PR TITLE
Update for chilldkg API changes from secp256kfun security review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3985,9 +3985,9 @@ checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
 name = "schnorr_fun"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711acb599464e57111c072bf6a9a64b51313f4baa776f4a500926dd4339bd32"
+checksum = "b92126e202853794199f04edf02851e17963c95e1d2308dccecf92a6857359d5"
 dependencies = [
  "bech32",
  "bincode",
@@ -4094,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "secp256kfun"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d209307a50f8baee901c4e65ccef0da4185ef2d54834d73d6847369b8fa049"
+checksum = "ca6e7ba8c21335d29d0c9b8f46c3fbd1127b03b0e0b7dc5ebbe3ef28ef820ec6"
 dependencies = [
  "bincode",
  "digest 0.10.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ rand_chacha = { version = "0.3", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 bitcoin = { version = "0.32", features = ["serde"], default-features = false }
 secp256kfun = { version = "0.12", default-features = false }
-schnorr_fun = { version = "0.12", default-features = false }
+schnorr_fun = { version = "0.13", default-features = false }
 bdk_coin_select = { version = "0.3" }
 rand_core = "0.6"
 rand = "0.8"
@@ -94,3 +94,4 @@ incremental = false
 lto = 'fat'
 opt-level = 's'
 overflow-checks = false
+

--- a/device/src/frosty_ui.rs
+++ b/device/src/frosty_ui.rs
@@ -204,14 +204,10 @@ impl<'a> UserInteraction for FrostyUi<'a> {
             Workflow::UserPrompt(prompt) => {
                 match prompt {
                     Prompt::KeyGen { phase } => {
-                        // Extract t_of_n and session_hash from phase
-                        let t_of_n = phase.t_of_n();
                         let session_hash = phase.session_hash();
-                        // Extract the first 4 bytes as security check code
                         let mut security_check_code = [0u8; 4];
                         security_check_code.copy_from_slice(&session_hash.0[..4]);
-                        // Create the KeygenCheck widget with just the display data
-                        let widget = KeygenCheck::new(t_of_n, security_check_code);
+                        let widget = KeygenCheck::new(phase.t_of_n(), security_check_code);
                         // Store both widget and phase in the WidgetTree
                         WidgetTree::KeygenCheck {
                             widget: Box::new(widget),

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -634,24 +634,20 @@ impl FrostCoordinator {
                         let cert_scheme = certpedpop::vrf_cert::VrfCertScheme::<Sha256>::new(
                             crate::message::keygen::VRF_CERT_SCHEME_ID,
                         );
-                        let share_index = state.device_to_share_index.get(&from).ok_or(
-                            Error::coordinator_invalid_message(
+                        let receiver_idx = state
+                            .devices_in_order
+                            .iter()
+                            .position(|d| d == &from)
+                            .ok_or(Error::coordinator_invalid_message(
                                 message_kind,
                                 "got share from device that was not part of keygen",
-                            ),
-                        )?;
-
-                        // Input-generator indices: [0..n_coordinators) are coordinators;
-                        // [n_coordinators..n_coordinators + n_devices) are devices in
-                        // share-index order. Share indices are 1-based, hence the `- 1`.
-                        let n_coordinators = state.coordinator_public_keys.len() as u32;
-                        let input_gen_index = u32::from(*share_index) - 1 + n_coordinators;
+                            ))? as u32;
 
                         state
                             .input_aggregator
                             .add_input(
-                                &schnorr_fun::new_with_deterministic_nonces::<Sha256>(),
-                                input_gen_index,
+                                &schnorr_fun::Schnorr::<Sha256>::verify_only(),
+                                certpedpop::Party::Receiver(receiver_idx),
                                 *response.input,
                             )
                             .map_err(|e| Error::coordinator_invalid_message(message_kind, e))?;
@@ -663,28 +659,28 @@ impl FrostCoordinator {
                             })];
 
                         if state.input_aggregator.is_finished() {
-                            // Remove the entry to take ownership
-                            let mut agg_input = state.input_aggregator.finish().unwrap();
-                            agg_input.grind_fingerprint::<Sha256>(self.keygen_fingerprint);
+                            let agg_input = state
+                                .input_aggregator
+                                .finish_with_fingerprint::<Sha256>(self.keygen_fingerprint)
+                                .expect("input aggregator just reported finished");
 
-                            // First we calculate our (the coordinator) certificate and add our VRF outputs
-                            let sig = state
+                            let schnorr = schnorr_fun::new_with_deterministic_nonces::<Sha256>();
+                            let (verified, sig) = state
                                 .contributer
-                                .verify_agg_input(&cert_scheme, &agg_input, &state.my_keypair)
+                                .verify_agg_input(
+                                    &schnorr,
+                                    &cert_scheme,
+                                    agg_input.clone(),
+                                    &state.my_keypair,
+                                )
                                 .expect("will be able to certify agg_input we created");
-
-                            let mut certifier = certpedpop::Certifier::new(
-                                cert_scheme,
-                                agg_input.clone(),
-                                &state.coordinator_public_keys,
-                            );
-
+                            let mut certifier = certpedpop::Certifier::new(cert_scheme, verified);
                             certifier
                                 .receive_certificate(state.my_keypair.public_key(), sig)
                                 .expect("will be able to verify our own certificate");
 
                             outgoing.push(CoordinatorSend::ToDevice {
-                                destinations: state.device_to_share_index.keys().cloned().collect(),
+                                destinations: state.devices_in_order.iter().copied().collect(),
                                 message: Keygen::CertifyPlease {
                                     keygen_id,
                                     agg_input,
@@ -695,7 +691,7 @@ impl FrostCoordinator {
                             entry.insert(KeyGenState::WaitingForCertificates(
                                 KeyGenWaitingForCertificates {
                                     keygen_id: state.keygen_id,
-                                    device_to_share_index: state.device_to_share_index,
+                                    devices_in_order: state.devices_in_order,
                                     pending_key_name: state.pending_key_name,
                                     purpose: state.purpose,
                                     certifier,
@@ -748,7 +744,7 @@ impl FrostCoordinator {
                                 .collect();
 
                             outgoing.push(CoordinatorSend::ToDevice {
-                                destinations: state.device_to_share_index.keys().cloned().collect(),
+                                destinations: state.devices_in_order.iter().copied().collect(),
                                 message: Keygen::Check {
                                     keygen_id,
                                     certificate,
@@ -765,7 +761,7 @@ impl FrostCoordinator {
                             entry.insert(
                                 KeyGenState::WaitingForAcks(KeyGenWaitingForAcks {
                                     certified_keygen,
-                                    device_to_share_index: state.device_to_share_index,
+                                    devices_in_order: state.devices_in_order,
                                     acks: Default::default(),
                                     pending_key_name: state.pending_key_name,
                                     purpose: state.purpose,
@@ -801,7 +797,7 @@ impl FrostCoordinator {
                             ));
                         }
 
-                        if !state.device_to_share_index.contains_key(&from) {
+                        if !state.devices_in_order.contains(&from) {
                             entry.insert(KeyGenState::WaitingForAcks(state));
                             return Err(Error::coordinator_invalid_message(
                                 message_kind,
@@ -811,22 +807,37 @@ impl FrostCoordinator {
 
                         if state.acks.insert(from) {
                             let all_acks_received =
-                                state.acks.len() == state.device_to_share_index.len();
+                                state.acks.len() == state.devices_in_order.len();
                             if all_acks_received {
                                 // XXX: we don't keep around the certified keygen for anything,
                                 // although it would make sense for settings where the secret key for
                                 // the DeviceId is persisted -- this would allow them to recover their
                                 // secret share from the certified keygen.
-                                let root_shared_key = state
-                                    .certified_keygen
-                                    .agg_input()
-                                    .shared_key()
-                                    .non_zero()
-                                    .expect("can't be zero we we contributed to it");
+                                let verified_agg_input =
+                                    state.certified_keygen.verified_agg_input();
+                                let root_shared_key = verified_agg_input.shared_key();
+                                assert_eq!(
+                                    verified_agg_input.n_receivers(),
+                                    state.devices_in_order.len(),
+                                    "chilldkg receiver count must match devices_in_order"
+                                );
+                                let device_to_share_index: BTreeMap<DeviceId, ShareIndex> = state
+                                    .devices_in_order
+                                    .iter()
+                                    .zip(verified_agg_input.receiver_keys())
+                                    .map(|(device, (share_index, receiver_key))| {
+                                        assert_eq!(
+                                            device.pubkey(),
+                                            receiver_key,
+                                            "device order must match keygen receiver order"
+                                        );
+                                        (*device, share_index)
+                                    })
+                                    .collect();
 
                                 entry.insert(KeyGenState::NeedsFinalize(KeyGenNeedsFinalize {
                                     root_shared_key,
-                                    device_to_share_index: state.device_to_share_index,
+                                    device_to_share_index,
                                     pending_key_name: state.pending_key_name,
                                     purpose: state.purpose,
                                 }));
@@ -951,7 +962,6 @@ impl FrostCoordinator {
         rng: &mut impl rand_core::RngCore,
     ) -> Result<SendBeginKeygen, ActionError> {
         let BeginKeygen {
-            device_to_share_index,
             threshold,
             key_name,
             purpose,
@@ -969,35 +979,36 @@ impl FrostCoordinator {
         let coordinator_secret = Scalar::random(rng);
         let coordinator_keypair = KeyPair::new(coordinator_secret);
 
-        let n_devices = device_to_share_index.len();
+        let n_devices = devices_in_order.len();
 
         if n_devices < threshold as usize {
             panic!(
                 "caller needs to ensure that threshold < devices.len(). Tried {threshold}-of-{n_devices}",
             );
         }
-        let share_receivers_enckeys = device_to_share_index
-            .iter()
-            .map(|(device, share_index)| (ShareIndex::from(*share_index), device.pubkey()))
-            .collect::<BTreeMap<_, _>>();
+        let receiver_keys: Vec<Point> = devices_in_order.iter().map(|d| d.pubkey()).collect();
         let schnorr = schnorr_fun::new_with_deterministic_nonces::<Sha256>();
 
         let coordinator_public_keys = vec![coordinator_keypair.public_key()];
 
+        let n_receivers = receiver_keys.len() as u32;
         let mut input_aggregator = certpedpop::Coordinator::new(
             threshold.into(),
-            1 + n_devices as u32,
-            &share_receivers_enckeys,
+            coordinator_public_keys.len() as u32,
+            n_receivers,
         );
-        let (contributer, input) = certpedpop::Contributor::gen_keygen_input(
-            &schnorr,
-            threshold.into(),
-            &share_receivers_enckeys,
-            0,
-            rng,
-        );
+        let (contributer, input) =
+            certpedpop::Contributor::<certpedpop::AuxContributor>::gen_keygen_input(
+                &schnorr,
+                threshold.into(),
+                &coordinator_public_keys,
+                &receiver_keys,
+                0,
+                rng,
+            )
+            .map_err(|e| ActionError::StateInconsistent(format!("gen_keygen_input failed: {e}")))?;
         input_aggregator
-            .add_input(&schnorr, 0, input)
+            .add_input(&schnorr, certpedpop::Party::AuxContributor(0), input)
             .expect("we just generated the input");
 
         self.pending_keygens.insert(
@@ -1005,12 +1016,11 @@ impl FrostCoordinator {
             KeyGenState::WaitingForResponses(KeyGenWaitingForResponses {
                 keygen_id,
                 input_aggregator,
-                device_to_share_index: device_to_share_index.clone(),
+                devices_in_order: devices_in_order.clone(),
                 pending_key_name: key_name.clone(),
                 purpose,
                 contributer: Box::new(contributer),
                 my_keypair: coordinator_keypair,
-                coordinator_public_keys: coordinator_public_keys.clone(),
             }),
         );
 
@@ -1035,21 +1045,17 @@ impl FrostCoordinator {
     ) -> Result<SendFinalizeKeygen, ActionError> {
         match self.pending_keygens.remove(&keygen_id) {
             Some(KeyGenState::NeedsFinalize(finalize)) => {
-                let device_to_share_index_converted = finalize
-                    .device_to_share_index
-                    .iter()
-                    .map(|(device, share_index)| (*device, ShareIndex::from(*share_index)))
-                    .collect();
+                let devices = finalize.device_to_share_index.keys().copied().collect();
                 let access_structure_ref = self.mutate_new_key(
                     finalize.pending_key_name,
                     finalize.root_shared_key,
-                    device_to_share_index_converted,
+                    finalize.device_to_share_index,
                     encryption_key,
                     finalize.purpose,
                     rng,
                 );
                 Ok(SendFinalizeKeygen {
-                    devices: finalize.device_to_share_index.into_keys().collect(),
+                    devices,
                     access_structure_ref,
                     keygen_id,
                 })
@@ -1681,18 +1687,17 @@ impl SignSession {
 pub struct KeyGenWaitingForResponses {
     pub keygen_id: KeygenId,
     pub input_aggregator: certpedpop::Coordinator,
-    pub device_to_share_index: BTreeMap<DeviceId, core::num::NonZeroU32>,
+    pub devices_in_order: Vec<DeviceId>,
     pub pending_key_name: String,
     pub purpose: KeyPurpose,
-    pub contributer: Box<certpedpop::Contributor>,
+    pub contributer: Box<certpedpop::Contributor<certpedpop::AuxContributor>>,
     pub my_keypair: KeyPair,
-    pub coordinator_public_keys: Vec<Point>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyGenWaitingForCertificates {
     pub keygen_id: KeygenId,
-    pub device_to_share_index: BTreeMap<DeviceId, core::num::NonZeroU32>,
+    pub devices_in_order: Vec<DeviceId>,
     pub pending_key_name: String,
     pub purpose: KeyPurpose,
     pub certifier: certpedpop::Certifier<certpedpop::vrf_cert::VrfCertScheme<Sha256>>,
@@ -1702,7 +1707,7 @@ pub struct KeyGenWaitingForCertificates {
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyGenWaitingForAcks {
     pub certified_keygen: certpedpop::CertifiedKeygen<certpedpop::vrf_cert::CertVrfProof>,
-    pub device_to_share_index: BTreeMap<DeviceId, core::num::NonZeroU32>,
+    pub devices_in_order: Vec<DeviceId>,
     pub acks: BTreeSet<DeviceId>,
     pub pending_key_name: String,
     pub purpose: KeyPurpose,
@@ -1711,7 +1716,7 @@ pub struct KeyGenWaitingForAcks {
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyGenNeedsFinalize {
     pub root_shared_key: SharedKey,
-    pub device_to_share_index: BTreeMap<DeviceId, core::num::NonZeroU32>,
+    pub device_to_share_index: BTreeMap<DeviceId, ShareIndex>,
     pub pending_key_name: String,
     pub purpose: KeyPurpose,
 }

--- a/frostsnap_core/src/coordinator/keys.rs
+++ b/frostsnap_core/src/coordinator/keys.rs
@@ -3,16 +3,17 @@ use crate::tweak::Xpub;
 use crate::{
     device::KeyPurpose, AccessStructureKind, AccessStructureRef, DeviceId, KeyId, KeygenId, Kind,
 };
-use alloc::{collections::BTreeMap, collections::BTreeSet, string::String, vec::Vec};
+use alloc::{collections::BTreeSet, string::String, vec::Vec};
 use frostsnap_macros::Kind as KindDerive;
 use schnorr_fun::frost::{ShareIndex, SharedKey};
 
-/// API input for beginning a key generation (without coordinator_public_key)
+/// API input for beginning a key generation (without coordinator_public_key).
+///
+/// Each device's `ShareIndex` is its position in `devices_in_order` plus one.
 #[derive(Clone, Debug)]
 pub struct BeginKeygen {
     pub keygen_id: KeygenId,
     pub devices_in_order: Vec<DeviceId>,
-    pub device_to_share_index: BTreeMap<DeviceId, core::num::NonZeroU32>,
     pub threshold: u16,
     pub key_name: String,
     pub purpose: KeyPurpose,
@@ -26,20 +27,8 @@ impl BeginKeygen {
         purpose: KeyPurpose,
         keygen_id: KeygenId,
     ) -> Self {
-        let device_to_share_index: BTreeMap<_, _> = devices
-            .iter()
-            .enumerate()
-            .map(|(index, device_id)| {
-                (
-                    *device_id,
-                    core::num::NonZeroU32::new((index + 1) as u32).expect("we added one"),
-                )
-            })
-            .collect();
-
         Self {
             devices_in_order: devices,
-            device_to_share_index,
             threshold,
             key_name,
             purpose,
@@ -67,7 +56,7 @@ impl BeginKeygen {
     }
 
     pub fn devices(&self) -> BTreeSet<DeviceId> {
-        self.device_to_share_index.keys().cloned().collect()
+        self.devices_in_order.iter().copied().collect()
     }
 }
 

--- a/frostsnap_core/src/device.rs
+++ b/frostsnap_core/src/device.rs
@@ -15,7 +15,6 @@ use alloc::{
     string::String,
     vec::Vec,
 };
-use core::num::NonZeroU32;
 use schnorr_fun::frost::chilldkg::certpedpop::{self};
 use schnorr_fun::frost::{Fingerprint, PairedSecretShare, SecretShare, ShareIndex, SharedKey};
 
@@ -142,23 +141,18 @@ impl EncryptedSecretShare {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyGenPhase1 {
-    pub device_to_share_index: BTreeMap<DeviceId, NonZeroU32>,
-    pub input_state: certpedpop::Contributor,
+    pub input_state: certpedpop::Contributor<certpedpop::ShareReceiver>,
     pub threshold: u16,
     pub key_name: String,
     pub key_purpose: KeyPurpose,
-    coordinator_public_keys: Vec<Point>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyGenPhase2 {
     pub keygen_id: KeygenId,
-    pub device_to_share_index: BTreeMap<DeviceId, NonZeroU32>,
-    paired_secret_share: PairedSecretShare,
-    agg_input: certpedpop::AggKeygenInput,
+    share_receiver: certpedpop::SecretShareReceiver,
     key_name: String,
     key_purpose: KeyPurpose,
-    coordinator_public_keys: Vec<Point>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -167,7 +161,7 @@ pub struct KeyGenPhase3 {
     session_hash: SessionHash,
     key_name: String,
     key_purpose: KeyPurpose,
-    t_of_n: (u16, u16),
+    n_receivers: u16,
     shared_key: SharedKey,
     secret_share: PairedSecretShare,
 }
@@ -186,12 +180,6 @@ impl KeyGenPhase2 {
     pub fn key_name(&self) -> &str {
         self.key_name.as_str()
     }
-    pub fn t_of_n(&self) -> (u16, u16) {
-        (
-            self.agg_input.shared_key().threshold().try_into().unwrap(),
-            self.agg_input.encryption_keys().count().try_into().unwrap(),
-        )
-    }
 }
 
 impl KeyGenPhase3 {
@@ -199,7 +187,8 @@ impl KeyGenPhase3 {
         self.key_name.as_str()
     }
     pub fn t_of_n(&self) -> (u16, u16) {
-        self.t_of_n
+        let threshold = u16::try_from(self.shared_key.threshold()).expect("threshold fits in u16");
+        (threshold, self.n_receivers)
     }
     pub fn session_hash(&self) -> SessionHash {
         self.session_hash
@@ -382,50 +371,46 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
             }
             KeyGen(keygen_msg) => match keygen_msg {
                 self::Keygen::Begin(begin) => {
-                    let device_to_share_index = begin.device_to_share_index();
-                    if !device_to_share_index.contains_key(&self.device_id()) {
-                        return Ok(vec![]);
-                    }
+                    let my_slot = begin
+                        .devices
+                        .iter()
+                        .position(|d| d == &self.device_id())
+                        .ok_or_else(|| {
+                            Error::signer_invalid_message(
+                                &message,
+                                format!(
+                                    "my device id {} was not part of the keygen",
+                                    self.device_id()
+                                ),
+                            )
+                        })?;
                     let schnorr = schnorr_fun::new_with_deterministic_nonces::<Sha256>();
 
-                    let share_receivers_enckeys = device_to_share_index
-                        .iter()
-                        .map(|(device, share_index)| {
-                            (ShareIndex::from(*share_index), device.pubkey())
-                        })
-                        .collect::<BTreeMap<_, _>>();
-                    let my_index =
-                        device_to_share_index
-                            .get(&self.device_id())
-                            .ok_or_else(|| {
-                                Error::signer_invalid_message(
-                                    &message,
-                                    format!(
-                                        "my device id {} was not party of the keygen",
-                                        self.device_id()
-                                    ),
-                                )
-                            })?;
+                    let receiver_keys: Vec<Point> =
+                        begin.devices.iter().map(|d| d.pubkey()).collect();
 
-                    let n_coordinators = begin.coordinator_public_keys.len() as u32;
-                    let input_gen_index = u32::from(*my_index) - 1 + n_coordinators;
-
-                    let (input_state, keygen_input) = certpedpop::Contributor::gen_keygen_input(
-                        &schnorr,
-                        begin.threshold as u32,
-                        &share_receivers_enckeys,
-                        input_gen_index,
-                        rng,
-                    );
+                    let (input_state, keygen_input) =
+                        certpedpop::Contributor::<certpedpop::ShareReceiver>::gen_keygen_input(
+                            &schnorr,
+                            begin.threshold as u32,
+                            &begin.coordinator_public_keys,
+                            &receiver_keys,
+                            my_slot as u32,
+                            rng,
+                        )
+                        .map_err(|e| {
+                            Error::signer_invalid_message(
+                                &message,
+                                format!("invalid keygen begin: {e}"),
+                            )
+                        })?;
                     self.tmp_keygen_phase1.insert(
                         begin.keygen_id,
                         KeyGenPhase1 {
-                            device_to_share_index,
                             input_state,
                             threshold: begin.threshold,
                             key_name: begin.key_name.clone(),
                             key_purpose: begin.purpose,
-                            coordinator_public_keys: begin.coordinator_public_keys,
                         },
                     );
                     Ok(vec![DeviceSend::ToCoordinator(Box::new(
@@ -452,15 +437,21 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                         )
                     })?;
 
-                    let my_index = phase1
-                        .device_to_share_index
-                        .get(&self.device_id())
-                        .expect("already checked");
+                    let (share_receiver, vrf_cert) = phase1
+                        .input_state
+                        .verify_agg_input(&schnorr, &cert_scheme, agg_input, self.keypair())
+                        .map_err(|e| {
+                            Error::signer_invalid_message(
+                                &message,
+                                format!("Failed to verify and receive share: {e}"),
+                            )
+                        })?;
 
-                    //XXX: We check the fingerprint so that a (mildly) malicious
+                    // XXX: We check the fingerprint so that a (mildly) malicious
                     // coordinator cannot create key generations without the
                     // fingerprint.
-                    if agg_input
+                    if share_receiver
+                        .verified_agg_input()
                         .shared_key()
                         .check_fingerprint::<sha2::Sha256>(self.keygen_fingerprint)
                         .is_none()
@@ -471,36 +462,13 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                         ));
                     }
 
-                    let (paired_secret_share, vrf_cert) = phase1
-                        .input_state
-                        .verify_receive_share_and_certify(
-                            &schnorr,
-                            &cert_scheme,
-                            (*my_index).into(),
-                            self.keypair(),
-                            &agg_input,
-                        )
-                        .map_err(|e| {
-                            Error::signer_invalid_message(
-                                &message,
-                                format!("Failed to verify and receive share: {e}"),
-                            )
-                        })?;
-
-                    let paired_secret_share = paired_secret_share.non_zero().ok_or_else(|| {
-                        Error::signer_invalid_message(&message, "keygen produced a zero shared key")
-                    })?;
-
                     self.tmp_keygen_phase2.insert(
                         keygen_id,
                         KeyGenPhase2 {
                             keygen_id,
-                            device_to_share_index: phase1.device_to_share_index,
-                            paired_secret_share,
-                            agg_input,
+                            share_receiver,
                             key_name: phase1.key_name.clone(),
                             key_purpose: phase1.key_purpose,
-                            coordinator_public_keys: phase1.coordinator_public_keys,
                         },
                     );
                     Ok(vec![DeviceSend::ToCoordinator(Box::new(
@@ -521,48 +489,31 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                         )
                     })?;
 
-                    // Reconstruct the certifier with all contributor public keys
                     let cert_scheme = certpedpop::vrf_cert::VrfCertScheme::<Sha256>::new(
                         crate::message::keygen::VRF_CERT_SCHEME_ID,
                     );
 
-                    let mut certifier = certpedpop::Certifier::new(
-                        cert_scheme,
-                        phase2.agg_input.clone(),
-                        &phase2.coordinator_public_keys,
-                    );
-
-                    // Add all certificates to the certifier
-                    for (pubkey, cert) in certificate {
-                        certifier.receive_certificate(pubkey, cert).map_err(|e| {
+                    let (certified_keygen, secret_share) = phase2
+                        .share_receiver
+                        .finalize(&cert_scheme, certificate)
+                        .map_err(|e| {
                             Error::signer_invalid_message(
                                 &message,
-                                format!("Invalid certificate received: {e}"),
+                                format!("certification failed: {e}"),
                             )
                         })?;
-                    }
-
-                    // Verify we have all certificates and create the certified keygen
-                    let certified_keygen = certifier.finish().map_err(|e| {
-                        Error::signer_invalid_message(
-                            &message,
-                            format!("Missing certificates or verification failed: {e}"),
-                        )
-                    })?;
 
                     let session_hash = SessionHash::from_certified_keygen(&certified_keygen);
+                    let agg_input = certified_keygen.verified_agg_input();
 
                     let phase3 = KeyGenPhase3 {
                         keygen_id,
-                        t_of_n: phase2.t_of_n(),
+                        n_receivers: u16::try_from(agg_input.n_receivers())
+                            .expect("n_receivers fits in u16"),
                         key_name: phase2.key_name,
                         key_purpose: phase2.key_purpose,
-                        shared_key: certified_keygen
-                            .agg_input()
-                            .shared_key()
-                            .non_zero()
-                            .expect("we contributed to coefficient -- can't be zero"),
-                        secret_share: phase2.paired_secret_share,
+                        shared_key: agg_input.shared_key(),
+                        secret_share,
                         session_hash,
                     };
 

--- a/frostsnap_core/src/message/keygen.rs
+++ b/frostsnap_core/src/message/keygen.rs
@@ -49,22 +49,6 @@ impl From<Begin> for CoordinatorToDeviceMessage {
     }
 }
 
-impl Begin {
-    /// Generate the device to share index mapping based on the device order in the Vec
-    pub fn device_to_share_index(&self) -> BTreeMap<DeviceId, core::num::NonZeroU32> {
-        self.devices
-            .iter()
-            .enumerate()
-            .map(|(index, device_id)| {
-                (
-                    *device_id,
-                    core::num::NonZeroU32::new((index as u32) + 1).expect("we added one"),
-                )
-            })
-            .collect()
-    }
-}
-
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, Kind)]
 pub enum DeviceKeygen {
     Response(super::KeyGenResponse),

--- a/frostsnap_core/src/tweak.rs
+++ b/frostsnap_core/src/tweak.rs
@@ -428,7 +428,7 @@ mod test {
         let cert_scheme = certpedpop::vrf_cert::VrfCertScheme::<sha2::Sha256>::new("chilldkg-vrf");
         let output = certpedpop::simulate_keygen(
             &schnorr,
-            cert_scheme,
+            &cert_scheme,
             3,
             5,
             5,
@@ -440,12 +440,7 @@ mod test {
             &mut rand::thread_rng(),
         );
 
-        let frost_key = output
-            .certified_keygen
-            .agg_input()
-            .shared_key()
-            .non_zero()
-            .unwrap();
+        let frost_key = output.certified_keygen.verified_agg_input().shared_key();
         let root_xpub = Xpub::from_rootkey(frost_key);
         let secp = Secp256k1::verification_only();
         let xpub = bitcoin::bip32::Xpub {

--- a/frostsnap_core/tests/proptest.rs
+++ b/frostsnap_core/tests/proptest.rs
@@ -246,8 +246,8 @@ impl ReferenceStateMachine for RefState {
         for (&keygen_id, keygen) in &state.pending_keygens {
             let candidates = keygen
                 .do_keygen
-                .device_to_share_index
-                .keys()
+                .devices_in_order
+                .iter()
                 .filter(|device_id| !keygen.devices_confirmed.contains(device_id))
                 .cloned()
                 .collect::<Vec<_>>();
@@ -421,10 +421,7 @@ impl ReferenceStateMachine for RefState {
                 keygen_id,
             } => match state.pending_keygens.get(keygen_id) {
                 Some(keygen_state) => {
-                    keygen_state
-                        .do_keygen
-                        .device_to_share_index
-                        .contains_key(device_id)
+                    keygen_state.do_keygen.devices_in_order.contains(device_id)
                         && !keygen_state.devices_confirmed.contains(device_id)
                 }
                 None => false,
@@ -433,7 +430,7 @@ impl ReferenceStateMachine for RefState {
                 match state.pending_keygens.get(keygen_id) {
                     Some(keygen_state) => {
                         keygen_state.devices_confirmed.len()
-                            == keygen_state.do_keygen.device_to_share_index.len()
+                            == keygen_state.do_keygen.devices_in_order.len()
                     }
                     None => false,
                 }


### PR DESCRIPTION
## Summary

Tracks the chilldkg API breakage on the [security-review omnibus branch](https://github.com/LLFourn/secp256kfun/pull/247) of secp256kfun. Patches in that branch via \`[patch.crates-io]\` and updates the call sites:

- \`certpedpop::Contributor::gen_keygen_input\` now takes \`n_contributors\` (= coord count + device count). Updated both coordinator and device call sites.
- \`Certifier::new\` is fallible (rejects \`agg_input.n_contributors() != contributor-set size\`); coordinator side propagates with \`.expect\` since the count was just enforced by \`Coordinator::new\`.
- \`verify_receive_share_and_certify\` now returns \`(SecretShareReceiver, Sig)\` instead of \`(PairedSecretShare, Sig)\`. The receiver holds the share internally until \`finalize\` runs with the full cert map. \`KeyGenPhase2\` stores the receiver (drops the redundant \`paired_secret_share\` and \`agg_input\` fields); the \`Check\` handler calls \`receiver.finalize\` to release the share, replacing the previous in-line \`Certifier::new\` + \`receive_certificate\` + \`finish\` dance.
- \`KeyGenPhase2::t_of_n()\` is gone; the only caller now derives it from the \`CertifiedKeygen\` returned by \`finalize\`.

## Test plan

- [x] \`cargo test -p frostsnap_core\` passes against the patched secp256kfun branch
- [ ] Smoke-test on real hardware before merge