### PR TITLE
Bump app version to 0.3.0+9

### DIFF
--- a/frostsnapp/pubspec.yaml
+++ b/frostsnapp/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.0+8
+version: 0.3.0+9
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
Required for Play Store submission. versionCode `8` was used for v0.2.0, and has it to be unique, Google Play rejects duplicates.