### PR TITLE
Add descriptor checksum generation

### DIFF
--- a/frost_backup/Cargo.toml
+++ b/frost_backup/Cargo.toml
@@ -13,16 +13,33 @@ rand = { workspace = true, optional = true }
 clap = { version = "4", optional = true, features = ["derive"] }
 bitcoin = { workspace = true, optional = true }
 bincode = { workspace = true, optional = true }
+miniscript = { version = "12.3", optional = true }
 
 [features]
-cli = ["clap", "std", "rand", "bitcoin"]
-std = ["schnorr_fun/std", "sha2/std", "bitcoin?/std"]
+cli = [
+    "clap",
+    "std",
+    "rand",
+    "bitcoin",
+    "miniscript",
+]
+
+std = [
+    "schnorr_fun/std",
+    "sha2/std",
+    "bitcoin?/std",
+]
+
 default = ["cli"]
-bincode = [ "dep:bincode", "schnorr_fun/bincode" ]
+
+bincode = [
+    "dep:bincode",
+    "schnorr_fun/bincode"
+]
 
 [[bin]]
 name = "frost_backup"
-required-features = ["cli" ]
+required-features = ["cli"]
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/frost_backup/src/lib.rs
+++ b/frost_backup/src/lib.rs
@@ -53,7 +53,13 @@ pub fn generate_descriptor(
     network: bitcoin::NetworkKind,
 ) -> alloc::string::String {
     use alloc::format;
+
     let xpriv = generate_xpriv(secret, network);
-    // Include the rootkey_to_master_appkey [0] derivation in the path
-    format!("tr({}/0/0/0/0/<0;1>/*)", xpriv)
+
+    let descriptor = format!("tr({xpriv}/0/0/0/0/<0;1>/*)");
+
+    let checksum = miniscript::descriptor::checksum::desc_checksum(&descriptor)
+        .expect("generated descriptor should always be valid");
+
+    format!("{descriptor}#{checksum}")
 }

--- a/frost_backup/tests/descriptor_match.rs
+++ b/frost_backup/tests/descriptor_match.rs
@@ -1,7 +1,7 @@
 use bitcoin::bip32::DerivationPath;
 use bitcoin::secp256k1;
 use bitcoin::{Address, Network};
-use frost_backup::generate_xpriv;
+use frost_backup::{generate_descriptor, generate_xpriv};
 use frostsnap_coordinator::bitcoin::{descriptor_for_account_keychain, wallet::KeychainId};
 use frostsnap_core::{
     tweak::{AccountKind, BitcoinAccount, BitcoinAccountKeychain, Keychain},
@@ -80,5 +80,25 @@ fn test_addresses_match() {
     assert_eq!(
         frost_backup_address_1, frostsnap_address_1,
         "Second address from frost_backup xpriv should match frostsnap_core descriptor"
+    );
+}
+#[test]
+fn test_descriptor_has_valid_checksum() {
+    let secret = Scalar::random(&mut rand::thread_rng());
+    let network = bitcoin::NetworkKind::Test;
+
+    let descriptor = generate_descriptor(&secret, network);
+
+    let (descriptor_without_checksum, checksum) = descriptor
+        .split_once('#')
+        .expect("descriptor should contain a checksum");
+
+    let expected_checksum =
+        miniscript::descriptor::checksum::desc_checksum(descriptor_without_checksum)
+            .expect("descriptor should be valid");
+
+    assert_eq!(
+        checksum, expected_checksum,
+        "descriptor checksum should match BIP380 checksum"
     );
 }


### PR DESCRIPTION
Closes #476

Summary

Adds BIP380 descriptor checksum generation to `frost_backup` descriptor reconstruction.

## Changes

- Added `miniscript` dependency for descriptor checksum calculation.
- Updated `generate_descriptor` to append the BIP380 checksum to generated descriptors.
- Added a test to verify generated descriptors contain a valid checksum.

## Testing

- `cargo fmt -p frost_backup`
- `cargo test -p frost_backup`

The generated descriptors continue to match the address derivation from `frostsnap_core`.