### PR TITLE
Enforce cargokit lockfile

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -53,6 +53,6 @@ runs:
     - name: Build appbundle
       shell: bash
       run: just env=${{ inputs.env }} build appbundle --release --flavor playstore
-    - name: Verify cargokit lockfile not drifted during build
+    - name: Verify no checked-out files drifted during build
       shell: bash
-      run: git diff --exit-code frostsnapp/rust_builder/cargokit/build_tool/pubspec.lock
+      run: git diff --exit-code

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -53,3 +53,6 @@ runs:
     - name: Build appbundle
       shell: bash
       run: just env=${{ inputs.env }} build appbundle --release --flavor playstore
+    - name: Verify cargokit lockfile not drifted during build
+      shell: bash
+      run: git diff --exit-code frostsnapp/rust_builder/cargokit/build_tool/pubspec.lock

--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -27,3 +27,6 @@ runs:
     - name: Build App Linux
       shell: bash
       run: just env=${{ inputs.env }} build linux --release
+    - name: Verify cargokit lockfile not drifted during build
+      shell: bash
+      run: git diff --exit-code frostsnapp/rust_builder/cargokit/build_tool/pubspec.lock

--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -27,6 +27,6 @@ runs:
     - name: Build App Linux
       shell: bash
       run: just env=${{ inputs.env }} build linux --release
-    - name: Verify cargokit lockfile not drifted during build
+    - name: Verify no checked-out files drifted during build
       shell: bash
-      run: git diff --exit-code frostsnapp/rust_builder/cargokit/build_tool/pubspec.lock
+      run: git diff --exit-code

--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -31,6 +31,6 @@ runs:
     - name: Build macOS App
       shell: bash
       run: just env=${{ inputs.env }} build macos --release
-    - name: Verify cargokit lockfile not drifted during build
+    - name: Verify no checked-out files drifted during build
       shell: bash
-      run: git diff --exit-code frostsnapp/rust_builder/cargokit/build_tool/pubspec.lock
+      run: git diff --exit-code

--- a/.github/actions/build-macos/action.yml
+++ b/.github/actions/build-macos/action.yml
@@ -31,3 +31,6 @@ runs:
     - name: Build macOS App
       shell: bash
       run: just env=${{ inputs.env }} build macos --release
+    - name: Verify cargokit lockfile not drifted during build
+      shell: bash
+      run: git diff --exit-code frostsnapp/rust_builder/cargokit/build_tool/pubspec.lock

--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -23,6 +23,6 @@ runs:
     - name: Build App Windows
       shell: bash
       run: just env=${{ inputs.env }} build windows --release
-    - name: Verify cargokit lockfile not drifted during build
+    - name: Verify no checked-out files drifted during build
       shell: bash
-      run: git diff --exit-code frostsnapp/rust_builder/cargokit/build_tool/pubspec.lock
+      run: git diff --exit-code

--- a/.github/actions/build-windows/action.yml
+++ b/.github/actions/build-windows/action.yml
@@ -23,3 +23,6 @@ runs:
     - name: Build App Windows
       shell: bash
       run: just env=${{ inputs.env }} build windows --release
+    - name: Verify cargokit lockfile not drifted during build
+      shell: bash
+      run: git diff --exit-code frostsnapp/rust_builder/cargokit/build_tool/pubspec.lock

--- a/.github/actions/set-up-app-build/action.yml
+++ b/.github/actions/set-up-app-build/action.yml
@@ -20,6 +20,10 @@ runs:
         cache: true
     - uses: "./.github/actions/fetch-cargo-deps"
     - uses: "./.github/actions/fetch-dart-deps"
+    - name: Enforce cargokit lockfile
+      working-directory: frostsnapp/rust_builder/cargokit/build_tool
+      shell: bash
+      run: dart pub get --enforce-lockfile
     - uses: "./.github/actions/generate-frb"
     - uses: "./.github/actions/install-cargo-bins"
     - name: Place firmware at conventional path

--- a/frostsnapp/macos/Podfile.lock
+++ b/frostsnapp/macos/Podfile.lock
@@ -46,15 +46,15 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
 SPEC CHECKSUMS:
-  dynamic_color: 5fdff3953fb3457311091863f72914fc76ea3209
+  dynamic_color: cb7c2a300ee67ed3bd96c3e852df3af0300bf610
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
-  package_info_plus: 12f1c5c2cfe8727ca46cbd0b26677728972d9a5b
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  rust_lib_frostsnapp: 44264e0da37cc4d7537fc7320651cc474040abe1
-  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
-  wakelock_plus: 9d63063ffb7af1c215209769067c57103bde719d
+  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  rust_lib_frostsnapp: 2eb3a2a2e0b3a08adcb5ae769f67820f2e7c5512
+  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+  wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
 
 PODFILE CHECKSUM: 9ebaf0ce3d369aaa26a9ea0e159195ed94724cf3
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/frostsnapp/macos/Podfile.lock
+++ b/frostsnapp/macos/Podfile.lock
@@ -46,14 +46,14 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
 SPEC CHECKSUMS:
-  dynamic_color: cb7c2a300ee67ed3bd96c3e852df3af0300bf610
+  dynamic_color: 5fdff3953fb3457311091863f72914fc76ea3209
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
-  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  rust_lib_frostsnapp: 2eb3a2a2e0b3a08adcb5ae769f67820f2e7c5512
-  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
-  wakelock_plus: 917609be14d812ddd9e9528876538b2263aaa03b
+  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
+  package_info_plus: 12f1c5c2cfe8727ca46cbd0b26677728972d9a5b
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  rust_lib_frostsnapp: 44264e0da37cc4d7537fc7320651cc474040abe1
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
+  wakelock_plus: 9d63063ffb7af1c215209769067c57103bde719d
 
 PODFILE CHECKSUM: 9ebaf0ce3d369aaa26a9ea0e159195ed94724cf3
 


### PR DESCRIPTION
Cargokit's `pubspec.lock` was unenforced. Its ~50 transitive Dart deps run at build time.

- `set-up-app-build`: Run `dart pub get --enforce-lockfile` against the committed cargokit lockfile.
- Post-build: `git diff --exit-code` to catch anything that drifted during the build itself.

Same pattern as the existing `Cargo.lock not dirty` check in `test.yml`.