### PR TITLE
[app] Prompt for screen lock instead of crashing when Android Keystore is unbound

### DIFF
--- a/frostsnapp/android/app/src/main/kotlin/com/frostsnap/SecureKeyManager.kt
+++ b/frostsnapp/android/app/src/main/kotlin/com/frostsnap/SecureKeyManager.kt
@@ -5,6 +5,7 @@ import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.provider.Settings
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.security.keystore.UserNotAuthenticatedException
@@ -24,18 +25,20 @@ import javax.crypto.Mac
 
 class SecureKeyManager : FlutterPlugin, MethodCallHandler, ActivityAware, PluginRegistry.ActivityResultListener {
     private lateinit var channel: MethodChannel
+    private lateinit var appContext: Context
     private var activity: Activity? = null
     private var pendingResult: Result? = null
     private val TAG = "SecureKeyManager"
-    
+
     companion object {
         private const val CHANNEL = "com.frostsnap/secure_key"
         private const val KEY_ALIAS = "frostsnap-app-encryption"
         private const val ANDROID_KEYSTORE = "AndroidKeyStore"
         private const val REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS = 1
     }
-    
+
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        appContext = flutterPluginBinding.applicationContext
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, CHANNEL)
         channel.setMethodCallHandler(this)
     }
@@ -50,6 +53,7 @@ class SecureKeyManager : FlutterPlugin, MethodCallHandler, ActivityAware, Plugin
             "requiresAuthentication" -> requiresAuthentication(result)
             "clearKey" -> clearKey(result)
             "deleteKey" -> deleteKey(result)
+            "openSecuritySettings" -> openSecuritySettings(result)
             else -> result.notImplemented()
         }
     }
@@ -74,9 +78,20 @@ class SecureKeyManager : FlutterPlugin, MethodCallHandler, ActivityAware, Plugin
     
     private fun getOrCreateKey(result: Result) {
         try {
+            // Fail fast if there's no device lock screen. KeyGenParameterSpec
+            // with setUserAuthenticationRequired(true) cannot bind a key without
+            // device credentials, and the resulting low-level exception is opaque,
+            // so we surface a typed error the UI can act on. Use the application
+            // context so this works even when no Activity is attached yet.
+            val keyguardManager = appContext.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+            if (!keyguardManager.isDeviceSecure) {
+                result.error("NO_LOCK_SCREEN", "Device does not have a secure lock screen", null)
+                return
+            }
+
             val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
             keyStore.load(null)
-            
+
             // Create key if it doesn't exist
             if (!keyStore.containsAlias(KEY_ALIAS)) {
                 createKey()
@@ -148,6 +163,20 @@ class SecureKeyManager : FlutterPlugin, MethodCallHandler, ActivityAware, Plugin
         Log.i(TAG, "Key created successfully with TEE backing")
     }
     
+    private fun openSecuritySettings(result: Result) {
+        val activity = activity ?: run {
+            result.error("NO_ACTIVITY", "Activity not available", null)
+            return
+        }
+        try {
+            activity.startActivity(Intent(Settings.ACTION_SECURITY_SETTINGS))
+            result.success(null)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to open security settings", e)
+            result.error("SETTINGS_ERROR", "Failed to open security settings: ${e.message}", null)
+        }
+    }
+
     private fun launchLockScreen(result: Result) {
         val activity = activity ?: run {
             result.error("NO_ACTIVITY", "Activity not available for authentication", null)

--- a/frostsnapp/lib/main.dart
+++ b/frostsnapp/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/serialport.dart';
+import 'package:frostsnap/snackbar.dart';
 import 'package:frostsnap/settings.dart';
 import 'package:frostsnap/stream_ext.dart';
 import 'package:frostsnap/theme.dart';
@@ -92,12 +93,34 @@ Future<void> main() async {
       for (var change in update.changes) {
         if (change.kind == DeviceListChangeKind.recoveryMode &&
             change.device.recoveryMode) {
-          SecureKeyProvider.getEncryptionKey().then((encryptionKey) {
+          final deviceId = change.device.id;
+          () async {
+            final SymmetricKey encryptionKey;
+            try {
+              encryptionKey = await SecureKeyProvider.getEncryptionKey();
+            } on PlatformException catch (e) {
+              final expected = e.code == 'NO_LOCK_SCREEN';
+              log(
+                level: expected ? LogLevel.info : LogLevel.error,
+                message:
+                    "skipping exitRecoveryMode for $deviceId: ${e.code} (${e.message})",
+              );
+              final ctx = rootNavKey.currentContext;
+              if (ctx != null) {
+                showErrorSnackbar(
+                  ctx,
+                  expected
+                      ? "Couldn't take device out of recovery mode: screen lock required."
+                      : "Couldn't take device out of recovery mode: ${e.message ?? e.code}",
+                );
+              }
+              return;
+            }
             coord.exitRecoveryMode(
-              deviceId: change.device.id,
+              deviceId: deviceId,
               encryptionKey: encryptionKey,
             );
-          });
+          }();
         }
       }
 

--- a/frostsnapp/lib/secure_key_provider.dart
+++ b/frostsnapp/lib/secure_key_provider.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
 import 'dart:io';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:frostsnap/global.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/lib.dart';
 
@@ -17,6 +20,9 @@ abstract class SecureKeyProvider {
   /// Delete the key from storage
   Future<void> deleteKey();
 
+  /// Open the OS settings page where the user can configure a screen lock.
+  Future<void> openSecuritySettings();
+
   /// Factory method to create the appropriate provider for the platform
   static SecureKeyProvider create() {
     if (Platform.isAndroid) {
@@ -33,9 +39,101 @@ abstract class SecureKeyProvider {
     return _instance!;
   }
 
-  /// Convenience method to get encryption key from global instance
+  /// Convenience method to get encryption key from global instance.
+  ///
+  /// On Android, if there's no device lock screen the Keystore can't bind a
+  /// user-auth-required key, so we surface a global blocking dialog asking the
+  /// user to set one up. The call is retried after they signal they're ready,
+  /// and rethrows the original PlatformException if they cancel.
   static Future<SymmetricKey> getEncryptionKey() async {
-    return await instance.getOrCreateKey();
+    while (true) {
+      try {
+        return await instance.getOrCreateKey();
+      } on PlatformException catch (e) {
+        if (e.code != _noLockScreenCode) rethrow;
+        final retry = await _ensureLockScreenDialog();
+        if (!retry) rethrow;
+      }
+    }
+  }
+
+  static const _noLockScreenCode = 'NO_LOCK_SCREEN';
+
+  static Future<bool>? _pendingDialog;
+
+  /// Concurrent callers share a single dialog future and all retry on the same
+  /// user gesture. The nav context may briefly be null at app startup before
+  /// MaterialApp mounts, so we wait for it instead of failing silently —
+  /// otherwise the recovery-mode listener that fires before runApp would
+  /// suppress the dialog entirely.
+  static Future<bool> _ensureLockScreenDialog() {
+    final existing = _pendingDialog;
+    if (existing != null) return existing;
+    final future = _showLockScreenDialog();
+    _pendingDialog = future;
+    future.whenComplete(() => _pendingDialog = null);
+    return future;
+  }
+
+  static Future<bool> _showLockScreenDialog() async {
+    BuildContext? ctx = rootNavKey.currentContext;
+    for (int i = 0; i < 100 && ctx == null; i++) {
+      await Future.delayed(const Duration(milliseconds: 50));
+      ctx = rootNavKey.currentContext;
+    }
+    if (ctx == null) {
+      throw StateError(
+        'SecureKeyProvider: no navigator context available to show '
+        'NO_LOCK_SCREEN dialog after 5s',
+      );
+    }
+    final result = await showDialog<bool>(
+      context: ctx,
+      barrierDismissible: false,
+      builder: (_) => const _NoLockScreenDialog(),
+    );
+    return result ?? false;
+  }
+}
+
+class _NoLockScreenDialog extends StatelessWidget {
+  const _NoLockScreenDialog();
+
+  Future<void> _openSettings() async {
+    try {
+      await SecureKeyProvider.instance.openSecuritySettings();
+    } catch (e) {
+      final messenger = rootScaffoldMessengerKey.currentState;
+      messenger?.showSnackBar(
+        SnackBar(content: Text('Could not open security settings: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Screen Lock Required'),
+      content: const Text(
+        'Frostsnap protects sensitive data on this phone using your screen '
+        'lock (PIN, password, pattern, or biometrics). Please set up a screen '
+        'lock in your phone\'s security settings to continue.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Try again'),
+        ),
+        FilledButton(
+          onPressed: _openSettings,
+          child: const Text('Open Settings'),
+        ),
+      ],
+    );
   }
 }
 
@@ -66,6 +164,11 @@ class AndroidSecureKeyProvider extends SecureKeyProvider {
   @override
   Future<void> deleteKey() async {
     await _channel.invokeMethod('deleteKey');
+  }
+
+  @override
+  Future<void> openSecuritySettings() async {
+    await _channel.invokeMethod('openSecuritySettings');
   }
 }
 
@@ -127,6 +230,11 @@ class DesktopSecureKeyProvider extends SecureKeyProvider {
 
   @override
   Future<void> deleteKey() async {
+    // No-op for desktop
+  }
+
+  @override
+  Future<void> openSecuritySettings() async {
     // No-op for desktop
   }
 }


### PR DESCRIPTION
## Summary
- Android Keystore key is created with `setUserAuthenticationRequired(true)`. On phones without a screen lock the key can't be created, and the resulting opaque `PlatformException` bubbles unhandled out of every signing / backup / recovery flow — the app effectively breaks for that user.
- Detect the no-lock-screen case proactively in `SecureKeyManager.kt` and surface a typed `NO_LOCK_SCREEN` error.
- `SecureKeyProvider.getEncryptionKey()` catches it once globally and shows a blocking dialog (Cancel / Try again / Open Settings) that retries on the user's gesture. Open Settings deep-links to `Settings.ACTION_SECURITY_SETTINGS`.
- Recovery-mode listener in `main.dart` narrows its catch by error code, logs unexpected codes at error level, and surfaces a snackbar so a user-cancelled prompt doesn't fail silently.

## Test plan
- [x] Install on an Android device **without** a screen lock; trigger any flow that calls `getEncryptionKey()` (e.g. signing, backup) and confirm the "Screen Lock Required" dialog appears.
- [x] Tap **Open Settings** — confirms it deep-links to the Security settings page; dialog stays open.
- [x] Set a PIN, return to app, tap **Try again** — flow completes.
- [x] Tap **Cancel** — confirms a snackbar appears (recovery-mode path) or the call site's existing error handling fires (other paths) instead of an unhandled exception.
- [x] Plug in a Frostsnap recovery-mode device at app launch with no PIN set — dialog still appears (not silently swallowed pre-`runApp`).
- [x] Install on an Android device **with** a screen lock — happy path still works, no dialog.