### PR TITLE
Electrum: fix disable/startup behavior + signet servers; refactor config to a watch subject

### DIFF
--- a/frostsnap_coordinator/Cargo.toml
+++ b/frostsnap_coordinator/Cargo.toml
@@ -27,7 +27,7 @@ bdk_electrum_streaming = { version = "0.5.2" }
 bdk_coin_select = { version = "0.4.1" }
 
 
-tokio = { version = "1.45", features = ["net", "rt", "time", "macros"] }
+tokio = { version = "1.45", features = ["net", "rt", "time", "macros", "sync"] }
 rustls = { version = "0.23", default-features = false, features = ["tls12", "ring"] }
 rustls-pki-types = { version = "1" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "ring"] }

--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -31,6 +31,7 @@ use std::{
     time::Duration,
 };
 use tokio::io::AsyncWriteExt;
+use tokio::sync::watch;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing::{event, Level};
 
@@ -40,7 +41,8 @@ use crate::Sink;
 
 use super::{
     descriptor_for_account_keychain,
-    handler_state::HandlerState,
+    handler_state::{ConnectedTo, Establish, HandlerState},
+    status_tracker::ConnPhase,
     tofu::{
         connection::{Conn, TargetServerReq},
         trusted_certs::TrustedCertificates,
@@ -86,11 +88,6 @@ pub enum Message {
         server_url: String,
         certificate_der: Vec<u8>,
     },
-    SetUrls {
-        primary: String,
-        backup: String,
-    },
-    SetEnabled(ElectrumEnabled),
     /// Connect to a specific server (primary or backup)
     ConnectTo {
         use_backup: bool,
@@ -115,13 +112,21 @@ impl std::fmt::Display for Message {
             Message::TrustCertificate { server_url, .. } => {
                 write!(f, "Message::TrustCertificate({})", server_url)
             }
-            Message::SetUrls { .. } => write!(f, "Message::SetUrls"),
-            Message::SetEnabled(enabled) => write!(f, "Message::SetEnabled({:?})", enabled),
             Message::ConnectTo { use_backup } => {
                 write!(f, "Message::ConnectTo(use_backup={})", use_backup)
             }
         }
     }
+}
+
+/// The settings-derived desired state for connecting: which servers and whether enabled.
+/// This is the single source of truth shared (via a watch) from the api to the handler —
+/// the handler queries it and reacts to its change signal; there is no replica.
+#[derive(Clone, Debug)]
+pub struct ElectrumConfig {
+    pub enabled: ElectrumEnabled,
+    pub primary: String,
+    pub backup: String,
 }
 
 /// Opaque API to the chain
@@ -130,22 +135,26 @@ pub struct ChainClient {
     req_sender: mpsc::UnboundedSender<Message>,
     client: KeychainClient,
     connection_requested: Arc<AtomicBool>,
+    config_tx: watch::Sender<ElectrumConfig>,
 }
 
 impl ChainClient {
     pub fn new(
         genesis_hash: BlockHash,
+        config: ElectrumConfig,
         trusted_certificates: Persisted<TrustedCertificates>,
         db: Arc<sync::Mutex<rusqlite::Connection>>,
     ) -> (Self, ConnectionHandler) {
         let (req_sender, req_recv) = mpsc::unbounded();
         let (client, client_recv) = KeychainClient::new();
+        let (config_tx, config_rx) = watch::channel(config);
         let cache = Cache::default();
         (
             Self {
                 req_sender,
                 client: client.clone(),
                 connection_requested: Arc::new(AtomicBool::new(false)),
+                config_tx,
             },
             ConnectionHandler {
                 req_recv,
@@ -155,6 +164,7 @@ impl ChainClient {
                 genesis_hash,
                 trusted_certificates,
                 db,
+                config_rx,
             },
         )
     }
@@ -251,15 +261,25 @@ impl ChainClient {
     }
 
     pub fn set_urls(&self, primary: String, backup: String) {
-        self.req_sender
-            .unbounded_send(Message::SetUrls { primary, backup })
-            .unwrap();
+        self.config_tx.send_modify(|c| {
+            c.primary = primary;
+            c.backup = backup;
+        });
+    }
+
+    /// Update a single server url (used after a `ChangeUrlReq` probe succeeds).
+    pub fn set_electrum_url(&self, url: String, is_backup: bool) {
+        self.config_tx.send_modify(|c| {
+            if is_backup {
+                c.backup = url;
+            } else {
+                c.primary = url;
+            }
+        });
     }
 
     pub fn set_enabled(&self, enabled: ElectrumEnabled) {
-        self.req_sender
-            .unbounded_send(Message::SetEnabled(enabled))
-            .unwrap();
+        self.config_tx.send_modify(|c| c.enabled = enabled);
     }
 
     pub fn connect_to(&self, use_backup: bool) {
@@ -309,13 +329,11 @@ pub struct ConnectionHandler {
     genesis_hash: BlockHash,
     trusted_certificates: Persisted<TrustedCertificates>,
     db: Arc<sync::Mutex<rusqlite::Connection>>,
+    config_rx: watch::Receiver<ElectrumConfig>,
 }
 
 impl ConnectionHandler {
-    const PING_DELAY: Duration = Duration::from_secs(21);
-    const PING_TIMEOUT: Duration = Duration::from_secs(3);
-
-    pub fn run<SW, F>(mut self, url: String, backup_url: String, super_wallet: SW, update_action: F)
+    pub fn run<SW, F>(mut self, super_wallet: SW, update_action: F)
     where
         SW: Deref<Target = sync::Mutex<CoordSuperWallet>> + Clone + Send + 'static,
         F: FnMut(MasterAppkey, Vec<crate::bitcoin::wallet::Transaction>) + Send + 'static,
@@ -339,160 +357,38 @@ impl ConnectionHandler {
             .build()
             .expect("cannot build tokio runtime");
 
-        let (mut update_sender, update_recv) = mpsc::unbounded::<Update<KeychainId>>();
+        let (update_sender, update_recv) = mpsc::unbounded::<Update<KeychainId>>();
 
         let _wallet_updates_jh = rt.spawn_blocking({
             let super_wallet = super_wallet.clone();
             move || Self::handle_wallet_updates(super_wallet, update_recv, update_action)
         });
 
-        let mut handler = HandlerState::new(
+        let handler = HandlerState::new(
             self.genesis_hash,
-            url,
-            backup_url,
+            self.config_rx.clone(),
             self.trusted_certificates,
             self.db,
         );
 
-        rt.block_on({
-            let mut electrum_state = AsyncState::<KeychainId>::new(
-                ReqCoord::new(rand::random::<u32>()),
-                self.cache,
-                DerivedSpkTracker::new(lookahead),
-                chain_tip,
-            );
+        let electrum_state = AsyncState::<KeychainId>::new(
+            ReqCoord::new(rand::random::<u32>()),
+            self.cache,
+            DerivedSpkTracker::new(lookahead),
+            chain_tip,
+        );
 
-            async move {
-                loop {
-                    // Wait until we should connect (started + enabled)
-                    while !handler.should_connect() {
-                        match self.req_recv.next().await {
-                            Some(msg) => {
-                                handler.handle_msg(msg).await;
-                            }
-                            None => return,
-                        }
-                    }
-
-                    let mut conn = match handler.get_connection().await {
-                        Some(conn) => conn,
-                        None => {
-                            tokio::time::sleep(HandlerState::RECONNECT_DELAY).await;
-                            continue;
-                        }
-                    };
-
-                    {
-                        let conn_fut = Self::run_connection(
-                            &mut conn,
-                            &mut electrum_state,
-                            &mut self.client_recv,
-                            &mut update_sender,
-                        )
-                            .fuse();
-                        let ping_fut = async {
-                            loop {
-                                tokio::time::sleep(Self::PING_DELAY).await;
-
-                                let req_fut = self.client.send_request(request::Ping).fuse();
-                                let req_timeout_fut = tokio::time::sleep(Self::PING_TIMEOUT).fuse();
-                                pin_mut!(req_fut);
-                                pin_mut!(req_timeout_fut);
-                                select! {
-                                    result = req_fut => {
-                                        if let Err(err) = result {
-                                            return err;
-                                        }
-                                        tracing::trace!("Received pong from server");
-                                    },
-                                    _ = req_timeout_fut => {
-                                        return anyhow!("Timeout waiting for pong");
-                                    },
-                                }
-                            }
-                        }.fuse();
-                        pin_mut!(conn_fut);
-                        pin_mut!(ping_fut);
-
-                        // Handle messages until connection fails or we get disabled
-                        loop {
-                            select_biased! {
-                                msg_opt = self.req_recv.next() => {
-                                    let msg = match msg_opt {
-                                        Some(msg) => msg,
-                                        None => return,
-                                    };
-                                    tracing::info!(msg = msg.to_string(), "Handling message");
-                                    let should_reconnect = handler.handle_msg(msg).await;
-
-                                    if !handler.should_connect() {
-                                        tracing::info!("Electrum disabled");
-                                        break;
-                                    }
-
-                                    if should_reconnect {
-                                        tracing::info!("Breaking connection loop due to reconnect request");
-                                        break;
-                                    }
-                                }
-                                err = ping_fut => {
-                                    tracing::error!(error = err.to_string(), "Failed to keep connection alive");
-                                    break;
-                                },
-                                _ = conn_fut => {
-                                    tracing::debug!("Connection service stopped");
-                                    break;
-                                },
-                            }
-                        }
-                    }
-
-                    // Shutdown the connection
-                    handler.set_disconnected();
-                    let shutdown_result = match conn {
-                        Conn::Tcp((rh, wh)) => rh.unsplit(wh).shutdown().await,
-                        Conn::Ssl((rh, wh)) => rh.unsplit(wh).shutdown().await,
-                    };
-                    tracing::info!(result = ?shutdown_result, "Connection shutdown");
-                }
-            }
-        });
-    }
-
-    /// Run the sync loop with an established connection
-    async fn run_connection(
-        conn: &mut Conn,
-        state: &mut AsyncState<KeychainId>,
-        client_recv: &mut AsyncReceiver<KeychainId>,
-        update_sender: &mut mpsc::UnboundedSender<Update<KeychainId>>,
-    ) {
-        let conn_result = match conn {
-            Conn::Tcp((read_half, write_half)) => {
-                run_async(
-                    state,
-                    update_sender,
-                    client_recv,
-                    read_half.compat(),
-                    write_half.compat_write(),
-                )
-                .await
-            }
-            Conn::Ssl((read_half, write_half)) => {
-                run_async(
-                    state,
-                    update_sender,
-                    client_recv,
-                    read_half.compat(),
-                    write_half.compat_write(),
-                )
-                .await
-            }
+        let mut conn_loop = ConnLoop {
+            handler,
+            client: self.client,
+            req_recv: self.req_recv,
+            client_recv: self.client_recv,
+            update_sender,
+            electrum_state,
+            config_rx: self.config_rx,
         };
-        // TODO: This is not necessarily a closed connection.
-        match conn_result {
-            Ok(_) => tracing::info!("Connection service stopped gracefully"),
-            Err(err) => tracing::warn!(?err, "Connection service stopped"),
-        };
+
+        rt.block_on(conn_loop.drive());
     }
 
     fn handle_wallet_updates<SW, F>(
@@ -527,7 +423,283 @@ impl ConnectionHandler {
     }
 }
 
-#[derive(Clone)]
+/// The next state for the connection driver. Each variant is handled by one method that
+/// awaits exactly the events meaningful in that state and returns the next `Next`, so the
+/// connection lifecycle is an explicit state machine rather than a loop with flags.
+enum Next {
+    /// Not started or disabled: park without opening a socket (lazy).
+    Idle,
+    /// Try to establish a connection (with primary→backup failover).
+    Connect,
+    /// Service a live connection.
+    Service(Conn, ConnectedTo),
+    /// Wait before the next connect attempt. `failover` rotates away from the failed server
+    /// (`was_on_backup`) first, so we don't tight-loop on a server that can't serve us.
+    Backoff { failover: bool, was_on_backup: bool },
+    /// The control channel closed: stop the loop.
+    Stop,
+}
+
+/// Owns the connection loop's working state for the lifetime of the runtime and drives it as a
+/// state machine. `HandlerState` holds connection policy (which server, enabled, status,
+/// certs); `ConnLoop` holds the live I/O plumbing plus the handler.
+struct ConnLoop {
+    handler: HandlerState,
+    client: KeychainClient,
+    req_recv: mpsc::UnboundedReceiver<Message>,
+    client_recv: KeychainClientReceiver,
+    update_sender: mpsc::UnboundedSender<Update<KeychainId>>,
+    electrum_state: AsyncState<KeychainId>,
+    config_rx: watch::Receiver<ElectrumConfig>,
+}
+
+impl ConnLoop {
+    const PING_DELAY: Duration = Duration::from_secs(21);
+    const PING_TIMEOUT: Duration = Duration::from_secs(3);
+
+    async fn drive(&mut self) {
+        let mut next = Next::Idle;
+        loop {
+            next = match next {
+                Next::Idle => self.idle().await,
+                Next::Connect => self.connect().await,
+                Next::Service(conn, info) => self.service(conn, info).await,
+                Next::Backoff {
+                    failover,
+                    was_on_backup,
+                } => self.backoff(failover, was_on_backup).await,
+                Next::Stop => return,
+            };
+        }
+    }
+
+    /// Park until we should connect, staying responsive to control messages and config
+    /// changes. No socket is opened here, so connections stay lazy.
+    async fn idle(&mut self) -> Next {
+        if self.handler.should_connect() {
+            return Next::Connect;
+        }
+        // Entering the parked state: this is the single funnel for "not connecting", so
+        // asserting Idle here also recovers the status after a disable that interrupted an
+        // in-flight connect (which left the phase on Connecting).
+        self.handler.status.set_phase(ConnPhase::Idle);
+        while !self.handler.should_connect() {
+            select_biased! {
+                msg_opt = self.req_recv.next() => match msg_opt {
+                    Some(msg) => { self.handler.handle_msg(msg).await; }
+                    None => return Next::Stop,
+                },
+                res = self.config_rx.changed().fuse() => match res {
+                    Ok(()) => self.handler.on_config_changed(),
+                    Err(_) => return Next::Stop,
+                },
+            }
+        }
+        Next::Connect
+    }
+
+    /// Establish a connection. The single place that decides whether to connect at all: when
+    /// disabled it parks (`Idle`). The attempt (incl. primary→backup failover) is raced ONLY
+    /// against the config watch — never `req_recv` — so a benign control message can't cancel
+    /// an in-flight connect. A connect failure becomes a `Backoff` (not an in-line sleep).
+    async fn connect(&mut self) -> Next {
+        if !self.handler.should_connect() {
+            return Next::Idle;
+        }
+        match self.handler.establish(&mut self.config_rx).await {
+            Establish::Connected(conn, info) => Next::Service(conn, info),
+            Establish::Retry => Next::Backoff {
+                failover: false,
+                was_on_backup: false,
+            },
+            Establish::TargetChanged => {
+                // Re-emit status (urls may have changed); re-evaluate from the top — the new
+                // target may be disabled, a different server, etc.
+                self.handler.on_config_changed();
+                Next::Idle
+            }
+            Establish::Closed => Next::Stop,
+        }
+    }
+
+    /// Service a live connection until it ends, then tear it down (status + socket shutdown)
+    /// before returning. The return value encodes *why* it ended and *what next*: a graceful
+    /// stop or deliberate reconnect → `Connect`; a session failure (sync error / ping timeout)
+    /// → `Backoff` with failover; a disable → `Idle`.
+    async fn service(&mut self, mut conn: Conn, info: ConnectedTo) -> Next {
+        let Self {
+            handler,
+            client,
+            req_recv,
+            client_recv,
+            update_sender,
+            electrum_state,
+            config_rx,
+        } = self;
+
+        let next = {
+            let conn_fut =
+                Self::run_connection(&mut conn, electrum_state, client_recv, update_sender).fuse();
+            let ping_fut = async {
+                loop {
+                    tokio::time::sleep(Self::PING_DELAY).await;
+
+                    let req_fut = client.send_request(request::Ping).fuse();
+                    let req_timeout_fut = tokio::time::sleep(Self::PING_TIMEOUT).fuse();
+                    pin_mut!(req_fut);
+                    pin_mut!(req_timeout_fut);
+                    select! {
+                        result = req_fut => {
+                            if let Err(err) = result {
+                                return err;
+                            }
+                            tracing::trace!("Received pong from server");
+                        },
+                        _ = req_timeout_fut => {
+                            return anyhow!("Timeout waiting for pong");
+                        },
+                    }
+                }
+            }
+            .fuse();
+            pin_mut!(conn_fut);
+            pin_mut!(ping_fut);
+
+            loop {
+                select_biased! {
+                    msg_opt = req_recv.next() => {
+                        let msg = match msg_opt {
+                            Some(msg) => msg,
+                            None => break Next::Stop,
+                        };
+                        tracing::info!(msg = msg.to_string(), "Handling message");
+                        let should_reconnect = handler.handle_msg(msg).await;
+
+                        if !handler.should_connect() {
+                            tracing::info!("Electrum disabled");
+                            break Next::Idle;
+                        }
+                        if should_reconnect {
+                            tracing::info!("Breaking connection loop due to reconnect request");
+                            break Next::Connect;
+                        }
+                    }
+                    res = config_rx.changed().fuse() => {
+                        if res.is_err() {
+                            break Next::Stop;
+                        }
+                        // Always re-emit status (displayed urls may have changed), but only tear
+                        // down the live connection if the change affects the server we're on — a
+                        // change to the other slot (e.g. toggling the backup while on the
+                        // primary) leaves it untouched.
+                        handler.on_config_changed();
+                        if handler.reconnect_needed(info.on_backup, &info.url) {
+                            tracing::info!("Breaking connection loop: config change affects the current server");
+                            break Next::Connect;
+                        }
+                    }
+                    err = ping_fut => {
+                        tracing::error!(error = err.to_string(), "Failed to keep connection alive");
+                        break Next::Backoff { failover: true, was_on_backup: info.on_backup };
+                    },
+                    res = conn_fut => {
+                        break match res {
+                            Ok(()) => {
+                                tracing::info!("Connection service stopped gracefully");
+                                Next::Connect
+                            }
+                            Err(err) => {
+                                // `{err:#}` keeps the cause chain on one line without anyhow's
+                                // backtrace dump.
+                                tracing::warn!(error = format!("{err:#}"), "Connection service failed");
+                                Next::Backoff { failover: true, was_on_backup: info.on_backup }
+                            }
+                        };
+                    },
+                }
+            }
+        };
+
+        // The control channel closed: stop without touching status (the app is going away).
+        if matches!(next, Next::Stop) {
+            return Next::Stop;
+        }
+
+        // Leaving the connection: assert the phase from the authoritative predicate (disabled
+        // → Idle, else Disconnected) before the socket shutdown, so the UI never lingers on a
+        // stale Connected while the socket closes. We don't infer it from `next`: a disable
+        // arrives as a config change that maps to Next::Connect, the same as a same-server
+        // reconnect, so `next` can't tell them apart.
+        let leaving = if handler.should_connect() {
+            ConnPhase::Disconnected
+        } else {
+            ConnPhase::Idle
+        };
+        handler.status.set_phase(leaving);
+        let shutdown_result = match conn {
+            Conn::Tcp((rh, wh)) => rh.unsplit(wh).shutdown().await,
+            Conn::Ssl((rh, wh)) => rh.unsplit(wh).shutdown().await,
+        };
+        tracing::info!(result = ?shutdown_result, "Connection shutdown");
+        next
+    }
+
+    /// Wait before the next connect attempt, interruptibly. On a session failure (`failover`),
+    /// rotate to the other server first.
+    async fn backoff(&mut self, failover: bool, was_on_backup: bool) -> Next {
+        // Between attempts we are disconnected (will retry). The service teardown already
+        // asserted this on the failover path; on the connect-failure path the phase is still
+        // Connecting, so assert it here. Deduped, so the redundant case is silent.
+        self.handler.status.set_phase(ConnPhase::Disconnected);
+        if failover {
+            self.handler.prefer_other_server(was_on_backup);
+        }
+        select_biased! {
+            res = self.config_rx.changed().fuse() => match res {
+                Ok(()) => self.handler.on_config_changed(),
+                Err(_) => return Next::Stop,
+            },
+            _ = tokio::time::sleep(HandlerState::RECONNECT_DELAY).fuse() => {}
+        }
+        Next::Connect
+    }
+
+    /// Run the sync loop with an established connection. `Ok` is a graceful stop; `Err` is a
+    /// session failure (e.g. the server passed the connectivity probe but rejected the real
+    /// sync) — `service` turns that into a failover `Backoff`.
+    async fn run_connection(
+        conn: &mut Conn,
+        state: &mut AsyncState<KeychainId>,
+        client_recv: &mut AsyncReceiver<KeychainId>,
+        update_sender: &mut mpsc::UnboundedSender<Update<KeychainId>>,
+    ) -> Result<()> {
+        let conn_result = match conn {
+            Conn::Tcp((read_half, write_half)) => {
+                run_async(
+                    state,
+                    update_sender,
+                    client_recv,
+                    read_half.compat(),
+                    write_half.compat_write(),
+                )
+                .await
+            }
+            Conn::Ssl((read_half, write_half)) => {
+                run_async(
+                    state,
+                    update_sender,
+                    client_recv,
+                    read_half.compat(),
+                    write_half.compat_write(),
+                )
+                .await
+            }
+        };
+        conn_result.map(|_| ())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
 pub struct ChainStatus {
     pub primary_url: String,
     pub backup_url: String,
@@ -535,7 +707,7 @@ pub struct ChainStatus {
     pub state: ChainStatusState,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ChainStatusState {
     /// No connection has been attempted yet
     Idle,

--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -279,7 +279,9 @@ pub const fn default_electrum_server(network: bitcoin::Network) -> &'static str 
         bitcoin::Network::Testnet => "tcp://electrum.blockstream.info:60001",
         bitcoin::Network::Testnet4 => "ssl://blackie.c3-soft.com:57010",
         bitcoin::Network::Regtest => "tcp://localhost:60401",
-        bitcoin::Network::Signet => "ssl://mempool.space:60602",
+        // tcp:// because most public signet servers' SSL certs are rejected by rustls
+        // (old X.509 versions), and mempool.space's signet electrum is currently unreliable.
+        bitcoin::Network::Signet => "tcp://signet.musdomworks.com:50001",
         _ => panic!("Unknown network"),
     }
 }
@@ -291,7 +293,9 @@ pub const fn default_backup_electrum_server(network: bitcoin::Network) -> &'stat
         bitcoin::Network::Bitcoin => "ssl://electrum.acinq.co:50002",
         bitcoin::Network::Testnet => "ssl://blockstream.info:993",
         bitcoin::Network::Testnet4 => "ssl://mempool.space:40002",
-        bitcoin::Network::Signet => "tcp://signet-electrumx.wakiyamap.dev:50001",
+        // Standard fallback: backend is currently down, but it has a valid cert and is
+        // expected to recover. The primary (musdom) is the signet server that works today.
+        bitcoin::Network::Signet => "ssl://mempool.space:60602",
         bitcoin::Network::Regtest => "tcp://127.0.0.1:51001",
         _ => panic!("Unknown network"),
     }

--- a/frostsnap_coordinator/src/bitcoin/handler_state.rs
+++ b/frostsnap_coordinator/src/bitcoin/handler_state.rs
@@ -215,7 +215,7 @@ impl HandlerState {
                             Ok(())
                         })
                 {
-                    tracing::error!("Failed to trust certificate: {:?}", e);
+                    tracing::error!("Failed to trust certificate: {e:#}");
                 }
                 false
             }

--- a/frostsnap_coordinator/src/bitcoin/handler_state.rs
+++ b/frostsnap_coordinator/src/bitcoin/handler_state.rs
@@ -4,14 +4,66 @@ use std::{
     time::Duration,
 };
 
+use futures::{pin_mut, select_biased, FutureExt};
+use tokio::sync::watch;
+
 use crate::persist::Persisted;
 use crate::settings::ElectrumEnabled;
 
 use super::{
-    chain_sync::{ChainStatus, ChainStatusState, ConnectionResult, Message},
-    status_tracker::StatusTracker,
+    chain_sync::{ConnectionResult, ElectrumConfig, Message},
+    status_tracker::{ConnPhase, StatusTracker},
     tofu::{connection::Conn, trusted_certs::TrustedCertificates, verifier::TofuError},
 };
+
+/// Identifies the server a live connection is on. Carried by the connection state so failover
+/// and reconnect decisions read it from the state — not back out of the status (output) layer.
+#[derive(Clone, Debug)]
+pub(super) struct ConnectedTo {
+    pub(super) url: String,
+    pub(super) on_backup: bool,
+}
+
+/// Outcome of [`HandlerState::establish`]: the connect attempt, raced ONLY against the config
+/// (desired-target) watch. Benign `req_recv` messages are deliberately not watched there, so
+/// they cannot cancel an in-flight connection / primary→backup failover — only a target change
+/// (disable / url change) can. Backoff-on-failure is the caller's `Backoff` state, not here.
+pub(super) enum Establish {
+    /// A connection was established.
+    Connected(Conn, ConnectedTo),
+    /// The connect attempt produced no connection; the caller should back off and retry.
+    Retry,
+    /// The desired target (enabled/urls) changed; drop the attempt and re-evaluate.
+    TargetChanged,
+    /// The config channel closed → stop.
+    Closed,
+}
+
+/// Whether a config change requires tearing down the live connection, given which server
+/// we're on (`on_backup`) and the url we actually connected to. A connection is kept unless
+/// the server it's on is no longer enabled, or *that* server's url changed — so changes to
+/// the other slot (e.g. toggling the backup while on the primary) leave it untouched.
+pub(super) fn reconnect_needed(
+    on_backup: bool,
+    connected_url: &str,
+    config: &ElectrumConfig,
+) -> bool {
+    match config.enabled {
+        // Nothing is enabled.
+        ElectrumEnabled::None => true,
+        // We're on the backup but only the primary is now enabled.
+        ElectrumEnabled::PrimaryOnly if on_backup => true,
+        // The server we're on is still enabled: reconnect only if *its* url changed.
+        _ => {
+            let current_url = if on_backup {
+                &config.backup
+            } else {
+                &config.primary
+            };
+            connected_url != current_url
+        }
+    }
+}
 
 /// State needed for message handling and connection attempts.
 pub(super) struct HandlerState {
@@ -22,6 +74,7 @@ pub(super) struct HandlerState {
     pub started: bool,
     /// One-time preference for which server to try first
     prefer_backup: bool,
+    config_rx: watch::Receiver<ElectrumConfig>,
 }
 
 impl HandlerState {
@@ -30,62 +83,91 @@ impl HandlerState {
 
     pub fn new(
         genesis_hash: BlockHash,
-        url: String,
-        backup_url: String,
+        config_rx: watch::Receiver<ElectrumConfig>,
         trusted_certificates: Persisted<TrustedCertificates>,
         db: Arc<sync::Mutex<rusqlite::Connection>>,
     ) -> Self {
-        let initial_status = ChainStatus {
-            primary_url: url,
-            backup_url,
-            on_backup: false,
-            state: ChainStatusState::Idle,
-        };
         Self {
             genesis_hash,
-            status: StatusTracker::new(initial_status),
+            status: StatusTracker::new(config_rx.clone()),
             trusted_certificates,
             db,
             started: false,
             prefer_backup: false,
+            config_rx,
         }
     }
 
     pub fn should_connect(&self) -> bool {
-        self.started && self.status.enabled() != ElectrumEnabled::None
+        self.started && self.config_rx.borrow().enabled != ElectrumEnabled::None
     }
 
-    pub fn set_disconnected(&mut self) {
-        self.status.set_state(ChainStatusState::Disconnected);
+    /// Re-emit status so subscribers observe updated urls after a config change.
+    pub fn on_config_changed(&mut self) {
+        self.status.refresh();
     }
 
-    /// Get a connection by connecting fresh.
-    /// Returns Some(connection) if successful, None if all servers fail.
-    pub async fn get_connection(&mut self) -> Option<Conn> {
-        self.try_connect().await.map(|(conn, _url)| conn)
+    /// Drive one connect attempt — including the primary→backup failover inside
+    /// `try_connect` — raced ONLY against the desired-target watch (`config_rx`).
+    ///
+    /// Crucially, this does NOT watch `req_recv`: a benign control message must never cancel
+    /// an in-flight connection / failover. Only a target change (disable / url change) may,
+    /// via `Establish::TargetChanged`. The caller acts on the result after the borrow ends.
+    pub(super) async fn establish(
+        &mut self,
+        config_rx: &mut watch::Receiver<ElectrumConfig>,
+    ) -> Establish {
+        let work = async {
+            match self.try_connect().await {
+                Some((conn, info)) => Establish::Connected(conn, info),
+                None => Establish::Retry,
+            }
+        }
+        .fuse();
+        pin_mut!(work);
+        select_biased! {
+            res = config_rx.changed().fuse() => match res {
+                Ok(()) => Establish::TargetChanged,
+                Err(_) => Establish::Closed,
+            },
+            done = work => done,
+        }
+    }
+
+    /// Whether a config change requires reconnecting the connection on `connected_url`, given
+    /// which server it's on (`on_backup`) — see [`reconnect_needed`].
+    pub(super) fn reconnect_needed(&self, on_backup: bool, connected_url: &str) -> bool {
+        reconnect_needed(on_backup, connected_url, &self.config_rx.borrow())
+    }
+
+    /// After the connection to the current server failed, prefer the OTHER server on the next
+    /// attempt — so a server that connects but can't actually serve us is rotated away from.
+    pub(super) fn prefer_other_server(&mut self, was_on_backup: bool) {
+        self.prefer_backup = !was_on_backup;
     }
 
     /// Try to establish a new connection.
-    /// Returns Some((connection, url)) if successful, None if all servers fail.
-    pub async fn try_connect(&mut self) -> Option<(Conn, String)> {
+    /// Returns Some((connection, server)) if successful, None if all servers fail.
+    pub(super) async fn try_connect(&mut self) -> Option<(Conn, ConnectedTo)> {
         let prefer_backup = std::mem::take(&mut self.prefer_backup);
-        let primary = self.status.primary_url().to_string();
-        let backup = self.status.backup_url().to_string();
+        // Copy the config out so we don't hold the watch borrow across awaits.
+        let config = self.config_rx.borrow().clone();
 
-        let urls_to_try: Vec<(bool, String)> = match self.status.enabled() {
+        let urls_to_try: Vec<(bool, String)> = match config.enabled {
             ElectrumEnabled::All if prefer_backup => {
-                vec![(true, backup), (false, primary)]
+                vec![(true, config.backup), (false, config.primary)]
             }
             ElectrumEnabled::All => {
-                vec![(false, primary), (true, backup)]
+                vec![(false, config.primary), (true, config.backup)]
             }
-            ElectrumEnabled::PrimaryOnly => vec![(false, primary)],
+            ElectrumEnabled::PrimaryOnly => vec![(false, config.primary)],
             ElectrumEnabled::None => return None,
         };
 
         for (is_backup, url) in urls_to_try {
-            self.status
-                .set_state_and_server(ChainStatusState::Connecting, is_backup);
+            self.status.set_phase(ConnPhase::Connecting {
+                on_backup: is_backup,
+            });
             tracing::info!("Connecting to {}.", url);
 
             match Conn::new(
@@ -97,12 +179,21 @@ impl HandlerState {
             .await
             {
                 Ok(conn) => {
-                    self.status.set_state(ChainStatusState::Connected);
+                    self.status.set_phase(ConnPhase::Connected {
+                        on_backup: is_backup,
+                    });
                     tracing::info!("Connection established with {}.", url);
-                    return Some((conn, url));
+                    return Some((
+                        conn,
+                        ConnectedTo {
+                            url,
+                            on_backup: is_backup,
+                        },
+                    ));
                 }
                 Err(err) => {
-                    self.status.set_state(ChainStatusState::Disconnected);
+                    // Stay in the Connecting phase across the failover to the next server; a
+                    // total failure settles to Disconnected in `backoff`.
                     tracing::error!(err = err.to_string(), url, "failed to connect",);
                 }
             }
@@ -127,7 +218,10 @@ impl HandlerState {
                     is_backup = request.is_backup,
                 );
 
-                let reconnect = match Conn::new(
+                // Probe-only: validate the candidate server here, but the api owns the
+                // config — on success it persists and writes the watch, which triggers a
+                // reconnect via the config-change path. So nothing to reconnect here.
+                match Conn::new(
                     self.genesis_hash,
                     &request.url,
                     Self::CONNECT_TIMEOUT,
@@ -136,41 +230,22 @@ impl HandlerState {
                 .await
                 {
                     Ok(_conn) => {
-                        let primary = if request.is_backup {
-                            self.status.primary_url().to_string()
-                        } else {
-                            request.url.clone()
-                        };
-                        let backup = if request.is_backup {
-                            request.url.clone()
-                        } else {
-                            self.status.backup_url().to_string()
-                        };
-                        self.status.set_urls(primary, backup);
                         let _ = response.send(Ok(ConnectionResult::Success));
-                        // Reconnect if we changed the server we're currently connected to
-                        request.is_backup == self.status.on_backup()
                     }
-                    Err(err) => {
-                        match err {
-                            TofuError::NotTrusted(cert) => {
-                                tracing::info!(
-                                    "Certificate not trusted for {}: {}",
-                                    request.url,
-                                    cert.fingerprint
-                                );
-                                let _ = response
-                                    .send(Ok(ConnectionResult::CertificatePromptNeeded(cert)));
-                            }
-                            TofuError::Other(e) => {
-                                tracing::error!("Failed to connect to {}: {}", request.url, e);
-                                let _ = response.send(Ok(ConnectionResult::Failed(e.to_string())));
-                            }
-                        }
-                        false
+                    Err(TofuError::NotTrusted(cert)) => {
+                        tracing::info!(
+                            "Certificate not trusted for {}: {}",
+                            request.url,
+                            cert.fingerprint
+                        );
+                        let _ = response.send(Ok(ConnectionResult::CertificatePromptNeeded(cert)));
                     }
-                };
-                reconnect
+                    Err(TofuError::Other(e)) => {
+                        tracing::error!("Failed to connect to {}: {}", request.url, e);
+                        let _ = response.send(Ok(ConnectionResult::Failed(e.to_string())));
+                    }
+                }
+                false
             }
             Message::SetStatusSink(new_sink) => {
                 tracing::info!(msg = "SetStatusSink");
@@ -219,36 +294,9 @@ impl HandlerState {
                 }
                 false
             }
-            Message::SetUrls { primary, backup } => {
-                tracing::info!(msg = "SetUrls", primary = %primary, backup = %backup);
-                self.status.set_urls(primary, backup);
-                true
-            }
-            Message::SetEnabled(new_enabled) => {
-                let old_enabled = self.status.enabled();
-                let on_backup = self.status.on_backup();
-                self.status.set_enabled(new_enabled);
-                tracing::info!(
-                    msg = "SetEnabled",
-                    old = ?old_enabled,
-                    new = ?new_enabled,
-                );
-
-                // Break loop if we disabled the server we're currently on
-                let should_reconnect = match new_enabled {
-                    ElectrumEnabled::None => true,
-                    ElectrumEnabled::PrimaryOnly if on_backup => true,
-                    _ => false,
-                };
-
-                if new_enabled == ElectrumEnabled::None {
-                    self.status.set_state(ChainStatusState::Idle);
-                }
-                should_reconnect
-            }
             Message::ConnectTo { use_backup } => {
                 tracing::info!(msg = "ConnectTo", use_backup);
-                if use_backup && self.status.enabled() == ElectrumEnabled::PrimaryOnly {
+                if use_backup && self.config_rx.borrow().enabled == ElectrumEnabled::PrimaryOnly {
                     tracing::warn!("Cannot connect to backup server when only primary is enabled");
                     return false;
                 }
@@ -256,5 +304,233 @@ impl HandlerState {
                 true
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitcoin::chain_sync::ElectrumConfig;
+    use bdk_chain::bitcoin::{consensus, constants::genesis_block, params::Params, Network};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::watch;
+
+    /// A started handler plus the config `watch` sender (kept alive so the receiver passed to
+    /// `establish` doesn't see a closed channel) and a receiver to drive `establish` with.
+    fn make_handler(
+        config: ElectrumConfig,
+    ) -> (
+        HandlerState,
+        watch::Sender<ElectrumConfig>,
+        watch::Receiver<ElectrumConfig>,
+    ) {
+        let genesis = genesis_block(Params::new(Network::Signet)).block_hash();
+        let mut db = rusqlite::Connection::open_in_memory().unwrap();
+        let certs = Persisted::<TrustedCertificates>::new(&mut db, Network::Signet).unwrap();
+        let (tx, rx) = watch::channel(config);
+        let mut handler =
+            HandlerState::new(genesis, rx.clone(), certs, Arc::new(sync::Mutex::new(db)));
+        handler.started = true;
+        (handler, tx, rx)
+    }
+
+    /// A url that always refuses fast (a port we bound then immediately freed).
+    async fn refused_url() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        format!("tcp://{addr}")
+    }
+
+    /// A server that accepts connections and never replies — connections to it hang until
+    /// `Conn::new`'s timeout fires. Deterministically "broken but slow".
+    async fn spawn_hanging_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((sock, _)) = listener.accept().await {
+                held.push(sock); // keep the socket open; never respond
+            }
+        });
+        format!("tcp://{addr}")
+    }
+
+    /// A minimal fake electrum server that answers the network check with the signet genesis
+    /// header, so `Conn::new` succeeds against it. Deterministically "working".
+    async fn spawn_fake_signet_server() -> String {
+        let header_hex =
+            consensus::encode::serialize_hex(&genesis_block(Params::new(Network::Signet)).header);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = listener.accept().await {
+                let header_hex = header_hex.clone();
+                tokio::spawn(async move {
+                    // Read the one request line.
+                    let mut buf = Vec::new();
+                    let mut b = [0u8; 1];
+                    loop {
+                        match sock.read(&mut b).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(_) => {}
+                        }
+                        if b[0] == b'\n' {
+                            break;
+                        }
+                        buf.push(b[0]);
+                    }
+                    // Echo the request id back with the genesis header as the result.
+                    let req = String::from_utf8_lossy(&buf);
+                    let id = req
+                        .split("\"id\":")
+                        .nth(1)
+                        .and_then(|t| {
+                            t.trim_start()
+                                .split(|c: char| !c.is_ascii_digit())
+                                .find(|s| !s.is_empty())
+                        })
+                        .unwrap_or("0");
+                    let resp = format!(
+                        "{{\"jsonrpc\":\"2.0\",\"id\":{id},\"result\":\"{header_hex}\"}}\n"
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    let _ = sock.flush().await;
+                    // Hold the connection open briefly so the client can read the reply.
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                });
+            }
+        });
+        format!("tcp://{addr}")
+    }
+
+    fn cfg(enabled: ElectrumEnabled, primary: &str, backup: &str) -> ElectrumConfig {
+        ElectrumConfig {
+            enabled,
+            primary: primary.into(),
+            backup: backup.into(),
+        }
+    }
+
+    /// The reported bug: toggling/changing the *other* slot must not reconnect the live
+    /// connection; only a change to the server we're on (or disabling it) should.
+    #[test]
+    fn reconnect_needed_only_when_current_server_is_affected() {
+        use ElectrumEnabled::{All, None, PrimaryOnly};
+        let (p, b) = ("tcp://p:1", "tcp://b:1");
+
+        // On the PRIMARY: changes to the backup slot must NOT reconnect.
+        assert!(!reconnect_needed(false, p, &cfg(All, p, b)));
+        assert!(!reconnect_needed(false, p, &cfg(PrimaryOnly, p, b))); // disable backup
+        assert!(!reconnect_needed(false, p, &cfg(All, p, "tcp://b:2"))); // backup url changed
+                                                                         // On the PRIMARY: changes that affect it DO reconnect.
+        assert!(reconnect_needed(false, p, &cfg(None, p, b))); // all off
+        assert!(reconnect_needed(false, p, &cfg(All, "tcp://p:2", b))); // primary url changed
+
+        // On the BACKUP (only reachable with All): symmetric.
+        assert!(!reconnect_needed(true, b, &cfg(All, p, b)));
+        assert!(!reconnect_needed(true, b, &cfg(All, "tcp://p:2", b))); // primary url changed → backup unaffected
+        assert!(reconnect_needed(true, b, &cfg(PrimaryOnly, p, b))); // backup disabled
+        assert!(reconnect_needed(true, b, &cfg(All, p, "tcp://b:2"))); // backup url changed
+        assert!(reconnect_needed(true, b, &cfg(None, p, b))); // all off
+    }
+
+    /// The lazy/disabled invariant has a single home: `should_connect` (which `ConnLoop`'s
+    /// idle gate and `connect` guard both delegate to). We connect only when started AND at
+    /// least one server is enabled.
+    #[test]
+    fn should_connect_requires_started_and_enabled() {
+        let (mut handler, tx, _rx) =
+            make_handler(cfg(ElectrumEnabled::All, "tcp://p:1", "tcp://b:1"));
+        assert!(handler.should_connect(), "started + enabled");
+
+        tx.send_modify(|c| c.enabled = ElectrumEnabled::None);
+        assert!(!handler.should_connect(), "disabled → never connect (lazy)");
+
+        tx.send_modify(|c| c.enabled = ElectrumEnabled::PrimaryOnly);
+        handler.started = false;
+        assert!(
+            !handler.should_connect(),
+            "not started → never connect (lazy)"
+        );
+    }
+
+    /// musdom's bug: with a broken primary and a working backup (`enabled = All`), establish
+    /// must complete the primary→backup failover. `establish` does not watch `req_recv`, so a
+    /// benign control message cannot abort it — only the result of the failover (here, the
+    /// working backup) decides the outcome.
+    #[tokio::test]
+    async fn establish_fails_over_to_backup_when_primary_broken() {
+        let primary = refused_url().await; // broken
+        let backup = spawn_fake_signet_server().await; // working
+        let (mut handler, _tx, mut config_rx) = make_handler(ElectrumConfig {
+            enabled: ElectrumEnabled::All,
+            primary,
+            backup,
+        });
+
+        assert!(
+            matches!(
+                handler.establish(&mut config_rx).await,
+                Establish::Connected(..)
+            ),
+            "establish should fail over to the working backup when the primary is broken"
+        );
+    }
+
+    /// The complement: a change to the desired target (here, disabling) during an in-flight
+    /// connect DOES interrupt it — so the fix doesn't over-correct into "nothing interrupts".
+    #[tokio::test]
+    async fn target_change_interrupts_in_flight_connect() {
+        let primary = spawn_hanging_server().await; // slow-broken: keeps the connect in flight
+        let backup = spawn_hanging_server().await; // also slow, so establish can't finish on its own
+        let (mut handler, tx, mut config_rx) = make_handler(ElectrumConfig {
+            enabled: ElectrumEnabled::All,
+            primary,
+            backup,
+        });
+
+        // Disable mid-connect, well before either server's connect timeout.
+        tokio::spawn({
+            let tx = tx.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                tx.send_modify(|c| c.enabled = ElectrumEnabled::None);
+            }
+        });
+
+        assert!(
+            matches!(
+                handler.establish(&mut config_rx).await,
+                Establish::TargetChanged
+            ),
+            "a target change (disable) should interrupt an in-flight connect"
+        );
+        drop(tx);
+    }
+
+    /// adam's bug: a server that connects (passes the probe) but fails its session must be
+    /// rotated away from — the next attempt should prefer the OTHER server, not retry the
+    /// failed one (which keeps passing the probe).
+    #[tokio::test]
+    async fn after_session_failure_rotates_to_the_other_server() {
+        let primary = spawn_fake_signet_server().await; // passes the probe; would be tried first
+        let backup = spawn_fake_signet_server().await; // also works
+        let (mut handler, _tx, _rx) = make_handler(ElectrumConfig {
+            enabled: ElectrumEnabled::All,
+            primary,
+            backup: backup.clone(),
+        });
+
+        // We were connected to the primary (on_backup = false) and its session failed.
+        handler.prefer_other_server(false);
+
+        // Despite the primary still being connectable, the next attempt rotates to the backup.
+        let (_conn, info) = handler.try_connect().await.expect("should connect");
+        assert_eq!(
+            info.url, backup,
+            "after a primary session failure the next connect should rotate to the backup"
+        );
     }
 }

--- a/frostsnap_coordinator/src/bitcoin/status_tracker.rs
+++ b/frostsnap_coordinator/src/bitcoin/status_tracker.rs
@@ -1,70 +1,170 @@
-use super::chain_sync::{ChainStatus, ChainStatusState};
-use crate::settings::ElectrumEnabled;
+use tokio::sync::watch;
+
+use super::chain_sync::{ChainStatus, ChainStatusState, ElectrumConfig};
 use crate::Sink;
 
-/// Manages chain status tracking and updates - single source of truth
+/// The connection's observable lifecycle phase — the single source of truth for status.
+/// `ChainStatus` is a pure projection of this plus the config; `state` and `on_backup` are
+/// never maintained independently, so they cannot disagree.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum ConnPhase {
+    Idle,
+    Connecting { on_backup: bool },
+    Connected { on_backup: bool },
+    Disconnected,
+}
+
+impl ConnPhase {
+    fn on_backup(self) -> bool {
+        matches!(
+            self,
+            ConnPhase::Connecting { on_backup: true } | ConnPhase::Connected { on_backup: true }
+        )
+    }
+
+    fn state(self) -> ChainStatusState {
+        match self {
+            ConnPhase::Idle => ChainStatusState::Idle,
+            ConnPhase::Connecting { .. } => ChainStatusState::Connecting,
+            ConnPhase::Connected { .. } => ChainStatusState::Connected,
+            ConnPhase::Disconnected => ChainStatusState::Disconnected,
+        }
+    }
+}
+
+/// Projects the connection phase + config into `ChainStatus` and emits it to the UI sink.
+/// Holds no status replica beyond the current phase — `state`, `on_backup` and the urls are
+/// all derived. Emission is deduped: an identical successive status is not re-sent.
 pub struct StatusTracker {
-    current: ChainStatus,
-    enabled: ElectrumEnabled,
+    phase: ConnPhase,
+    last_emitted: Option<ChainStatus>,
+    config_rx: watch::Receiver<ElectrumConfig>,
     sink: Box<dyn Sink<ChainStatus>>,
 }
 
 impl StatusTracker {
-    pub fn new(initial_status: ChainStatus) -> Self {
+    pub fn new(config_rx: watch::Receiver<ElectrumConfig>) -> Self {
         Self {
-            current: initial_status,
-            enabled: ElectrumEnabled::default(),
+            phase: ConnPhase::Idle,
+            last_emitted: None,
+            config_rx,
             sink: Box::new(()),
         }
     }
 
     pub fn set_sink(&mut self, new_sink: Box<dyn Sink<ChainStatus>>) {
         self.sink = new_sink;
-        self.sink.send(self.current.clone());
+        // A fresh subscriber must see the current status even if it equals the last one we
+        // emitted to the previous sink, so bypass the dedupe here.
+        let status = self.project();
+        self.last_emitted = Some(status.clone());
+        self.sink.send(status);
+    }
+
+    fn project(&self) -> ChainStatus {
+        let config = self.config_rx.borrow();
+        ChainStatus {
+            primary_url: config.primary.clone(),
+            backup_url: config.backup.clone(),
+            on_backup: self.phase.on_backup(),
+            state: self.phase.state(),
+        }
     }
 
     fn emit(&mut self) {
-        self.sink.send(self.current.clone());
+        let status = self.project();
+        if self.last_emitted.as_ref() == Some(&status) {
+            return;
+        }
+        self.last_emitted = Some(status.clone());
+        self.sink.send(status);
     }
 
-    pub fn current(&self) -> &ChainStatus {
-        &self.current
-    }
-
-    pub fn set_state(&mut self, state: ChainStatusState) {
-        self.current.state = state;
+    /// Set the connection phase and emit the projected status (deduped). The sole status
+    /// mutator: status changes only by moving the connection through its phases.
+    pub(super) fn set_phase(&mut self, phase: ConnPhase) {
+        self.phase = phase;
         self.emit();
     }
 
-    pub fn set_state_and_server(&mut self, state: ChainStatusState, on_backup: bool) {
-        self.current.state = state;
-        self.current.on_backup = on_backup;
+    /// Re-project and emit after a config-url change (phase unchanged); deduped, so a config
+    /// change that doesn't alter the displayed status is silent.
+    pub fn refresh(&mut self) {
         self.emit();
     }
+}
 
-    pub fn set_urls(&mut self, primary: String, backup: String) {
-        self.current.primary_url = primary;
-        self.current.backup_url = backup;
-        self.emit();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::ElectrumEnabled;
+    use std::sync::{Arc, Mutex};
+
+    struct Recorder(Arc<Mutex<Vec<ChainStatus>>>);
+    impl Sink<ChainStatus> for Recorder {
+        fn send(&self, status: ChainStatus) {
+            self.0.lock().unwrap().push(status);
+        }
     }
 
-    pub fn set_enabled(&mut self, enabled: ElectrumEnabled) {
-        self.enabled = enabled;
+    fn tracker(
+        log: Arc<Mutex<Vec<ChainStatus>>>,
+    ) -> (StatusTracker, watch::Sender<ElectrumConfig>) {
+        let (tx, rx) = watch::channel(ElectrumConfig {
+            enabled: ElectrumEnabled::All,
+            primary: "tcp://p:1".into(),
+            backup: "tcp://b:1".into(),
+        });
+        let mut tracker = StatusTracker::new(rx);
+        tracker.set_sink(Box::new(Recorder(log))); // emits the initial Idle
+        (tracker, tx)
     }
 
-    pub fn primary_url(&self) -> &str {
-        &self.current.primary_url
+    /// `ChainStatus` is a total projection of the phase (+ config urls): every phase maps to
+    /// the right `state` + `on_backup`, and the urls always come from the config.
+    #[test]
+    fn projects_phase_to_status() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let (mut t, _tx) = tracker(log.clone());
+
+        t.set_phase(ConnPhase::Connecting { on_backup: true });
+        t.set_phase(ConnPhase::Connected { on_backup: false });
+        t.set_phase(ConnPhase::Disconnected);
+        t.set_phase(ConnPhase::Idle);
+
+        let log = log.lock().unwrap();
+        let observed: Vec<_> = log.iter().map(|s| (s.state, s.on_backup)).collect();
+        assert_eq!(
+            observed,
+            vec![
+                (ChainStatusState::Idle, false), // initial, from set_sink
+                (ChainStatusState::Connecting, true),
+                (ChainStatusState::Connected, false),
+                (ChainStatusState::Disconnected, false),
+                (ChainStatusState::Idle, false),
+            ]
+        );
+        assert_eq!(log[1].primary_url, "tcp://p:1");
+        assert_eq!(log[1].backup_url, "tcp://b:1");
     }
 
-    pub fn backup_url(&self) -> &str {
-        &self.current.backup_url
-    }
+    /// Identical successive statuses are not re-emitted; a config-url change re-emits.
+    #[test]
+    fn dedupes_identical_status() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let (mut t, tx) = tracker(log.clone());
+        let base = log.lock().unwrap().len(); // 1: the initial Idle
 
-    pub fn enabled(&self) -> ElectrumEnabled {
-        self.enabled
-    }
+        t.set_phase(ConnPhase::Connected { on_backup: false });
+        t.set_phase(ConnPhase::Connected { on_backup: false }); // identical → no emit
+        assert_eq!(log.lock().unwrap().len(), base + 1);
 
-    pub fn on_backup(&self) -> bool {
-        self.current.on_backup
+        t.refresh(); // no url change → no emit
+        assert_eq!(log.lock().unwrap().len(), base + 1);
+
+        tx.send_modify(|c| c.primary = "tcp://p:2".into());
+        t.refresh(); // urls changed → emit
+        assert_eq!(log.lock().unwrap().len(), base + 2);
+        assert_eq!(log.lock().unwrap().last().unwrap().primary_url, "tcp://p:2");
     }
 }

--- a/frostsnap_coordinator/src/bitcoin/tofu/connection.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/connection.rs
@@ -131,18 +131,18 @@ impl Conn {
                 check_conn(&mut rh, &mut wh, genesis_hash)
                     .await
                     .map_err(TofuError::Other)
-                    .inspect_err(|e| tracing::error!("Network check failed: {:?}", e))?;
+                    .inspect_err(|e| tracing::error!(url, "Network check failed: {e}"))?;
                 Ok(Conn::Ssl((rh, wh)))
             } else {
                 let sock = happy_eyeballs_connect(&socket_addr).await.map_err(|e| {
-                    tracing::error!("TCP connection failed to {}: {}", socket_addr, e);
+                    tracing::error!(url, "TCP connection failed: {e}");
                     TofuError::Other(e.into())
                 })?;
                 let (mut rh, mut wh) = tokio::io::split(sock);
                 check_conn(&mut rh, &mut wh, genesis_hash)
                     .await
                     .map_err(TofuError::Other)
-                    .inspect_err(|e| tracing::error!("Network check failed: {:?}", e))?;
+                    .inspect_err(|e| tracing::error!(url, "Network check failed: {e}"))?;
                 Ok(Conn::Tcp((rh, wh)))
             }
         }
@@ -152,13 +152,17 @@ impl Conn {
         let timeout_fut = tokio::time::sleep(timeout).fuse();
         pin_mut!(timeout_fut);
 
-        select! {
+        let result = select! {
             conn_res = connect_fut => conn_res,
-            _ = timeout_fut => {
-                tracing::error!("Connection to {} timed out after {:?}", url, timeout);
-                Err(TofuError::Other(anyhow!("Timed out")))
-            },
-        }
+            _ = timeout_fut => Err(TofuError::Other(anyhow!("timed out after {timeout:?}"))),
+        };
+
+        // Attribute every failure to its server so the url travels with the error itself
+        // (not just the log line), regardless of which path produced it.
+        result.map_err(|err| match err {
+            TofuError::Other(e) => TofuError::Other(e.context(format!("connecting to {url}"))),
+            not_trusted => not_trusted,
+        })
     }
 }
 
@@ -292,6 +296,33 @@ pub struct TargetServerReq {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    #[ignore] // requires network
+    async fn test_real_signet_server_via_our_stack() {
+        use crate::persist::Persisted;
+        use bdk_chain::bitcoin::{constants::genesis_block, params::Params, Network};
+
+        // Defaults to the shipped signet primary; override with SIGNET_URL to vet other servers.
+        let url = std::env::var("SIGNET_URL")
+            .unwrap_or_else(|_| "tcp://signet.musdomworks.com:50001".into());
+        let mut db = rusqlite::Connection::open_in_memory().unwrap();
+        let mut certs = Persisted::<TrustedCertificates>::new(&mut db, Network::Signet).unwrap();
+        let genesis = genesis_block(Params::new(Network::Signet)).block_hash();
+
+        match Conn::new(genesis, &url, Duration::from_secs(10), &mut certs).await {
+            Ok(_) => println!(
+                "OK: {url} connected, PKI-valid cert (no TOFU prompt), signet genesis matched"
+            ),
+            Err(TofuError::NotTrusted(c)) => {
+                panic!(
+                    "{url}: cert not PKI-valid, would TOFU-prompt (fingerprint {})",
+                    c.fingerprint
+                )
+            }
+            Err(TofuError::Other(e)) => panic!("{url}: FAILED via our stack: {e:?}"),
+        }
+    }
 
     #[tokio::test]
     #[ignore] // requires network

--- a/frostsnapp/rust/src/api/settings.rs
+++ b/frostsnapp/rust/src/api/settings.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use bitcoin::constants::genesis_block;
 use bitcoin::Network as BitcoinNetwork;
 use flutter_rust_bridge::frb;
-use frostsnap_coordinator::bitcoin::chain_sync::{ChainClient, SUPPORTED_NETWORKS};
+use frostsnap_coordinator::bitcoin::chain_sync::{ChainClient, ElectrumConfig, SUPPORTED_NETWORKS};
 pub use frostsnap_coordinator::bitcoin::chain_sync::{
     ChainStatus, ChainStatusState, ConnectionResult,
 };
@@ -67,8 +67,11 @@ impl Settings {
         let mut chain_apis = HashMap::new();
 
         for network in SUPPORTED_NETWORKS {
-            let electrum_url = persisted.get_electrum_server(network);
-            let backup_electrum_url = persisted.get_backup_electrum_server(network);
+            let electrum_config = ElectrumConfig {
+                enabled: persisted.get_electrum_enabled(network),
+                primary: persisted.get_electrum_server(network),
+                backup: persisted.get_backup_electrum_server(network),
+            };
 
             let genesis_hash = genesis_block(bitcoin::params::Params::new(network)).block_hash();
 
@@ -80,36 +83,35 @@ impl Settings {
                 Persisted::<TrustedCertificates>::new(&mut *db_, network)?
             };
 
-            let (chain_api, conn_handler) =
-                ChainClient::new(genesis_hash, trusted_certificates, db.clone());
+            let (chain_api, conn_handler) = ChainClient::new(
+                genesis_hash,
+                electrum_config,
+                trusted_certificates,
+                db.clone(),
+            );
             let super_wallet =
                 SuperWallet::load_or_new(&app_directory, network, chain_api.clone())?;
             // FIXME: the dependency relationship here is overly convoluted.
             thread::spawn({
                 let super_wallet = super_wallet.clone();
                 move || {
-                    conn_handler.run(
-                        electrum_url,
-                        backup_electrum_url,
-                        super_wallet.inner.clone(),
-                        {
-                            let wallet_streams = super_wallet.wallet_streams.clone();
-                            move |master_appkey, txs| {
-                                let wallet_streams = wallet_streams.lock().unwrap();
-                                if let Some(stream) = wallet_streams.get(&master_appkey) {
-                                    if let Err(err) = stream.add(txs.into()) {
-                                        tracing::error!(
-                                            {
-                                                master_appkey = master_appkey.to_redacted_string(),
-                                                err = err.to_string(),
-                                            },
-                                            "Failed to add txs to stream"
-                                        );
-                                    }
+                    conn_handler.run(super_wallet.inner.clone(), {
+                        let wallet_streams = super_wallet.wallet_streams.clone();
+                        move |master_appkey, txs| {
+                            let wallet_streams = wallet_streams.lock().unwrap();
+                            if let Some(stream) = wallet_streams.get(&master_appkey) {
+                                if let Err(err) = stream.add(txs.into()) {
+                                    tracing::error!(
+                                        {
+                                            master_appkey = master_appkey.to_redacted_string(),
+                                            err = err.to_string(),
+                                        },
+                                        "Failed to add txs to stream"
+                                    );
                                 }
                             }
-                        },
-                    )
+                        }
+                    })
                 }
             });
             loaded_wallets.insert(network, super_wallet);
@@ -204,16 +206,22 @@ impl Settings {
 
         match chain_api.check_and_set_electrum_server_url(url.clone(), is_backup)? {
             ConnectionResult::Success => {
-                // Connection succeeded, persist the setting
-                let mut db = self.db.lock().unwrap();
-                self.settings.mutate2(&mut *db, |settings, update| {
-                    if is_backup {
-                        settings.set_backup_electrum_server(network, url, update);
-                    } else {
-                        settings.set_electrum_server(network, url, update);
-                    }
-                    Ok(())
-                })?;
+                // Persist first — the persisted config is authoritative — then push the new
+                // url into the live watch (which triggers a reconnect) and emit. Ordering it
+                // this way means a persistence failure never leaves the handler on a url that
+                // wasn't saved.
+                {
+                    let mut db = self.db.lock().unwrap();
+                    self.settings.mutate2(&mut *db, |settings, update| {
+                        if is_backup {
+                            settings.set_backup_electrum_server(network, url.clone(), update);
+                        } else {
+                            settings.set_electrum_server(network, url.clone(), update);
+                        }
+                        Ok(())
+                    })?;
+                }
+                chain_api.set_electrum_url(url, is_backup);
                 self.emit_electrum_settings();
                 Ok(ConnectionResult::Success)
             }


### PR DESCRIPTION
Two commits.

## 1. Fix electrum: respect disabled state, interrupt connections, fix signet servers

With both electrum servers disabled, the coordinator kept connecting to them — on a fresh start with a persisted-disabled config, and after toggling them off at runtime.

Root causes:
- the connection handler's enabled state was never initialized from persisted settings (it defaulted to "all")
- the connect attempt and reconnect backoff didn't poll the control channel, so a disable could never interrupt them

Changes:
- initialize the handler's enabled state from persisted settings at startup → restart-with-disabled never attempts a connection
- race the connect attempt and reconnect backoff against control messages → disabling (or a url change / reconnect) interrupts an in-flight or retrying attempt instead of churning through every server
- attribute connection failures to their server url at the `Conn::new` boundary, so the url travels in the error value, not just the log line
- replace the broken signet defaults: primary `tcp://signet.musdomworks.com:50001`, backup `ssl://mempool.space:60602` (the old defaults were down / rate-limited)

## 2. Refactor electrum config into a single `tokio::sync::watch` subject

The fix above left the settings-derived desired state (enabled + primary/backup urls) duplicated: authoritative in `Settings`, replicated in `StatusTracker`, kept in sync by a startup snapshot plus `SetEnabled`/`SetUrls` messages.

Model it as one `tokio::sync::watch<ElectrumConfig>` shared api→handler: the api writes it, the handler queries it (`should_connect` / `try_connect` read `config_rx.borrow()`) and reacts to its change signal (`config_rx.changed()` preempts idle/connect/backoff/connected and re-emits status with fresh urls). Deletes `Message::SetEnabled`, `Message::SetUrls`, the startup snapshot, and the `StatusTracker` replicas; `ChangeUrlReq` becomes probe-only with the api updating the config on success — removing the duplication that made the startup ordering race possible.

## Testing

- `cargo check` + `cargo test` on `frostsnap_coordinator` and `rust_lib_frostsnapp`
- an ignored network test verifies a signet server connects through the real `Conn::new` (rustls + TOFU + genesis check)
- manually verified on signet: connects via the primary, disabling both servers stops/interrupts attempts immediately, restart-with-disabled never connects, re-enabling / changing a url reconnects
