### PR TITLE
Centralize bottom safe-area handling (fix buttons under the Android nav bar)

### DIFF
--- a/frostsnapp/lib/device_action.dart
+++ b/frostsnapp/lib/device_action.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frostsnap/theme.dart';
 import 'dart:async';
 
 Future<T?> showDeviceActionDialog<T>({
@@ -27,9 +28,8 @@ Future<T?> showDeviceActionDialog<T>({
       });
 
   final theme = Theme.of(context);
-  final result = await showModalBottomSheet<T>(
-    context: context,
-    isScrollControlled: true,
+  final result = await showAppBottomSheet<T>(
+    context,
     isDismissible: false,
     backgroundColor: Colors.transparent,
     builder: (BuildContext dialogContext_) {

--- a/frostsnapp/lib/dialog_content_with_actions.dart
+++ b/frostsnapp/lib/dialog_content_with_actions.dart
@@ -33,14 +33,17 @@ class DialogContentWithActions extends StatelessWidget {
           ),
         ),
         if (!isCompact) const Divider(height: 0),
-        Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: OverflowBar(
-            alignment: actionsAlignment,
-            overflowAlignment: OverflowBarAlignment.end,
-            spacing: 8,
-            overflowSpacing: 8,
-            children: actions,
+        SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: OverflowBar(
+              alignment: actionsAlignment,
+              overflowAlignment: OverflowBarAlignment.end,
+              spacing: 8,
+              overflowSpacing: 8,
+              children: actions,
+            ),
           ),
         ),
       ],

--- a/frostsnapp/lib/maybe_fullscreen_dialog.dart
+++ b/frostsnapp/lib/maybe_fullscreen_dialog.dart
@@ -161,9 +161,14 @@ class _MaybeFullscreenDialogState extends State<MaybeFullscreenDialog>
           //   _ => blurFilter,
           // },
           child: switch (_sizeClass.value) {
+            // Compact = fullscreen on mobile, where the Android gesture/nav bar
+            // overlaps the bottom edge. This is the single owner of the bottom
+            // inset for every fullscreen dialog; leaves must not re-add it
+            // (SafeArea is idempotent, so a stray nested one is a harmless
+            // no-op). Top stays edge-to-edge so top bars reach the status bar.
             WindowSizeClass.compact => Dialog.fullscreen(
               backgroundColor: widget.backgroundColor,
-              child: child,
+              child: SafeArea(top: false, child: child!),
             ),
             WindowSizeClass.medium || WindowSizeClass.expanded => Dialog(
               insetPadding: EdgeInsets.zero,

--- a/frostsnapp/lib/settings.dart
+++ b/frostsnapp/lib/settings.dart
@@ -696,8 +696,8 @@ class ChainStatusIcon extends StatelessWidget {
       },
     );
 
-    showModalBottomSheet(
-      context: context,
+    showAppBottomSheet(
+      context,
       builder: (sheetContext) => StreamBuilder(
         stream: combinedStream,
         builder: (context, snapshot) {
@@ -706,73 +706,71 @@ class ChainStatusIcon extends StatelessWidget {
           final primaryEnabled = enabled != ElectrumEnabled.none;
           final backupEnabled = enabled == ElectrumEnabled.all;
 
-          return SafeArea(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-                  child: Text(
-                    'Server Status',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text(
+                  'Server Status',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
-                _ServerStatusTile(
-                  label: 'Primary Server',
-                  url: status.primaryUrl,
-                  status: _getServerStatusFor(status, false),
-                  enabled: primaryEnabled,
-                  onTap: primaryEnabled
-                      ? () {
-                          Navigator.pop(sheetContext);
-                          settingsCtx.settings.connectTo(
-                            network: network,
-                            useBackup: false,
-                          );
-                        }
-                      : null,
-                  onEnabledChanged: (value) async {
-                    final newEnabled = value
-                        ? ElectrumEnabled.primaryOnly
-                        : ElectrumEnabled.none;
-                    await settingsCtx.settings.setElectrumEnabled(
-                      network: network,
-                      enabled: newEnabled,
-                    );
-                  },
-                ),
-                _ServerStatusTile(
-                  label: 'Backup Server',
-                  url: status.backupUrl,
-                  status: _getServerStatusFor(status, true),
-                  enabled: backupEnabled,
-                  onTap: backupEnabled
-                      ? () {
-                          Navigator.pop(sheetContext);
-                          settingsCtx.settings.connectTo(
-                            network: network,
-                            useBackup: true,
-                          );
-                        }
-                      : null,
-                  onEnabledChanged: primaryEnabled
-                      ? (value) async {
-                          final newEnabled = value
-                              ? ElectrumEnabled.all
-                              : ElectrumEnabled.primaryOnly;
-                          await settingsCtx.settings.setElectrumEnabled(
-                            network: network,
-                            enabled: newEnabled,
-                          );
-                        }
-                      : null,
-                ),
-                const SizedBox(height: 8),
-              ],
-            ),
+              ),
+              _ServerStatusTile(
+                label: 'Primary Server',
+                url: status.primaryUrl,
+                status: _getServerStatusFor(status, false),
+                enabled: primaryEnabled,
+                onTap: primaryEnabled
+                    ? () {
+                        Navigator.pop(sheetContext);
+                        settingsCtx.settings.connectTo(
+                          network: network,
+                          useBackup: false,
+                        );
+                      }
+                    : null,
+                onEnabledChanged: (value) async {
+                  final newEnabled = value
+                      ? ElectrumEnabled.primaryOnly
+                      : ElectrumEnabled.none;
+                  await settingsCtx.settings.setElectrumEnabled(
+                    network: network,
+                    enabled: newEnabled,
+                  );
+                },
+              ),
+              _ServerStatusTile(
+                label: 'Backup Server',
+                url: status.backupUrl,
+                status: _getServerStatusFor(status, true),
+                enabled: backupEnabled,
+                onTap: backupEnabled
+                    ? () {
+                        Navigator.pop(sheetContext);
+                        settingsCtx.settings.connectTo(
+                          network: network,
+                          useBackup: true,
+                        );
+                      }
+                    : null,
+                onEnabledChanged: primaryEnabled
+                    ? (value) async {
+                        final newEnabled = value
+                            ? ElectrumEnabled.all
+                            : ElectrumEnabled.primaryOnly;
+                        await settingsCtx.settings.setElectrumEnabled(
+                          network: network,
+                          enabled: newEnabled,
+                        );
+                      }
+                    : null,
+              ),
+              const SizedBox(height: 8),
+            ],
           );
         },
       ),
@@ -1365,43 +1363,41 @@ class AboutPage extends StatelessWidget {
                     : null,
                 onTap: buildCommit != 'unknown'
                     ? () {
-                        showModalBottomSheet(
-                          context: context,
-                          builder: (context) => SafeArea(
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                CopyTapTarget(
-                                  data: buildCommit,
-                                  builder: (ctx, onCopy, checked) => ListTile(
-                                    leading: CopyIcon(checked: checked),
-                                    title: Text('Copy commit hash'),
-                                    onTap: onCopy == null
-                                        ? null
-                                        : () {
-                                            onCopy();
-                                            Navigator.pop(context);
-                                          },
-                                  ),
+                        showAppBottomSheet(
+                          context,
+                          builder: (context) => Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              CopyTapTarget(
+                                data: buildCommit,
+                                builder: (ctx, onCopy, checked) => ListTile(
+                                  leading: CopyIcon(checked: checked),
+                                  title: Text('Copy commit hash'),
+                                  onTap: onCopy == null
+                                      ? null
+                                      : () {
+                                          onCopy();
+                                          Navigator.pop(context);
+                                        },
                                 ),
-                                ListTile(
-                                  leading: Icon(Icons.open_in_new),
-                                  title: Text('View on GitHub'),
-                                  onTap: () async {
-                                    Navigator.pop(context);
-                                    final url = Uri.parse(
-                                      'https://github.com/frostsnap/frostsnap/commit/$commitHash',
+                              ),
+                              ListTile(
+                                leading: Icon(Icons.open_in_new),
+                                title: Text('View on GitHub'),
+                                onTap: () async {
+                                  Navigator.pop(context);
+                                  final url = Uri.parse(
+                                    'https://github.com/frostsnap/frostsnap/commit/$commitHash',
+                                  );
+                                  if (await canLaunchUrl(url)) {
+                                    await launchUrl(
+                                      url,
+                                      mode: LaunchMode.externalApplication,
                                     );
-                                    if (await canLaunchUrl(url)) {
-                                      await launchUrl(
-                                        url,
-                                        mode: LaunchMode.externalApplication,
-                                      );
-                                    }
-                                  },
-                                ),
-                              ],
-                            ),
+                                  }
+                                },
+                              ),
+                            ],
                           ),
                         );
                       }

--- a/frostsnapp/lib/theme.dart
+++ b/frostsnapp/lib/theme.dart
@@ -45,6 +45,59 @@ Color tintOnSurface(
   elevation,
 );
 
+/// A bottom-anchored bar (toolbar / action row) that owns its safe-area inset.
+///
+/// Use this — or `Scaffold.persistentFooterButtons` — for any custom
+/// bottom-anchored controls. A plain `Scaffold.bottomNavigationBar` child is NOT
+/// auto-inset by Flutter, so hand-building one is exactly how bottom controls end
+/// up under the Android gesture bar.
+class BottomActionBar extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry padding;
+
+  const BottomActionBar({
+    super.key,
+    required this.child,
+    this.padding = EdgeInsets.zero,
+  });
+
+  @override
+  Widget build(BuildContext context) => SafeArea(
+    top: false,
+    child: Padding(padding: padding, child: child),
+  );
+}
+
+/// Shows a modal bottom sheet that owns its bottom safe-area inset.
+///
+/// Flutter's `showModalBottomSheet(useSafeArea: true)` is `SafeArea(bottom:
+/// false)` — it never insets the bottom, so action content would sit under the
+/// Android gesture/navigation bar. This is the only sanctioned way to open a
+/// bottom sheet; raw `showModalBottomSheet` is rejected by the lint guard so the
+/// bottom inset can't be forgotten.
+Future<T?> showAppBottomSheet<T>(
+  BuildContext context, {
+  required WidgetBuilder builder,
+  Color? backgroundColor,
+  bool isScrollControlled = true,
+  bool isDismissible = true,
+  bool showDragHandle = false,
+  Clip? clipBehavior,
+}) {
+  // This is the one sanctioned showModalBottomSheet call; the
+  // `check-safe-area-surfaces` lint guard forbids it everywhere else.
+  return showModalBottomSheet<T>(
+    context: context,
+    backgroundColor: backgroundColor,
+    isScrollControlled: isScrollControlled,
+    isDismissible: isDismissible,
+    showDragHandle: showDragHandle,
+    clipBehavior: clipBehavior,
+    useSafeArea: true,
+    builder: (context) => SafeArea(top: false, child: builder(context)),
+  );
+}
+
 Future<T?> showBottomSheetOrDialog<T>(
   BuildContext context, {
   required Widget Function(BuildContext, ScrollController) builder,
@@ -83,14 +136,10 @@ Future<T?> showBottomSheetOrDialog<T>(
             child: column,
           ),
         )
-      : showModalBottomSheet<T>(
-          context: context,
+      : showAppBottomSheet<T>(
+          context,
           clipBehavior: Clip.hardEdge,
           backgroundColor: backgroundColor,
-          isScrollControlled: true,
-          useSafeArea: true,
-          isDismissible: true,
-          showDragHandle: false,
           builder: (context) => column,
         );
 

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -790,7 +790,7 @@ class WalletBottomBar extends StatelessWidget {
     return SizedBox(
       // Arbitary height to bound the bottom bar.
       height: 200,
-      child: SafeArea(
+      child: BottomActionBar(
         child: Align(
           alignment: Alignment.bottomCenter,
           child: Padding(

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -1269,29 +1269,26 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
                 padding: EdgeInsets.all(
                   16,
                 ).add(EdgeInsets.only(bottom: mediaQuery.viewInsets.bottom)),
-                child: SafeArea(
-                  top: false,
-                  child: Align(
-                    alignment: Alignment.centerRight,
-                    child: FilledButton(
-                      onPressed:
-                          !_controller.canGoNext ||
-                              (_controller.step == WalletCreateStep.threshold &&
-                                  _keygenInFlight)
-                          ? null
-                          : () {
-                              if (_controller.step ==
-                                  WalletCreateStep.threshold) {
-                                _beginThresholdKeygen(context);
-                              } else {
-                                _controller.next(context);
-                              }
-                            },
-                      child: Text(
-                        _controller.nextText ?? 'Next',
-                        softWrap: false,
-                        overflow: TextOverflow.fade,
-                      ),
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: FilledButton(
+                    onPressed:
+                        !_controller.canGoNext ||
+                            (_controller.step == WalletCreateStep.threshold &&
+                                _keygenInFlight)
+                        ? null
+                        : () {
+                            if (_controller.step ==
+                                WalletCreateStep.threshold) {
+                              _beginThresholdKeygen(context);
+                            } else {
+                              _controller.next(context);
+                            }
+                          },
+                    child: Text(
+                      _controller.nextText ?? 'Next',
+                      softWrap: false,
+                      overflow: TextOverflow.fade,
                     ),
                   ),
                 ),

--- a/frostsnapp/lib/wallet_more.dart
+++ b/frostsnapp/lib/wallet_more.dart
@@ -56,7 +56,7 @@ class _WalletMoreState extends State<WalletMore> {
       slivers: [
         if (walletCtx != null)
           SliverToBoxAdapter(child: buildColumn(context, walletCtx)),
-        SliverSafeArea(sliver: SliverToBoxAdapter(child: SizedBox(height: 12))),
+        SliverToBoxAdapter(child: SizedBox(height: 12)),
       ],
     );
   }

--- a/justfile
+++ b/justfile
@@ -291,7 +291,24 @@ lint-device +ARGS="":
 dart-format-check-app:
     ( cd frostsnapp; dart format --set-exit-if-changed --output=none  $(find ./lib -type f -name "*.dart" -not -path "./lib/src/rust/*" -not -name "*.freezed.dart") )
 
-lint-app +ARGS="": maybe-gen dart-format-check-app
+# Bottom safe-area insets are owned by surface helpers (showAppBottomSheet,
+# MaybeFullscreenDialog, BottomActionBar). Forbid the raw surface APIs elsewhere
+# so the inset can't be forgotten on a new screen.
+check-safe-area-surfaces:
+    #!/bin/sh
+    cd frostsnapp/lib
+    fail=0
+    if grep -rnE --include='*.dart' 'showModalBottomSheet(<[^>]*>)?\(' . | grep -v '^\./theme\.dart:'; then
+        echo "error: use showAppBottomSheet() (theme.dart) instead of raw showModalBottomSheet()" >&2
+        fail=1
+    fi
+    if grep -rnE --include='*.dart' 'Dialog\.fullscreen\(' . | grep -v '^\./maybe_fullscreen_dialog\.dart:'; then
+        echo "error: use MaybeFullscreenDialog instead of raw Dialog.fullscreen()" >&2
+        fail=1
+    fi
+    exit $fail
+
+lint-app +ARGS="": maybe-gen dart-format-check-app check-safe-area-surfaces
     ( cd frostsnapp; flutter analyze {{ARGS}} )
 
 fix-dart: maybe-gen


### PR DESCRIPTION
## Problem

On Android with edge-to-edge rendering, bottom action buttons can render *under* the system navigation bar (the gesture pill, or a transparent full-height 3-button bar) on some screens — making them hard or impossible to tap.

## Root cause

Safe-area insets were each **leaf screen's** responsibility — 22 hand-written `SafeArea`/`SliverSafeArea` wraps scattered across `lib/`. A cross-cutting concern done by per-leaf copy-paste is easy to forget, and the forgotten ones are the bug.

## Fix — give each *surface* a single inset owner

Every screen reaches the user through one of a few surfaces; make each own its bottom inset, so a leaf can't forget:

- **`MaybeFullscreenDialog`** (compact) wraps its child in `SafeArea(top: false)` — one owner for every fullscreen dialog (incl. the **Backup Keys** page via `wallet.dart`, and the recovery flow).
- **`showAppBottomSheet`** bakes the bottom inset into sheet content, since `showModalBottomSheet(useSafeArea: true)` is `SafeArea(bottom: false)` and never insets the bottom. `device_action` and both `settings` sheets migrate onto it.
- **`BottomActionBar`** owns custom bottom bars (a `Scaffold.bottomNavigationBar` child is *not* auto-inset by Flutter); the wallet toolbar uses it.
- `DialogContentWithActions` insets its own footer too.
- Removed two now-redundant per-leaf wraps; kept the full-`SafeArea` ones that also own the top edge.

`SafeArea` is idempotent, so the migration was safe and incremental.

## Guarantee it can't regress

`just lint-app` now runs `check-safe-area-surfaces`, which fails if `showModalBottomSheet(`/`Dialog.fullscreen(` (incl. typed `<T>`) appears outside the surface helpers. A new screen physically can't reintroduce the bug.

## ⚠️ Testing — visual verification still needed on Android 15

I could **not** get a faithful visual repro: the available test device (moto g04, Android 14) draws 3-button nav **opaque** (the OS insets the window), so the overlap doesn't manifest there, and its gesture-pill inset is too small to be dramatic. The fix is verified **by construction** — `SafeArea` consumes `MediaQuery.padding.bottom`, exactly the inset that's non-zero in every edge-to-edge / transparent-bar config — and on the Backup Keys code path (shown via `MaybeFullscreenDialog`, now surface-inset).

**Please verify visually on Android 15** (edge-to-edge enforced, nav bar transparent in both modes): recovery-flow footers, the device-action sheet, and the backup checklist with several devices.

Design/plan doc: `.clank/plans/fix-missing-safe-areas.md`.