### PR TITLE
keygen: in-button spinner instead of the saving dialog (for #514)

### DIFF
--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -990,114 +990,163 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
 
           if (!state.allAcks) continue;
 
-          final keygenCodeMatches =
-              await showDialog<bool>(
-                context: context,
-                barrierDismissible: false,
-                builder: (context) {
-                  final theme = Theme.of(context);
-                  return BackdropFilter(
-                    filter: blurFilter,
-                    child: AlertDialog(
-                      title: Text('Final check'),
-                      content: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        spacing: 16,
-                        children: [
-                          Text('Do all devices show this code?'),
-                          Card.filled(
-                            child: Center(
-                              child: Padding(
-                                padding: EdgeInsets.symmetric(
-                                  vertical: 12,
-                                  horizontal: 16,
-                                ),
-                                child: Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    Text(
-                                      '${form.threshold}-of-${form.selectedDevices.length}',
-                                      style: theme.textTheme.labelLarge,
-                                    ),
-                                    Text(
-                                      _controller.keygenChecksum,
-                                      style: theme.textTheme.headlineLarge
-                                          ?.copyWith(
-                                            fontFamily:
-                                                monospaceTextStyle.fontFamily,
+          final deviceNames = [
+            for (final id in state.devices)
+              if (_controller.form.deviceNames[id] != null)
+                DeviceNameCommit(
+                  id: id,
+                  name: _controller.form.deviceNames[id]!,
+                ),
+          ];
+
+          // The "Final check" dialog owns the finalize itself: tapping Yes
+          // shows an in-button spinner while it saves to devices, then pops
+          // the resulting AccessStructureRef (null if the user tapped No or
+          // the save failed).
+          final asRef = await showDialog<AccessStructureRef>(
+            context: context,
+            barrierDismissible: false,
+            builder: (dialogContext) {
+              final theme = Theme.of(dialogContext);
+              var saving = false;
+              return StatefulBuilder(
+                builder: (_, setDialogState) {
+                  Future<void> finalize() async {
+                    if (saving) return;
+                    setDialogState(() => saving = true);
+                    try {
+                      final encryptionKey =
+                          await SecureKeyProvider.getEncryptionKey();
+                      final asRef = await coord.finalizeKeygen(
+                        keygenId: state.keygenId,
+                        encryptionKey: encryptionKey,
+                        deviceNames: deviceNames,
+                      );
+                      await Future<void>.delayed(const Duration(seconds: 1));
+                      if (dialogContext.mounted) {
+                        Navigator.pop(dialogContext, asRef);
+                      }
+                    } catch (e) {
+                      if (dialogContext.mounted) {
+                        Navigator.pop(dialogContext, null);
+                      }
+                      if (context.mounted) {
+                        showErrorSnackbar(
+                          context,
+                          'Failed to finalize keygen: $e',
+                        );
+                      }
+                    }
+                  }
+
+                  return PopScope(
+                    canPop: !saving,
+                    child: BackdropFilter(
+                      filter: blurFilter,
+                      child: AlertDialog(
+                        title: Text('Final check'),
+                        content: Stack(
+                          children: [
+                            Column(
+                              mainAxisSize: MainAxisSize.min,
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              spacing: 16,
+                              children: [
+                                Text('Do all devices show this code?'),
+                                Card.filled(
+                                  child: Center(
+                                    child: Padding(
+                                      padding: EdgeInsets.symmetric(
+                                        vertical: 12,
+                                        horizontal: 16,
+                                      ),
+                                      child: Column(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          Text(
+                                            '${form.threshold}-of-${form.selectedDevices.length}',
+                                            style: theme.textTheme.labelLarge,
                                           ),
+                                          Text(
+                                            _controller.keygenChecksum,
+                                            style: theme.textTheme.headlineLarge
+                                                ?.copyWith(
+                                                  fontFamily: monospaceTextStyle
+                                                      .fontFamily,
+                                                ),
+                                          ),
+                                        ],
+                                      ),
                                     ),
-                                  ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                            // Announce the saving state to screen readers while
+                            // the inline spinner runs. A zero-size Positioned.fill
+                            // overlay so it never adds height to the dialog.
+                            if (saving)
+                              Positioned.fill(
+                                child: Semantics(
+                                  container: true,
+                                  liveRegion: true,
+                                  label: 'Saving wallet to devices',
+                                  child: const SizedBox.shrink(),
                                 ),
                               ),
+                          ],
+                        ),
+                        actionsAlignment: MainAxisAlignment.spaceBetween,
+                        actions: [
+                          TextButton(
+                            onPressed: saving
+                                ? null
+                                : () => Navigator.pop(dialogContext, null),
+                            child: Text('No'),
+                          ),
+                          TextButton(
+                            onPressed: saving ? null : finalize,
+                            // The always-present (transparent) 'Yes' label is the
+                            // ONLY child that sizes the button; the spinner is a
+                            // Positioned.fill overlay, so it can never change the
+                            // button's width or height — no jump on press.
+                            child: Stack(
+                              alignment: Alignment.center,
+                              children: [
+                                Opacity(
+                                  opacity: saving ? 0 : 1,
+                                  child: const Text('Yes'),
+                                ),
+                                if (saving)
+                                  const Positioned.fill(
+                                    child: Center(
+                                      child: SizedBox.square(
+                                        dimension: 16,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                              ],
                             ),
                           ),
                         ],
                       ),
-                      actionsAlignment: MainAxisAlignment.spaceBetween,
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, false),
-                          child: Text('No'),
-                        ),
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, true),
-                          child: Text('Yes'),
-                        ),
-                      ],
                     ),
                   );
                 },
-              ) ??
-              false;
-          if (!keygenCodeMatches) {
+              );
+            },
+          );
+
+          if (asRef == null) {
             _controller._keygenState = null;
             _controller.notifyListeners();
             return;
           }
-
-          try {
-            final deviceNames = [
-              for (final id in state.devices)
-                if (_controller.form.deviceNames[id] != null)
-                  DeviceNameCommit(
-                    id: id,
-                    name: _controller.form.deviceNames[id]!,
-                  ),
-            ];
-            final result = await showDialog<_KeygenFinalizeResult>(
-              context: context,
-              barrierDismissible: false,
-              builder: (dialogContext) => _KeygenSavingDialog(
-                finalize: () async {
-                  final encryptionKey =
-                      await SecureKeyProvider.getEncryptionKey();
-                  final asRef = await coord.finalizeKeygen(
-                    keygenId: state.keygenId,
-                    encryptionKey: encryptionKey,
-                    deviceNames: deviceNames,
-                  );
-                  await Future<void>.delayed(const Duration(seconds: 1));
-                  return asRef;
-                },
-              ),
-            );
-            if (result == null) return;
-            switch (result) {
-              case _KeygenFinalizeSuccess(:final asRef):
-                _controller._asRef = asRef;
-                if (context.mounted) Navigator.pop(context, asRef);
-              case _KeygenFinalizeFailure(:final error):
-                throw error;
-            }
-          } catch (e) {
-            _controller._keygenState = null;
-            _controller.notifyListeners();
-            if (context.mounted) {
-              showErrorSnackbar(context, 'Failed to finalize keygen: $e');
-            }
-          }
+          _controller._asRef = asRef;
+          if (context.mounted) Navigator.pop(context, asRef);
           return;
         }
       } finally {
@@ -1433,76 +1482,6 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
           ),
         );
       },
-    );
-  }
-}
-
-abstract class _KeygenFinalizeResult {
-  const _KeygenFinalizeResult();
-}
-
-class _KeygenFinalizeSuccess extends _KeygenFinalizeResult {
-  final AccessStructureRef asRef;
-
-  const _KeygenFinalizeSuccess(this.asRef);
-}
-
-class _KeygenFinalizeFailure extends _KeygenFinalizeResult {
-  final Object error;
-
-  const _KeygenFinalizeFailure(this.error);
-}
-
-class _KeygenSavingDialog extends StatefulWidget {
-  final Future<AccessStructureRef> Function() finalize;
-
-  const _KeygenSavingDialog({required this.finalize});
-
-  @override
-  State<_KeygenSavingDialog> createState() => _KeygenSavingDialogState();
-}
-
-class _KeygenSavingDialogState extends State<_KeygenSavingDialog> {
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_run());
-  }
-
-  Future<void> _run() async {
-    try {
-      final asRef = await widget.finalize();
-      if (mounted) Navigator.of(context).pop(_KeygenFinalizeSuccess(asRef));
-    } catch (e) {
-      if (mounted) Navigator.of(context).pop(_KeygenFinalizeFailure(e));
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false,
-      child: AlertDialog(
-        title: const Text('Saving wallet to devices'),
-        content: Semantics(
-          label: 'Saving wallet to devices',
-          container: true,
-          liveRegion: true,
-          child: ExcludeSemantics(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: const [
-                SizedBox.square(
-                  dimension: 24,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
-                SizedBox(width: 16),
-                Flexible(child: Text('Saving wallet to devices')),
-              ],
-            ),
-          ),
-        ),
-      ),
     );
   }
 }


### PR DESCRIPTION
Implements the in-button spinner LLFourn asked for on #514 — no separate "Saving wallet to devices" dialog. Targets #514's branch; base it in and reconstruct as the signed commit when adopting (this is an unsigned experiment branch).

**Change** (`wallet_create.dart`, net −33 lines): on the "Final check → **Yes**" button, spin the Yes button in place while `getEncryptionKey → finalizeKeygen → ~1s settle` run inline, then close. Deletes the standalone `_KeygenSavingDialog` and the `_KeygenFinalizeResult`/`Success`/`Failure` classes; the dialog returns `AccessStructureRef?` directly.

**Safety (keygen-finalize path):**
- `PopScope(canPop: !saving)` so system-back can't dismiss the route mid-finalize; `barrierDismissible: false` kept.
- Re-entrancy guard — a second Yes is a no-op; both buttons disabled once saving.
- Fixed-footprint spinner (`Opacity` + `Stack`, 16px / strokeWidth 2) so the button doesn't reflow.
- `mounted` / `context.mounted` checked after every await before any pop/snackbar/setState.
- Single failure owner, exactly once: error → pop `null` + the existing `Failed to finalize keygen: $e` snackbar; the outer `asRef == null` uniformly resets keygen state for both No and failure — no retry path left open.
- Kept the `Semantics(liveRegion, label: 'Saving wallet to devices')` announcement.

**Video** (Android fsim, 1-of-1 keygen):

![in-button spinner](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-514/keygen-yes-button-spinner.gif)

Final check → tap **Yes** → "No" greys out and the "Yes" label becomes an in-place spinner (~1s) → wallet home. **Success path only** — the failure/snackbar path isn't recorded.

`flutter analyze`: **clean** on both the CI-fork base and #514's head `57378723`.

**Note for reviewers:** the existing e2e drivers `keygen_drive.dart` / `keygen_2of3_drive.dart` `waitFor('Saving wallet to devices')` still pass (that string is kept as the `Semantics` live-region label), but the separate saving *dialog* no longer appears — worth a driver comment.

Supersedes the page-step approach in #517.
