### PR TITLE
[app] Fix duplicate-name false positive when a freed name is reused after disconnect

### DIFF
--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -504,13 +504,8 @@ impl<'a> DeviceLoop<'a> {
                             new_name: preview_name.clone(),
                         });
                     }
-                    frostsnap_comms::NameCommand::Prompt(new_name) => {
-                        self.ui
-                            .set_workflow(ui::Workflow::prompt(ui::Prompt::NewName {
-                                old_name: self.name.clone(),
-                                new_name: new_name.clone(),
-                            }));
-                    }
+                    // Retired rename command, kept only to reserve its wire slot.
+                    frostsnap_comms::NameCommand::_Prompt(_) => {}
                 },
                 CoordinatorSendBody::Core(core_message) => {
                     if matches!(
@@ -731,21 +726,6 @@ impl<'a> DeviceLoop<'a> {
                             .sign_ack(*phase, &mut self.hmac_keys.share_encryption)
                             .expect("state changed while acking sign"),
                     );
-                }
-                UiEvent::NameConfirm(ref new_name) => {
-                    self.mutation_log
-                        .push(Mutation::Name(new_name.to_string()))
-                        .expect("flash write fail");
-                    self.name = Some(new_name.clone());
-                    self.update_default_workflow();
-                    self.pending_device_name = Some(new_name.clone());
-                    self.ui.set_workflow(ui::Workflow::NamingDevice {
-                        new_name: new_name.clone(),
-                    });
-                    self.upstream_connection
-                        .send_to_coordinator([DeviceSendBody::SetName {
-                            name: new_name.clone(),
-                        }]);
                 }
                 UiEvent::BackupRecorded => {
                     self.upstream_connection

--- a/device/src/frosty_ui.rs
+++ b/device/src/frosty_ui.rs
@@ -10,7 +10,6 @@ use frostsnap_widgets::{
     keygen_check::KeygenCheck,
     sign_prompt::SignTxPrompt,
     DeviceNameScreen, DynWidget, FirmwareUpgradeConfirm, FirmwareUpgradeProgress, Standby, Widget,
-    HOLD_TO_CONFIRM_TIME_MS,
 };
 
 use crate::touch_handler;
@@ -270,32 +269,6 @@ impl<'a> UserInteraction for FrostyUi<'a> {
                             confirmed: false,
                         }
                     }
-                    Prompt::NewName { old_name, new_name } => {
-                        use frostsnap_widgets::DefaultTextStyle;
-                        use frostsnap_widgets::{HoldToConfirm, Text, FONT_MED};
-
-                        // Create text for the prompt
-                        let prompt_text = if let Some(old_name) = old_name {
-                            format!("Rename device\nfrom '{}'\nto '{}'?", old_name, new_name)
-                        } else {
-                            format!("Name device\n'{}'?", new_name)
-                        };
-
-                        let text_widget = Text::new(
-                            prompt_text,
-                            DefaultTextStyle::new(FONT_MED, PALETTE.on_background),
-                        )
-                        .with_alignment(embedded_graphics::text::Alignment::Center);
-
-                        // Create HoldToConfirm widget with 2 second hold time
-                        let hold_to_confirm =
-                            HoldToConfirm::new(HOLD_TO_CONFIRM_TIME_MS, text_widget);
-
-                        WidgetTree::NewNamePrompt {
-                            widget: Box::new(hold_to_confirm),
-                            new_name: Some(new_name.clone()),
-                        }
-                    }
                     Prompt::EraseDevice => {
                         use frostsnap_widgets::EraseDevice;
 
@@ -497,11 +470,6 @@ impl<'a> UserInteraction for FrostyUi<'a> {
                     phase,
                     share_backup,
                 });
-            }
-            WidgetTree::NewNamePrompt { widget, new_name } if widget.is_confirmed() => {
-                if let Some(name) = new_name.take() {
-                    return Some(UiEvent::NameConfirm(name));
-                }
             }
             WidgetTree::EraseDevicePrompt { widget, confirmed } => {
                 if !widget.is_confirmed() || *confirmed {

--- a/device/src/ui.rs
+++ b/device/src/ui.rs
@@ -114,10 +114,6 @@ pub enum Prompt {
         phase: Box<SignPhase1>,
         rand_seed: u32,
     },
-    NewName {
-        old_name: Option<DeviceName>,
-        new_name: DeviceName,
-    },
     ConfirmFirmwareUpgrade {
         firmware_digest: Sha256Digest,
         size: u32,
@@ -149,7 +145,6 @@ pub enum UiEvent {
     SigningConfirm {
         phase: Box<SignPhase1>,
     },
-    NameConfirm(frostsnap_comms::DeviceName),
     EnteredShareBackup {
         phase: EnterBackupPhase,
         share_backup: ShareBackup,

--- a/device/src/widget_tree.rs
+++ b/device/src/widget_tree.rs
@@ -10,7 +10,7 @@ use frostsnap_widgets::{
     layout::*,
     sign_prompt::SignTxPrompt,
     DeviceNameScreen, EraseDevice, EraseProgress, FirmwareUpgradeConfirm, FirmwareUpgradeProgress,
-    HoldToConfirm, SignMessageConfirm, Standby, Text,
+    SignMessageConfirm, Standby,
 };
 
 use crate::ui::FirmwareUpgradeStatus;
@@ -55,12 +55,6 @@ pub enum WidgetTree {
     FirmwareUpgradeProgress {
         widget: Box<FirmwareUpgradeProgress>,
         status: FirmwareUpgradeStatus,
-    },
-
-    /// New name confirmation prompt
-    NewNamePrompt {
-        widget: Box<HoldToConfirm<Text>>,
-        new_name: Option<frostsnap_comms::DeviceName>,
     },
 
     /// Device erase confirmation prompt

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -297,7 +297,10 @@ pub enum CoordinatorUpgradeMessage {
 #[derive(Encode, Decode, Debug, Clone)]
 pub enum NameCommand {
     Preview(DeviceName),
-    Prompt(DeviceName),
+    /// Retired standalone-rename command. Never deleted or reordered: keeping it
+    /// reserves this bincode index so a future variant can't take the slot and be
+    /// misdecoded as a rename by old firmware. Nothing sends it; devices ignore it.
+    _Prompt(DeviceName),
 }
 
 impl Gist for CoordinatorSendBody {

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -776,21 +776,6 @@ impl UsbSender {
             .expect("receiver exists");
     }
 
-    pub fn finish_naming(&self, device_id: DeviceId, name: DeviceName) {
-        event!(
-            Level::INFO,
-            name = %name,
-            device_id = device_id.to_string(),
-            "Named device"
-        );
-        self.sender
-            .send(CoordinatorSendMessage::to(
-                device_id,
-                CoordinatorSendBody::Naming(frostsnap_comms::NameCommand::Prompt(name)),
-            ))
-            .expect("receiver exists");
-    }
-
     pub fn send(&self, message: CoordinatorSendMessage) {
         self.sender.send(message).expect("receiver exists")
     }

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -51,6 +51,34 @@ class WalletCreateForm {
       selectedDevices.every((id) => deviceNames.containsKey(id));
 }
 
+/// The ids in [names] whose chosen name collides (case-insensitively, after
+/// trimming) with another named device, considering only devices in
+/// [participants].
+///
+/// [names] is retained across disconnects, so an entry may name a device that is
+/// no longer part of the keygen. Restricting the comparison to [participants]
+/// (the currently connected devices) means a name freed by a disconnected device
+/// can be reused by a remaining device without a false collision.
+Set<DeviceId> duplicateNamedDeviceIdsAmong(
+  Set<DeviceId> participants,
+  Map<DeviceId, String> names,
+) {
+  final counts = <String, int>{};
+  for (final entry in names.entries) {
+    if (!participants.contains(entry.key)) continue;
+    final key = entry.value.trim().toLowerCase();
+    if (key.isEmpty) continue;
+    counts.update(key, (c) => c + 1, ifAbsent: () => 1);
+  }
+  final dups = deviceIdSet([]);
+  names.forEach((id, name) {
+    if (!participants.contains(id)) return;
+    final key = name.trim().toLowerCase();
+    if (key.isNotEmpty && (counts[key] ?? 0) > 1) dups.add(id);
+  });
+  return dups;
+}
+
 class WalletCreateController extends ChangeNotifier {
   WalletCreateStep _step = WalletCreateStep.values.first;
   final WalletCreateForm _form = WalletCreateForm();
@@ -331,21 +359,13 @@ class WalletCreateController extends ChangeNotifier {
 
   /// Device ids whose chosen name collides (case-insensitively, after
   /// trimming) with another device being named in this keygen. Two devices in
-  /// the same wallet must not share a name, so these block advancing.
-  Set<DeviceId> get duplicateNamedDeviceIds {
-    final counts = <String, int>{};
-    for (final name in _form.deviceNames.values) {
-      final key = name.trim().toLowerCase();
-      if (key.isEmpty) continue;
-      counts.update(key, (c) => c + 1, ifAbsent: () => 1);
-    }
-    final dups = deviceIdSet([]);
-    _form.deviceNames.forEach((id, name) {
-      final key = name.trim().toLowerCase();
-      if (key.isNotEmpty && (counts[key] ?? 0) > 1) dups.add(id);
-    });
-    return dups;
-  }
+  /// the same wallet must not share a name, so these block advancing. Only the
+  /// currently connected devices ([_deviceList]) participate — a name retained
+  /// from a since-disconnected device must not block a remaining device.
+  Set<DeviceId> get duplicateNamedDeviceIds => duplicateNamedDeviceIdsAmong(
+    deviceIdSet(_deviceList.devices.map((dev) => dev.id)),
+    _form.deviceNames,
+  );
 
   bool get hasDuplicateDeviceNames => duplicateNamedDeviceIds.isNotEmpty;
 

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -801,47 +801,6 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
 
   final Map<DeviceId, TextEditingController> _nameControllers = deviceIdMap();
 
-  void showRenameDeviceDialog(
-    BuildContext context,
-    ConnectedDevice device,
-  ) async {
-    await showBottomSheetOrDialog(
-      context,
-      title: Text("Name device"),
-      builder: (context, _) {
-        final mediaQuery = MediaQuery.of(context);
-        return SafeArea(
-          minimum: const EdgeInsets.symmetric(
-            horizontal: 20,
-          ).copyWith(bottom: 32 + mediaQuery.viewInsets.bottom, top: 32),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            spacing: 12,
-            children: [
-              TextFormField(
-                autofocus: true,
-                decoration: InputDecoration(
-                  border: OutlineInputBorder(),
-                  labelText: 'Device Name',
-                ),
-                maxLength: DeviceName.maxLength(),
-                inputFormatters: [nameInputFormatter],
-                initialValue: _controller.form.deviceNames[device.id],
-                onChanged: (name) => _controller.setDeviceName(device.id, name),
-                onFieldSubmitted: (_) => Navigator.pop(context),
-              ),
-              FilledButton(
-                onPressed: () => Navigator.pop(context),
-                child: Text('Done'),
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
   Widget _inlineNameField(BuildContext context, ConnectedDevice device) {
     final cs = Theme.of(context).colorScheme;
     final currentName = _controller.form.deviceNames[device.id] ?? '';

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -318,6 +318,7 @@ class WalletCreateController extends ChangeNotifier {
           !devicesNeedUpgrade &&
           !devicesUsed &&
           !devicesIncompatible &&
+          !hasDuplicateDeviceNames &&
           _deviceList.devices.every((d) => _form.deviceNames.containsKey(d.id)),
     WalletCreateStep.nonceReplenish => false, // Auto-advances, no manual next
     WalletCreateStep.threshold =>
@@ -327,6 +328,26 @@ class WalletCreateController extends ChangeNotifier {
           _form.threshold! <= _form.selectedDevices.length,
   };
   bool get canGoBack => _step.index != 0;
+
+  /// Device ids whose chosen name collides (case-insensitively, after
+  /// trimming) with another device being named in this keygen. Two devices in
+  /// the same wallet must not share a name, so these block advancing.
+  Set<DeviceId> get duplicateNamedDeviceIds {
+    final counts = <String, int>{};
+    for (final name in _form.deviceNames.values) {
+      final key = name.trim().toLowerCase();
+      if (key.isEmpty) continue;
+      counts.update(key, (c) => c + 1, ifAbsent: () => 1);
+    }
+    final dups = deviceIdSet([]);
+    _form.deviceNames.forEach((id, name) {
+      final key = name.trim().toLowerCase();
+      if (key.isNotEmpty && (counts[key] ?? 0) > 1) dups.add(id);
+    });
+    return dups;
+  }
+
+  bool get hasDuplicateDeviceNames => duplicateNamedDeviceIds.isNotEmpty;
 
   bool setNetwork(BitcoinNetwork network) {
     if (_asRef != null) return false;
@@ -828,6 +849,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
       device.id,
       () => TextEditingController(text: currentName),
     );
+    final isDuplicate = _controller.duplicateNamedDeviceIds.contains(device.id);
     return TextField(
       controller: textController,
       style: monospaceTextStyle,
@@ -840,6 +862,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
         isDense: true,
         contentPadding: EdgeInsets.zero,
         counterText: '',
+        errorText: isDuplicate ? 'Name already used in this wallet' : null,
       ),
       onChanged: (name) => _controller.setDeviceName(device.id, name),
     );

--- a/frostsnapp/rust/src/api/coordinator.rs
+++ b/frostsnapp/rust/src/api/coordinator.rs
@@ -166,10 +166,6 @@ impl Coordinator {
         self.0.update_name_preview(id, &name)
     }
 
-    pub fn finish_naming(&self, id: DeviceId, name: String) -> Result<()> {
-        self.0.finish_naming(id, &name)
-    }
-
     pub fn send_cancel(&self, id: DeviceId) {
         event!(Level::WARN, "dart sent cancel");
         self.0.send_cancel(id);

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -364,12 +364,6 @@ impl FfiCoordinator {
         Ok(())
     }
 
-    pub fn finish_naming(&self, id: DeviceId, name: &str) -> anyhow::Result<()> {
-        let device_name: frostsnap_coordinator::frostsnap_comms::DeviceName = name.try_into()?;
-        self.usb_sender.finish_naming(id, device_name);
-        Ok(())
-    }
-
     pub fn send_cancel(&self, id: DeviceId) {
         self.usb_sender.send_cancel(id)
     }

--- a/frostsnapp/test/wallet_create_duplicate_name_test.dart
+++ b/frostsnapp/test/wallet_create_duplicate_name_test.dart
@@ -1,0 +1,84 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frostsnap/id_ext.dart';
+import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/src/rust/lib.dart';
+import 'package:frostsnap/wallet_create.dart';
+
+// Regression guard for PR #505's duplicate-device-name check (the false positive fixed here).
+// The wallet-create form retains a device's typed name after it disconnects, but only the
+// currently connected devices are participants in the keygen. `duplicateNamedDeviceIdsAmong`
+// must therefore count collisions over the live participants alone — otherwise a name freed by
+// a disconnected device would falsely flag a remaining device that reuses it, jamming Continue.
+
+DeviceId deviceId(int seed) {
+  final bytes = Uint8List(33);
+  bytes[0] = seed; // distinct first byte => distinct id
+  return DeviceId(field0: U8Array33(bytes));
+}
+
+void main() {
+  group('duplicateNamedDeviceIdsAmong', () {
+    final a = deviceId(1);
+    final b = deviceId(2);
+
+    Map<DeviceId, String> names(Map<DeviceId, String> entries) {
+      final map = deviceIdMap<String>();
+      map.addAll(entries);
+      return map;
+    }
+
+    test(
+      'a name freed by a disconnected device can be reused (the #505 bug)',
+      () {
+        // A was named "Cold", then A left the device list; B (still connected)
+        // reuses "Cold". A's retained entry must not flag B.
+        final participants = deviceIdSet([b]); // only B is connected now
+        final dups = duplicateNamedDeviceIdsAmong(
+          participants,
+          names({a: 'Cold', b: 'Cold'}),
+        );
+        expect(dups, isEmpty);
+      },
+    );
+
+    test('two currently-connected devices sharing a name are both flagged', () {
+      final participants = deviceIdSet([a, b]);
+      final dups = duplicateNamedDeviceIdsAmong(
+        participants,
+        names({a: 'Cold', b: 'Cold'}),
+      );
+      expect(dups.length, 2);
+      expect(dups.contains(a), isTrue);
+      expect(dups.contains(b), isTrue);
+    });
+
+    test('the collision is case-insensitive and trims whitespace', () {
+      final participants = deviceIdSet([a, b]);
+      final dups = duplicateNamedDeviceIdsAmong(
+        participants,
+        names({a: 'Cold', b: '  cOLD '}),
+      );
+      expect(dups.length, 2);
+    });
+
+    test('distinct names among connected devices are not flagged', () {
+      final participants = deviceIdSet([a, b]);
+      final dups = duplicateNamedDeviceIdsAmong(
+        participants,
+        names({a: 'Cold', b: 'Hot'}),
+      );
+      expect(dups, isEmpty);
+    });
+
+    test('an empty or whitespace-only name never collides', () {
+      final participants = deviceIdSet([a, b]);
+      final dups = duplicateNamedDeviceIdsAmong(
+        participants,
+        names({a: '', b: '   '}),
+      );
+      expect(dups, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
A fix for the duplicate-device-name check in #505, targeted at that PR's branch so it can be folded in.

### The bug
`WalletCreateController.duplicateNamedDeviceIds` counts name collisions over every retained entry in `_form.deviceNames`. That map keeps a device's typed name **after it disconnects**, while only the currently connected devices participate in keygen. So: name device A "Cold" → unplug A → reuse "Cold" on a remaining device → a false *"Name already used in this wallet"* blocks Continue even though only one connected device is named "Cold".

**Before (bug):**
![before](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-505/duplicate-name-false-positive-bug.gif)

### The fix
Delegate to a pure `duplicateNamedDeviceIdsAmong(participants, names)` that counts collisions **only over the live participants** (`_deviceList.devices`). Two currently-connected devices sharing a name are still both flagged (unchanged) — only names held by *disconnected* devices stop producing a false collision.

**After (fixed):**
![after](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-505/duplicate-name-fixed-after.gif)

### Behavior note — reconnecting the original device (intentionally not optimized)
`deviceNames` retains a name across disconnects and it's **not** transferred when another device reuses it. So one edge case remains by design: name A "foo" → unplug A → name B "foo" (fine) → **plug A back in** → A and B are now both connected and both "foo", so both are flagged and you resolve it by renaming one. That's a genuine two-connected-devices-same-name conflict — flagging it (what this feature is for) is the correct outcome, so we deliberately don't make B "steal" the name from A.

### Validation
- New `frostsnapp/test/wallet_create_duplicate_name_test.dart` (5 cases: the reuse-after-disconnect false positive, the true-positive, case/trim/empty). `flutter test` → 5/5.
- `just lint-app` clean.
- Full CI (analyze, ordinary tests, all app builds, device firmware) ran green on the fork mirror `LLFourn/frostsnap#8`.
