### PR TITLE
Refresh stat cache before BUILD_COMMIT dirty check

### DIFF
--- a/justfile
+++ b/justfile
@@ -134,6 +134,7 @@ sign-firmware INPUT="target/riscv32imc-unknown-none-elf/release/frontier.bin" OU
 get-build-commit:
     #!/bin/sh
     BUILD_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+    git update-index -q --refresh
     if [ "$BUILD_COMMIT" != "unknown" ] && ! git diff-index --quiet HEAD --; then
         BUILD_COMMIT="${BUILD_COMMIT}-modified"
     fi
@@ -142,6 +143,7 @@ get-build-commit:
 get-build-version:
     #!/bin/sh
     BUILD_VERSION=$(git describe --tags --always 2>/dev/null || echo "unknown")
+    git update-index -q --refresh
     if [ "$BUILD_VERSION" != "unknown" ] && ! git diff-index --quiet HEAD --; then
         BUILD_VERSION="${BUILD_VERSION}-modified"
     fi


### PR DESCRIPTION
Release APKs were getting tagged `<sha>-modified` even with no content changes. 

`get-build-commit` ran `git diff-index --quiet HEAD --`, which exits early on a stale stat cache without comparing content. 

Three CI tools rewrite tracked files in-place with identical content, leaving stat info stale:

- `flutter pub get`  → `pubspec.lock`
- `flutter_rust_bridge_codegen` → `lib/src/rust/.gitkeep`
- cargokit → `cargokit/run_build_tool.sh`

Add `git update-index -q --refresh` before the dirty check to clear stale stat entries.