### PR TITLE
[app] Evict cached wallet streams on delete

### DIFF
--- a/frostsnapp/lib/contexts.dart
+++ b/frostsnapp/lib/contexts.dart
@@ -70,6 +70,12 @@ class SuperWalletContext extends InheritedWidget {
     return stream;
   }
 
+  void evictWallet(KeyId keyId) {
+    _txStreams.remove(keyId);
+    _signingSessionSignals.remove(keyId);
+    _backupStreams.remove(keyId);
+  }
+
   (Wallet, Stream<TxState>)? txStateStream(KeyId keyId) {
     final frostKey = coord.getFrostKey(keyId: keyId);
     if (frostKey == null) {

--- a/frostsnapp/lib/settings.dart
+++ b/frostsnapp/lib/settings.dart
@@ -922,7 +922,9 @@ class DeleteWalletPage extends StatelessWidget {
                             "Hold to Delete",
                           ),
                           onComplete: () async {
+                            final superCtx = SuperWalletContext.of(context);
                             await coord.deleteKey(keyId: keyId);
+                            superCtx?.evictWallet(keyId);
                             Navigator.popUntil(context, (r) => r.isFirst);
                             if (context.mounted) {
                               showDialog(


### PR DESCRIPTION
## Summary

`SuperWalletContext` (`frostsnapp/lib/contexts.dart:46-48`) lazily caches per-`KeyId` `BehaviorSubject`s for three things:

- `_txStreams` — wallet tx state (drives balance display & tx list)
- `_signingSessionSignals`
- `_backupStreams`

Nothing ever evicts these entries. When the user deletes a wallet (`coord.deleteKey`) the Rust→Dart source stream gets torn down but the Dart-side `BehaviorSubject` stays in the map. If a wallet is later restored under the same `KeyId` in the same session, `txStateStream(keyId)` cache-hits and hands the UI the dead subject — which never emits the new wallet's tx state. Result: balance shows 0 (and tx list is empty / signing signals quietly miss) until the app is fully restarted.

We're fairly sure this is also behind several "this only sometimes happens" UI-staleness reports — anywhere a destructive flow tears down a wallet without invalidating its cached subjects, the same hazard applies. The pattern is the type of bug that recovers on app relaunch and resists targeted reproduction, which matches what we've been chasing.

## Fix

Add `SuperWalletContext.evictWallet(KeyId)` which clears the three map entries, and call it from the delete callback in `settings.dart` immediately after `coord.deleteKey` returns. The `SuperWalletContext` reference is captured before the await so the call doesn't depend on `context.mounted` post-await.

This is the minimal correctness fix. A broader pass to invalidate reactively whenever the Rust side reports a wallet removal (rather than only at the explicit settings-page delete callback) would be more bulletproof but is out of scope for this PR.

## Test plan

- [ ] Create a wallet, receive a small amount on one of its addresses so its balance is non-zero.
- [ ] Delete the wallet from settings.
- [ ] Restore the same wallet (same `KeyId`). Confirm balance shows the on-chain amount within the normal sync window, not 0.
- [ ] Repeat the delete/restore cycle a second time without restarting the app; confirm the same.
- [ ] Sanity: existing single-create flow (no prior delete) still works.