### PR TITLE
Pin Android build JDK to 17

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -26,7 +26,7 @@ runs:
       uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 18
+        java-version: 17
         cache: gradle
     - name: Install android
       uses: android-actions/setup-android@v3


### PR DESCRIPTION
GitHub-hosted runner apparently ships cmdline-tools whose Android Lint bootstrap fails on Java 18 (AndroidLintWorkAction class init). See https://github.com/frostsnap/frostsnap/actions/runs/26081273732/job/76686147999