### PR TITLE
[ci] Use a proper release signing config (stacked on #487)

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -40,12 +40,13 @@ runs:
         ndk-version: r25c
         link-to-sdk: true
         add-to-path: true
-    - name: Restore release signing keystore
-      if: env.ANDROID_KEYSTORE != ''
-      shell: bash
-      run: |
-        mkdir -p "$HOME/.android"
-        echo "$ANDROID_KEYSTORE" | base64 -d > "$HOME/.android/debug.keystore"
+    # Release signing is set up in .github/workflows/release.yml *before* this
+    # action runs. release.yml sets FROSTSNAP_RELEASE_BUILD=true and the four
+    # ANDROID_RELEASE_* env vars scoped to the step that invokes this action;
+    # gradle then errors loudly if any are missing and otherwise wires the
+    # release signing config. PR / test builds leave FROSTSNAP_RELEASE_BUILD
+    # unset and fall through to debug signing — intentional, so production
+    # credentials never live on a CI runner outside the release workflow.
     - name: Build App APK
       shell: bash
       run: just env=${{ inputs.env }} build apk --release --flavor direct

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,15 +34,38 @@ jobs:
     name: "Build Android"
     needs: ["verify-firmware"]
     runs-on: ubuntu-latest
-    env:
-      ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
     steps:
       - uses: actions/checkout@v4
+      # Decode the keystore secret to a file the build step can hand to gradle.
+      # Base64 secret is scoped to this step only — not needed in subsequent steps.
+      - name: Stage release keystore for gradle
+        env:
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE }}
+        shell: bash
+        run: |
+          if [ -z "${ANDROID_RELEASE_KEYSTORE_BASE64:-}" ]; then
+            echo "::error::ANDROID_RELEASE_KEYSTORE secret is empty or unset — refusing to build." >&2
+            exit 1
+          fi
+          keystore_path="$RUNNER_TEMP/release.keystore"
+          umask 077
+          # `printenv` rather than `echo "$VAR"` so the secret never appears on a
+          # shell command line, even under bash debug tracing.
+          printenv ANDROID_RELEASE_KEYSTORE_BASE64 | base64 -d > "$keystore_path"
+          echo "ANDROID_RELEASE_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
       - name: Download firmware from release
         run: |
           mkdir -p firmware
           gh release download ${{ env.TAG_NAME }} --pattern "firmware.bin" --dir firmware
       - uses: "./.github/actions/build-android"
+        env:
+          # FROSTSNAP_RELEASE_BUILD=true is the explicit "this build must be release-signed"
+          # switch — gradle fails loudly at configuration time if any of the four
+          # ANDROID_RELEASE_* env vars are missing or empty when this is set.
+          FROSTSNAP_RELEASE_BUILD: 'true'
+          ANDROID_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEYSTORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
         with:
           firmware_path: firmware/firmware.bin
           env: prod

--- a/frostsnapp/android/app/build.gradle
+++ b/frostsnapp/android/app/build.gradle
@@ -63,9 +63,50 @@ android {
         }
     }
 
+    // Release signing for the `direct` flavor is opt-in via FROSTSNAP_RELEASE_BUILD=true,
+    // which is set exclusively by .github/workflows/release.yml. When that switch is on,
+    // all four ANDROID_RELEASE_* env vars are REQUIRED and a missing one fails the build
+    // loudly at gradle configuration time. Without the switch (PR builds, test.yml,
+    // local dev), the `direct` flavor falls back to debug signing — so building locally
+    // doesn't require setting up any credentials.
+    //
+    // The keystore configured by these env vars is the project's permanent direct-APK
+    // signing identity. Rotating it breaks the upgrade path for every direct-APK user
+    // on Android — for a Bitcoin wallet that means forcing every user through a
+    // hardware-device wallet restore. Don't rotate without first shipping an in-app
+    // passphrase-encrypted export feature so users have a migration path off their
+    // current install.
+    def releaseSigningEnabled = System.getenv('FROSTSNAP_RELEASE_BUILD') == 'true'
+    if (releaseSigningEnabled) {
+        def missing = [
+            'ANDROID_RELEASE_KEYSTORE_PATH',
+            'ANDROID_RELEASE_KEYSTORE_PASSWORD',
+            'ANDROID_RELEASE_KEY_ALIAS',
+            'ANDROID_RELEASE_KEY_PASSWORD',
+        ].findAll { !System.getenv(it) }
+        if (!missing.isEmpty()) {
+            throw new GradleException(
+                "FROSTSNAP_RELEASE_BUILD=true but required env var(s) missing or empty: " +
+                missing.join(', ') + ". Release builds must set the keystore path, " +
+                "store password, key alias, and key password."
+            )
+        }
+    }
+
     signingConfigs {
+        // AGP's default debug keystore (~/.android/debug.keystore with hardcoded
+        // password "android"). Used for `debug` build types and as the local-dev
+        // fallback for the `direct` flavor's `release` build type.
         debug {
-            // Standard debug keystore - automatically available
+        }
+
+        release {
+            if (releaseSigningEnabled) {
+                storeFile file(System.getenv("ANDROID_RELEASE_KEYSTORE_PATH"))
+                storePassword System.getenv("ANDROID_RELEASE_KEYSTORE_PASSWORD")
+                keyAlias System.getenv("ANDROID_RELEASE_KEY_ALIAS")
+                keyPassword System.getenv("ANDROID_RELEASE_KEY_PASSWORD")
+            }
         }
     }
 
@@ -82,15 +123,16 @@ android {
 
     // Configure signing per flavor
     productFlavors {
-        // Default flavor for direct APK distribution
-        // Uses debug signing even in release mode for easy testing/distribution
+        // Default flavor for direct APK distribution.
+        // Uses the release signing config when FROSTSNAP_RELEASE_BUILD=true
+        // (release.yml only); otherwise falls back to debug signing so local dev
+        // builds and PR/test CI work with no setup.
         direct {
             dimension "distribution"
             isDefault = true
-            // Apply debug signing to release builds for this flavor
-            signingConfig = signingConfigs.debug
+            signingConfig = releaseSigningEnabled ? signingConfigs.release : signingConfigs.debug
         }
-        
+
         // Flavor for Google Play Store distribution
         // Must remain unsigned - Google signs with their own keys
         playstore {


### PR DESCRIPTION
Stacked on #487. Three tightening changes:

1. **Real release signing, not the AGP debug-config piggyback.** New `ANDROID_RELEASE_*` secrets (keystore, password, key alias, key password) feed a proper `release { }` signingConfig in `build.gradle`. The keystore can have a normal DN (`CN=Frostsnap`) instead of `CN=Android Debug` and a real password instead of the hardcoded `android`. Anything that inspects the cert (security scanners, F-Droid metadata, app-store audits) now sees what it's supposed to.

2. **Release signing logic lives only in `release.yml`.** Secrets are scoped step-by-step inside that one workflow; the shared `build-android` action and `test.yml` are signing-agnostic. If we ever want to move release signing off GitHub Infrastructure — manual offline signing, HSM, multi-party reproducible builds, whatever — the only file that has to change is `release.yml`. Nothing in gradle or the shared action would need to move.

3. **Explicit opt-in switch + fail-fast.** `release.yml` sets `FROSTSNAP_RELEASE_BUILD=true`; gradle throws a `GradleException` at configuration time if that switch is set but any of the four keystore env vars are missing. Catches the env-var-typo failure mode (someone renames a variable in CI but forgets gradle, or vice versa) instead of silently falling back to debug. PR / test / local builds are unchanged — switch unset, debug-signing fallback, no setup required.

## Migration

I checked the certs on every published release — v0.1.0, v0.1.1, v0.2.0 (and the currently-draft v0.3.0 APK) all have `C=US, O=Android, CN=Android Debug` as their DN, with four distinct fingerprints. So whatever keystore is currently sitting in the `ANDROID_KEYSTORE` secret from #487 is one of those, and reusing it would mean shipping v0.3.0 forever with `CN=Android Debug` on the cert.

Since pre-v0.3.0 users are uninstalling+reinstalling anyway, this is the moment to generate a fresh keystore with a proper DN. Recommendation: ECDSA on the P-256 curve (smaller signatures and faster verification than RSA, universally supported on Android 7+):

```sh
keytool -genkey -v \
    -keystore frostsnap-release.keystore \
    -alias frostsnap-release \
    -keyalg EC -keysize 256 \
    -validity 36500 \
    -dname "CN=Frostsnap, O=Frostsnap, C=AU"
```

Then base64 it, populate the four new repo secrets (`ANDROID_RELEASE_KEYSTORE`, `_PASSWORD`, `_KEY_ALIAS`, `_KEY_PASSWORD`), delete the now-unused `ANDROID_KEYSTORE` secret, and replace the draft v0.3.0 APK with one built under this setup before publishing. Keep the original `.keystore` file and its credentials in offline backup — losing them means another forced uninstall+reinstall for every direct-APK user, and we don't want to do this twice.