### PR TITLE
Device naming improvements

### DIFF
--- a/frostsnapp/lib/device_setup.dart
+++ b/frostsnapp/lib/device_setup.dart
@@ -83,6 +83,7 @@ class DeviceNameFieldState extends State<DeviceNameField> {
               labelText: 'Device name',
             ),
             inputFormatters: [nameInputFormatter],
+            textCapitalization: TextCapitalization.sentences,
             onSubmitted: (_) => _handleSubmitted(context),
             onChanged: (value) async => await coord.updateNamePreview(
               id: widget.id,

--- a/frostsnapp/lib/restoration/enter_wallet_name_view.dart
+++ b/frostsnapp/lib/restoration/enter_wallet_name_view.dart
@@ -90,6 +90,7 @@ class _EnterWalletNameViewState extends State<EnterWalletNameView> {
               controller: _walletNameController,
               maxLength: keyNameMaxLength(),
               inputFormatters: [nameInputFormatter],
+              textCapitalization: TextCapitalization.words,
               autofocus: true,
               decoration: const InputDecoration(
                 labelText: 'Wallet Name',

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -816,6 +816,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
                 ),
                 maxLength: DeviceName.maxLength(),
                 inputFormatters: [nameInputFormatter],
+                textCapitalization: TextCapitalization.sentences,
                 initialValue: _controller.form.deviceNames[device.id],
                 onChanged: (name) => _controller.setDeviceName(device.id, name),
                 onFieldSubmitted: (_) => Navigator.pop(context),
@@ -844,6 +845,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
       style: monospaceTextStyle,
       maxLength: DeviceName.maxLength(),
       inputFormatters: [nameInputFormatter],
+      textCapitalization: TextCapitalization.sentences,
       decoration: InputDecoration(
         hintText: 'Enter device name',
         hintStyle: monospaceTextStyle.copyWith(color: cs.onSurfaceVariant),

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -561,6 +561,9 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
     for (final c in _nameControllers.values) {
       c.dispose();
     }
+    for (final n in _nameFocusNodes.values) {
+      n.dispose();
+    }
     _upgradeController.dispose();
     _controller.dispose();
     super.dispose();
@@ -618,10 +621,16 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
               upToDate: () => _deviceRow(
                 context: context,
                 title: _inlineNameField(context, device),
-                trailing: Icon(
-                  Icons.edit_rounded,
-                  color: cs.onSurfaceVariant,
-                  size: 20,
+                trailing: IconButton(
+                  icon: Icon(
+                    Icons.edit_rounded,
+                    color: cs.onSurfaceVariant,
+                    size: 20,
+                  ),
+                  tooltip: 'Edit device name',
+                  onPressed: () => _nameFocusNodes
+                      .putIfAbsent(device.id, () => FocusNode())
+                      .requestFocus(),
                 ),
               ),
               canUpgrade: () => _deviceRow(
@@ -779,6 +788,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
   );
 
   final Map<DeviceId, TextEditingController> _nameControllers = deviceIdMap();
+  final Map<DeviceId, FocusNode> _nameFocusNodes = deviceIdMap();
 
   void showRenameDeviceDialog(
     BuildContext context,
@@ -830,6 +840,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
     );
     return TextField(
       controller: textController,
+      focusNode: _nameFocusNodes.putIfAbsent(device.id, () => FocusNode()),
       style: monospaceTextStyle,
       maxLength: DeviceName.maxLength(),
       inputFormatters: [nameInputFormatter],


### PR DESCRIPTION
* During conference demos, both @aphanley and I independently noticed users attempting to tap the pencil icon to select the field to enter device names (frustratingly unresponsive). d3d1f437b1ca8d2420f0cf560fc2ca8bb8d280ac makes it so tapping the icon activates the field. 
* I noticed that I often went to capitalize the first letter of device/wallet names for aesthetics, which is slow and difficult when demoing on peculiar orientations. 3a8a9bb6ffa1a3a6714546d4ba6167d423e39e5b