### PR TITLE
[device] Raise magic-bytes timeout threshold to absorb coord poll lag

### DIFF
--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -49,6 +49,12 @@ type EspSerial<'a, D> = SerialInterface<'a, TimgTimer<Timer0<TIMG0>, Blocking>, 
 type EspMutationLog<'a> = MutationLog<'a, esp_storage::FlashStorage>;
 type EspSigner<'a> = FrostSigner<NonceAbSlot<'a, esp_storage::FlashStorage>>;
 
+/// Max consecutive magic-bytes frames tolerated after we've replied to the
+/// coord but before it ack's. Absorbs the coord's `awaiting_magic` retry loop,
+/// which may queue several frames before reading our reply (in-flight noise).
+/// At the 100 ms coord cadence this is ~1 s before we give up and re-handshake.
+const MAGIC_BYTES_RESET_THRESHOLD: u32 = 9;
+
 struct DeviceLoop<'a> {
     // Borrowed from Resources
     rng: &'a mut ChaCha20Rng,
@@ -444,13 +450,12 @@ impl<'a> DeviceLoop<'a> {
                 if last_message_was_magic_bytes {
                     if is_upstream_established {
                         self.soft_reset = true;
-                    } else if self.magic_bytes_timeout_counter > 2 {
+                    } else if self.magic_bytes_timeout_counter > MAGIC_BYTES_RESET_THRESHOLD {
                         // Coord is still in `awaiting_magic` long after we
                         // replied — it didn't see our Announce. Reset so we
-                        // re-handshake on the next magic bytes. Threshold has
-                        // a small margin because the coord may have queued a
-                        // few magic-bytes frames during its initial retry loop
-                        // before reading our reply (in-flight noise).
+                        // re-handshake on the next magic bytes. See
+                        // `MAGIC_BYTES_RESET_THRESHOLD` for the in-flight-noise
+                        // margin rationale.
                         self.upstream_connection
                             .set_state(UpstreamConnectionState::PowerOn, self.ui);
                         self.magic_bytes_timeout_counter = 0;


### PR DESCRIPTION
## Summary

- Lift the in-flight magic-bytes tolerance in `device/src/esp32_run.rs` into a named constant `MAGIC_BYTES_RESET_THRESHOLD` and bump from `> 2` to `> 9` (~1 s of headroom at the coord's 100 ms cadence).

## Why

The coord's poll loop in `frostsnapp/rust/src/coordinator.rs:141` sleeps 100 ms between iterations and the `awaiting_magic` branch in `frostsnap_coordinator/src/usb_serial_manager.rs:248-284` writes a magic-bytes frame whenever its read came back empty. If the device's first reply lands in the kernel TTY buffer between two coord polls, the coord doesn't see it for ~100 ms and queues another magic-bytes frame. In a real session this was observed to stack up to 5 frames over ~500 ms.

Each frame arrives at the device in its own (very fast) poll cycle and increments `magic_bytes_timeout_counter` by 1, so the previous threshold of `> 2` trips trivially. That kicks the device back to `PowerOn`, where it re-handshakes and emits a duplicate `Announce` — which then arrives at the coord *after* the coord has already registered the device and started driving its next UI protocol (e.g. `DisplayBackupProtocol`), leaving the user with a device that appears to ignore the host.

The change is a one-side adjustment of the existing margin the comment at this site already acknowledged ("Threshold has a small margin because the coord may have queued a few magic-bytes frames during its initial retry loop"). It still detects a genuinely stalled coord — just not on the first burst.

## Test plan

- [ ] `cargo check` / `cargo clippy --release -- -D warnings` clean in `device/` (verified locally).
- [ ] Flash; reproduce the slow-boot scenario (erase then immediately drive a `DisplayBackup`); confirm coord logs show only one `Announced!` / `Registered device` even when it wrote ≥3 magic-bytes frames before reading.
- [ ] Walk the rest of the test checklist — keygen, send, receive, restore — to confirm no regression on normal flows.
- [ ] Negative test: relaunch the coord app while a device is in `EstablishedAndCoordAck`; device should still soft-reset on the first incoming magic-bytes frame (unchanged behavior; this branch only touches the pre-ack path).