### PR TITLE
Don't double-apply lookahead to electrum subscriptions

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -167,12 +167,12 @@ impl CoordSuperWallet {
                     .index
                     .insert_descriptor(keychain_id, descriptor)
                     .expect("two keychains must not have the same spks");
-                let lookahead = self.lookahead();
+                // the spk tracker already applies lookahead on top of this
                 let next_index = self
                     .tx_graph
                     .index
                     .last_revealed_index(keychain_id)
-                    .map_or(lookahead, |lr| lr + lookahead + 1);
+                    .map_or(0, |lr| lr + 1);
                 self.chain_client.monitor_keychain(keychain_id, next_index);
             }
             let all_txs = self


### PR DESCRIPTION
Fixes the reconnect loop on mempool.space signet (`subscription limit reached (100 max per client)`).

`bdk_electrum_streaming`'s spk tracker expects the next *unrevealed* index and [applies the lookahead itself](https://github.com/evanlinjin/experiments/blob/0d1d201057d2e30de1c2c16571e157e83d961d05/bdk_electrum_streaming/src/derived_spk_tracker.rs#L90), but we were padding the index we pass to `monitor_keychain` with lookahead too. 52 scripthashes per keychain instead of 27. A single empty key (external + internal) subscribed to 104 scripthashes, over mempool-electrs' 100-per-client limit, so the server killed the session on every (re)connect.