### PR TITLE
[app,coord] Persist device name at keygen/restoration commit boundary

### DIFF
--- a/frostsnap_coordinator/src/keygen.rs
+++ b/frostsnap_coordinator/src/keygen.rs
@@ -75,6 +75,10 @@ impl KeyGen {
     pub fn keygen_id(&self) -> KeygenId {
         self.state.keygen_id
     }
+
+    pub fn devices(&self) -> &[DeviceId] {
+        &self.state.devices
+    }
 }
 
 impl UiProtocol for KeyGen {

--- a/frostsnapp/lib/device_setup.dart
+++ b/frostsnapp/lib/device_setup.dart
@@ -34,7 +34,7 @@ class DeviceNameFieldState extends State<DeviceNameField> {
     if (name != null) {
       _controller.text = name;
     }
-    coord.updateNamePreview(id: widget.id, name: _controller.text);
+    coord.updateNamePreview(id: widget.id, name: _controller.text.trim());
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       widget.onCanSubmitChanged?.call(canSubmit);
@@ -84,8 +84,10 @@ class DeviceNameFieldState extends State<DeviceNameField> {
             ),
             inputFormatters: [nameInputFormatter],
             onSubmitted: (_) => _handleSubmitted(context),
-            onChanged: (value) async =>
-                await coord.updateNamePreview(id: widget.id, name: value),
+            onChanged: (value) async => await coord.updateNamePreview(
+              id: widget.id,
+              name: value.trim(),
+            ),
           ),
         ],
       ),

--- a/frostsnapp/lib/restoration/recovery_flow.dart
+++ b/frostsnapp/lib/restoration/recovery_flow.dart
@@ -320,6 +320,7 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
                     accessStructureRef: accessStructureRef,
                     phase: backupPhase,
                     encryptionKey: encryptionKey,
+                    deviceName: deviceName,
                   );
                   if (mounted) {
                     Navigator.pop(context);
@@ -355,6 +356,7 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
                   await coord.tellDeviceToSavePhysicalBackup(
                     phase: backupPhase,
                     restorationId: restorationId,
+                    deviceName: deviceName,
                   );
                   setState(() {
                     recoveryContext = (recoveryContext as NewRestorationContext)
@@ -384,6 +386,7 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
                   await coord.tellDeviceToSavePhysicalBackup(
                     phase: backupPhase,
                     restorationId: restorationId,
+                    deviceName: deviceName,
                   );
                   setState(() {
                     flowState.stage = RecoveryFlowStage.physicalBackupSuccess(

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -493,11 +493,11 @@ class WalletCreateController extends ChangeNotifier {
   };
 
   void setDeviceName(DeviceId id, String name) async {
-    final trimmedName = name.trim();
-    if (trimmedName.isNotEmpty) {
-      _form.deviceNames[id] = trimmedName;
+    final trimmed = name.trim();
+    if (trimmed.isNotEmpty) {
+      _form.deviceNames[id] = trimmed;
       notifyListeners();
-      await coord.updateNamePreview(id: id, name: trimmedName);
+      await coord.updateNamePreview(id: id, name: trimmed);
     } else {
       _form.deviceNames.remove(id);
       notifyListeners();
@@ -828,9 +828,6 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
       device.id,
       () => TextEditingController(text: currentName),
     );
-    if (textController.text != currentName) {
-      textController.text = currentName;
-    }
     return TextField(
       controller: textController,
       style: monospaceTextStyle,
@@ -992,9 +989,18 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
 
           try {
             final encryptionKey = await SecureKeyProvider.getEncryptionKey();
+            final deviceNames = [
+              for (final id in state.devices)
+                if (_controller.form.deviceNames[id] != null)
+                  DeviceNameCommit(
+                    id: id,
+                    name: _controller.form.deviceNames[id]!,
+                  ),
+            ];
             final asRef = await coord.finalizeKeygen(
               keygenId: state.keygenId,
               encryptionKey: encryptionKey,
+              deviceNames: deviceNames,
             );
             _controller._asRef = asRef;
             if (context.mounted) Navigator.pop(context, asRef);

--- a/frostsnapp/rust/src/api/keygen.rs
+++ b/frostsnapp/rust/src/api/keygen.rs
@@ -21,6 +21,15 @@ pub struct _KeyGenState {
     pub keygen_id: KeygenId,
 }
 
+/// A device-name commit handed to `finalize_keygen` so the coordinator can persist the
+/// user-typed name locally at the same moment it sends the keygen-finalize message to the
+/// device. Names for non-participants of the current keygen are silently dropped on the
+/// Rust side; empty / whitespace-only / over-long names are validated per entry and skipped.
+pub struct DeviceNameCommit {
+    pub id: DeviceId,
+    pub name: String,
+}
+
 impl super::coordinator::Coordinator {
     pub fn generate_new_key(
         &self,
@@ -43,7 +52,9 @@ impl super::coordinator::Coordinator {
         &self,
         keygen_id: KeygenId,
         encryption_key: SymmetricKey,
+        device_names: Vec<DeviceNameCommit>,
     ) -> Result<AccessStructureRef> {
-        self.0.finalize_keygen(keygen_id, encryption_key)
+        self.0
+            .finalize_keygen(keygen_id, encryption_key, device_names)
     }
 }

--- a/frostsnapp/rust/src/api/recovery.rs
+++ b/frostsnapp/rust/src/api/recovery.rs
@@ -209,9 +209,10 @@ impl super::coordinator::Coordinator {
         &self,
         phase: &PhysicalBackupPhase,
         restoration_id: RestorationId,
+        device_name: String,
     ) {
         self.0
-            .tell_device_to_save_physical_backup(*phase, restoration_id)
+            .tell_device_to_save_physical_backup(*phase, restoration_id, device_name)
     }
 
     pub fn tell_device_to_consolidate_physical_backup(
@@ -219,11 +220,13 @@ impl super::coordinator::Coordinator {
         access_structure_ref: AccessStructureRef,
         phase: &PhysicalBackupPhase,
         encryption_key: SymmetricKey,
+        device_name: String,
     ) -> anyhow::Result<()> {
         self.0.tell_device_to_consolidate_physical_backup(
             access_structure_ref,
             *phase,
             encryption_key,
+            device_name,
         )?;
         Ok(())
     }

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -647,10 +647,33 @@ impl FfiCoordinator {
         self.device_names.lock().unwrap().get(id)
     }
 
+    /// Persist a user-typed device name into the coord's local `device_names` store without
+    /// waiting for the device's `SetName` round-trip. Stores verbatim — name hygiene (trim,
+    /// charset, length) is the Dart input layer's responsibility; the keygen and recovery
+    /// `TextField`s enforce it via `maxLength: DeviceName.maxLength()` and `nameInputFormatter`,
+    /// and the Dart-side commit paths trim before submitting. The device's eventual `SetName`
+    /// remains the durable source of truth.
+    fn commit_device_name_locally(&self, db: &mut rusqlite::Connection, id: DeviceId, name: &str) {
+        let mut device_names = self.device_names.lock().unwrap();
+        if let Err(e) = device_names.staged_mutate(db, |names| {
+            names.insert(id, name.to_string());
+            Ok(())
+        }) {
+            event!(
+                Level::ERROR,
+                id = id.to_string(),
+                name = name,
+                error = e.to_string(),
+                "failed to persist device name locally"
+            );
+        }
+    }
+
     pub fn finalize_keygen(
         &self,
         keygen_id: KeygenId,
         symmetric_key: SymmetricKey,
+        device_names: Vec<crate::api::keygen::DeviceNameCommit>,
     ) -> Result<AccessStructureRef> {
         let access_structure_ref = {
             let mut coordinator = self.coordinator.lock().unwrap();
@@ -659,6 +682,8 @@ impl FfiCoordinator {
             let keygen = ui_stack
                 .get_mut::<frostsnap_coordinator::keygen::KeyGen>()
                 .ok_or(anyhow!("somehow UI was not in KeyGen state"))?;
+
+            let participant_set: BTreeSet<DeviceId> = keygen.devices().iter().copied().collect();
 
             let finalized_keygen = coordinator.staged_mutate(&mut db, |coordinator| {
                 Ok(coordinator.finalize_keygen(
@@ -670,6 +695,19 @@ impl FfiCoordinator {
             let access_structure_ref = finalized_keygen.access_structure_ref;
 
             self.usb_sender.send_from_core(finalized_keygen);
+
+            for commit in device_names {
+                if !participant_set.contains(&commit.id) {
+                    event!(
+                        Level::DEBUG,
+                        id = commit.id.to_string(),
+                        "ignoring device name commit for non-participant"
+                    );
+                    continue;
+                }
+                self.commit_device_name_locally(&mut db, commit.id, &commit.name);
+            }
+
             keygen.keygen_finalized(access_structure_ref);
             access_structure_ref
         };
@@ -1100,6 +1138,7 @@ impl FfiCoordinator {
         &self,
         phase: PhysicalBackupPhase,
         restoration_id: RestorationId,
+        device_name: String,
     ) {
         {
             let mut coord = self.coordinator.lock().unwrap();
@@ -1107,6 +1146,11 @@ impl FfiCoordinator {
                 .MUTATE_NO_PERSIST()
                 .tell_device_to_save_physical_backup(phase, restoration_id);
             self.usb_sender.send_from_core(messages);
+        }
+
+        {
+            let mut db = self.db.lock().unwrap();
+            self.commit_device_name_locally(&mut db, phase.from, &device_name);
         }
 
         // hook into to user messages to see when it is successfully saved
@@ -1143,6 +1187,7 @@ impl FfiCoordinator {
         access_structure_ref: AccessStructureRef,
         phase: PhysicalBackupPhase,
         encryption_key: SymmetricKey,
+        device_name: String,
     ) -> Result<()> {
         let msgs = {
             let mut coordinator = self.coordinator.lock().unwrap();
@@ -1156,6 +1201,11 @@ impl FfiCoordinator {
         };
 
         self.usb_sender.send_from_core(msgs);
+
+        {
+            let mut db = self.db.lock().unwrap();
+            self.commit_device_name_locally(&mut db, phase.from, &device_name);
+        }
 
         // hook into to user messages to see when it is successfully consolidated
         let success = self.block_for_to_user_message([phase.from], move |to_user| {


### PR DESCRIPTION
## The bug

Devices in a signer list can render as `<unknown>` even though the user named them — most visibly in the Send-tx review dialog. Bundled side fix: in the inline keygen name field, typing a space after a few characters silently dropped the space.

## Why it matters

The coord only persists a device's name when the device sends `SetName` upstream. That message is emitted from the device's commit handlers (`save_pending_device_name` at keygen finalize and at backup save/consolidate). If the cable is yanked in the in-flight window — common enough during test cycles — the coord never sees the name. Every UI surface that reads `coord.get_device_name(id)` then shows `<unknown>` until the device is replugged. Devices that don't come back stay `<unknown>` forever.

The SPC bug had the same shape on the input side: typing-time trim plus a rebuild-driven controller resync were fighting each other and the user's space keystroke lost.

## The fix

Persist the user-typed name on the coord side at the same Dart→Rust call that drives the device's commit — in `finalize_keygen` and the two `tell_device_to_*_physical_backup` wrappers — between the outbound message and the blocking wait. The eventual `SetName` is still received and processed; since both paths converge on the same string, the existing reactive handler short-circuits.

Names flow through verbatim. Dart trims at every Dart→Rust boundary (including the per-keystroke Preview); Rust trusts whatever it receives. Charset and length are enforced by the Dart `TextField`s (`maxLength` and `nameInputFormatter`). Keeping the trim on one side only avoids the "save 'Server ' on the device but 'Server' on the coord and then watch them fight" failure mode.

The SPC bug is fixed by deleting the rebuild force-sync of the keygen name field's controller — the per-keystroke trim was harmless on its own; the resync was the actual culprit.

## Test plan

- [ ] Keygen a 2-of-3 wallet, name each device, yank the cable right after pressing the keygen confirm. Send-tx dialog should show all three names without any replug.
- [ ] In the inline keygen name field, type "Server" then space then "R" — should appear as "Server R".
- [ ] Standard upgrade → keygen → send → receive → erase → restore loop ends with named signers from the start.