### PR TITLE
exitRecoveryMode: route the re-plug auto-exit through the guarded key path + fail-safe consolidation

### DIFF
--- a/frostsnap_core/src/coordinator/restoration.rs
+++ b/frostsnap_core/src/coordinator/restoration.rs
@@ -958,18 +958,35 @@ impl FrostCoordinator {
         }
     }
 
-    pub fn has_backups_that_need_to_be_consolidated(&self, device_id: DeviceId) -> bool {
+    /// The pending physical backups `device_id` still needs to consolidate — one
+    /// per share it recovered by entering a physical backup during restoration.
+    /// The unique wallet work set is `.map(|c| c.access_structure_ref)` deduped.
+    pub fn backups_that_need_to_be_consolidated(
+        &self,
+        device_id: DeviceId,
+    ) -> Vec<PendingConsolidation> {
         self.restoration
             .pending_physical_consolidations
             .iter()
-            .any(|consolidation| consolidation.device_id == device_id)
+            .filter(|consolidation| consolidation.device_id == device_id)
+            .cloned()
+            .collect()
     }
 
+    /// Builds the messages telling `device_id` to consolidate its pending physical
+    /// backups, or fails without emitting anything.
+    ///
+    /// A single device can hold pending consolidations across access structures
+    /// from different global-key eras, so `encryption_key` is not guaranteed to
+    /// decrypt every wallet in the set. Each ref is decrypt-checked while the batch
+    /// is built and the batch is only returned once all succeed, so a key that
+    /// can't decrypt one wallet abandons the whole batch (`ConsolidateError`)
+    /// rather than telling the device to consolidate only some of its shares.
     pub fn consolidate_pending_physical_backups(
         &self,
         device_id: DeviceId,
         encryption_key: SymmetricKey,
-    ) -> impl IntoIterator<Item = CoordinatorSend> {
+    ) -> Result<Vec<CoordinatorSend>, ConsolidateError> {
         let consolidations = self
             .restoration
             .pending_physical_consolidations
@@ -979,12 +996,17 @@ impl FrostCoordinator {
         let mut messages = vec![];
 
         for consolidation in consolidations {
+            let access_structure_ref = consolidation.access_structure_ref;
             let root_shared_key = self
-                .root_shared_key(consolidation.access_structure_ref, encryption_key)
-                .expect("invariant");
-            let frost_key = self
-                .get_frost_key(consolidation.access_structure_ref.key_id)
-                .expect("invariant");
+                .root_shared_key(access_structure_ref, encryption_key)
+                .ok_or(ConsolidateError::CannotDecrypt {
+                    access_structure_ref,
+                })?;
+            let frost_key = self.get_frost_key(access_structure_ref.key_id).ok_or(
+                ConsolidateError::CannotDecrypt {
+                    access_structure_ref,
+                },
+            )?;
 
             messages.push(CoordinatorSend::ToDevice {
                 message: CoordinatorToDeviceMessage::Restoration(
@@ -999,7 +1021,7 @@ impl FrostCoordinator {
             });
         }
 
-        messages
+        Ok(messages)
     }
 
     pub fn request_device_display_backup(
@@ -1302,6 +1324,33 @@ impl fmt::Display for CheckBackupError {
 }
 
 impl std::error::Error for CheckBackupError {}
+
+/// Consolidating a device's pending physical backups failed before anything was
+/// sent, because the supplied key couldn't decrypt one of the wallets involved.
+#[derive(Debug, Clone)]
+pub enum ConsolidateError {
+    /// The supplied key can't decrypt this access structure, so its consolidation
+    /// message can't be built. Returned before any message is emitted, so the
+    /// whole batch is abandoned rather than partially sent.
+    CannotDecrypt {
+        access_structure_ref: AccessStructureRef,
+    },
+}
+
+impl fmt::Display for ConsolidateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConsolidateError::CannotDecrypt {
+                access_structure_ref,
+            } => write!(
+                f,
+                "the encryption key can't decrypt wallet {access_structure_ref:?} to consolidate its physical backup"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConsolidateError {}
 
 #[derive(Debug, Clone)]
 pub enum RestorationError {

--- a/frostsnap_core/tests/restoration.rs
+++ b/frostsnap_core/tests/restoration.rs
@@ -349,10 +349,20 @@ fn consolidate_with_mixed_key_eras_is_fail_safe() {
     // the backup is extracted out as a plain value, so nothing is lost.
     let mut run = Run::generate(2, &mut rng);
     let devices: Vec<_> = run.device_set().into_iter().collect();
-    let backup_a =
-        keygen_and_backup(&mut run, &mut TestEnv::default(), &mut rng, devices[0], [1u8; 32]);
-    let backup_b =
-        keygen_and_backup(&mut run, &mut TestEnv::default(), &mut rng, devices[1], [2u8; 32]);
+    let backup_a = keygen_and_backup(
+        &mut run,
+        &mut TestEnv::default(),
+        &mut rng,
+        devices[0],
+        [1u8; 32],
+    );
+    let backup_b = keygen_and_backup(
+        &mut run,
+        &mut TestEnv::default(),
+        &mut rng,
+        devices[1],
+        [2u8; 32],
+    );
 
     // One fresh device recovers both wallets, each finished under a different key.
     let mut env = TestEnv::default();

--- a/frostsnap_core/tests/restoration.rs
+++ b/frostsnap_core/tests/restoration.rs
@@ -1,6 +1,8 @@
 use common::TEST_ENCRYPTION_KEY;
+use frostsnap_core::coordinator::restoration::ConsolidateError;
+use frostsnap_core::coordinator::BeginKeygen;
 use frostsnap_core::device::KeyPurpose;
-use frostsnap_core::{EnterPhysicalId, WireSignTask};
+use frostsnap_core::{AccessStructureRef, DeviceId, EnterPhysicalId, SymmetricKey, WireSignTask};
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use schnorr_fun::Schnorr;
@@ -197,13 +199,15 @@ fn restore_2_of_3_with_physical_backups_propagates_threshold() {
 
     // Now consolidate the physical backups on all devices
     for &device_id in &devices {
-        if run
+        if !run
             .coordinator
-            .has_backups_that_need_to_be_consolidated(device_id)
+            .backups_that_need_to_be_consolidated(device_id)
+            .is_empty()
         {
             let consolidate_messages = run
                 .coordinator
-                .consolidate_pending_physical_backups(device_id, TEST_ENCRYPTION_KEY);
+                .consolidate_pending_physical_backups(device_id, TEST_ENCRYPTION_KEY)
+                .expect("the test key decrypts every pending wallet");
             run.extend(consolidate_messages);
         }
     }
@@ -213,8 +217,9 @@ fn restore_2_of_3_with_physical_backups_propagates_threshold() {
     // Verify all devices now have properly encrypted shares
     for (i, &device_id) in devices.iter().enumerate() {
         assert!(
-            !run.coordinator
-                .has_backups_that_need_to_be_consolidated(device_id),
+            run.coordinator
+                .backups_that_need_to_be_consolidated(device_id)
+                .is_empty(),
             "Device {:?} should have all backups consolidated",
             device_id
         );
@@ -236,6 +241,167 @@ fn restore_2_of_3_with_physical_backups_propagates_threshold() {
     assert_eq!(
         restored_access_structure_ref, access_structure_ref,
         "Restored access structure should match original"
+    );
+}
+
+/// Keygen a single-device wallet and return that device's displayed backup, so
+/// it can be restored onto a different device later.
+fn keygen_and_backup(
+    run: &mut Run,
+    env: &mut TestEnv,
+    rng: &mut ChaCha20Rng,
+    device_id: DeviceId,
+    coordinator_seed: [u8; 32],
+) -> frost_backup::ShareBackup {
+    let keygen_init = run
+        .coordinator
+        .begin_keygen(
+            BeginKeygen::new(
+                vec![device_id],
+                1,
+                "wallet".to_string(),
+                KeyPurpose::Test,
+                rng,
+            ),
+            &mut ChaCha20Rng::from_seed(coordinator_seed),
+        )
+        .unwrap();
+    run.extend(keygen_init);
+    run.run_until_finished(env, rng).unwrap();
+
+    let access_structure_ref = run
+        .coordinator
+        .iter_access_structures()
+        .find(|access_structure| access_structure.contains_device(device_id))
+        .expect("keygen created an access structure for the device")
+        .access_structure_ref();
+
+    let display_backup = run
+        .coordinator
+        .request_device_display_backup(device_id, access_structure_ref, TEST_ENCRYPTION_KEY)
+        .unwrap();
+    run.extend(display_backup);
+    run.run_until_finished(env, rng).unwrap();
+
+    env.backups
+        .get(&device_id)
+        .expect("device displayed its backup")
+        .1
+        .clone()
+}
+
+/// Recover `backup` onto `device_id` and finish the restoration under
+/// `encryption_key`, leaving the device with a pending consolidation whose
+/// wallet is encrypted under that key.
+fn restore_backup_onto_device(
+    run: &mut Run,
+    env: &mut TestEnv,
+    rng: &mut ChaCha20Rng,
+    device_id: DeviceId,
+    backup: frost_backup::ShareBackup,
+    encryption_key: SymmetricKey,
+) -> AccessStructureRef {
+    env.backup_to_enter.insert(device_id, backup);
+
+    let restoration_id = frostsnap_core::RestorationId::new(rng);
+    // These wallets are 1-of-1, so state the threshold explicitly — a single
+    // recovered share is then immediately restorable.
+    run.coordinator.start_restoring_key(
+        "Restored".to_string(),
+        Some(1),
+        KeyPurpose::Test,
+        restoration_id,
+    );
+
+    let enter_physical_id = EnterPhysicalId::new(rng);
+    let enter_backup = run
+        .coordinator
+        .tell_device_to_load_physical_backup(enter_physical_id, device_id);
+    run.extend(enter_backup);
+    run.run_until_finished(env, rng).unwrap();
+
+    let phase = *env
+        .physical_backups_entered
+        .last()
+        .expect("device entered its physical backup");
+
+    let save = run
+        .coordinator
+        .tell_device_to_save_physical_backup(phase, restoration_id);
+    run.extend(save);
+    run.run_until_finished(env, rng).unwrap();
+
+    run.coordinator
+        .finish_restoring(restoration_id, encryption_key, rng)
+        .expect("restoration is complete")
+}
+
+/// A device can hold pending consolidations for wallets from different app
+/// key-eras (#511), so no single key is guaranteed to decrypt them all.
+/// Consolidation must then refuse the whole batch — a typed error, no panic, no
+/// messages — rather than telling the device to consolidate only some shares.
+#[test]
+fn consolidate_with_mixed_key_eras_is_fail_safe() {
+    const OTHER_KEY: SymmetricKey = SymmetricKey([7u8; 32]);
+    let mut rng = ChaCha20Rng::from_seed([77u8; 32]);
+
+    // Each keygen gets its own env: the env's keygen tracking is one-shot, and
+    // the backup is extracted out as a plain value, so nothing is lost.
+    let mut run = Run::generate(2, &mut rng);
+    let devices: Vec<_> = run.device_set().into_iter().collect();
+    let backup_a =
+        keygen_and_backup(&mut run, &mut TestEnv::default(), &mut rng, devices[0], [1u8; 32]);
+    let backup_b =
+        keygen_and_backup(&mut run, &mut TestEnv::default(), &mut rng, devices[1], [2u8; 32]);
+
+    // One fresh device recovers both wallets, each finished under a different key.
+    let mut env = TestEnv::default();
+    run.clear_coordinator();
+    let device_id = run.new_device(&mut rng);
+    let ref_a = restore_backup_onto_device(
+        &mut run,
+        &mut env,
+        &mut rng,
+        device_id,
+        backup_a,
+        TEST_ENCRYPTION_KEY,
+    );
+    let ref_b =
+        restore_backup_onto_device(&mut run, &mut env, &mut rng, device_id, backup_b, OTHER_KEY);
+    assert_ne!(ref_a, ref_b);
+
+    let pending = run
+        .coordinator
+        .backups_that_need_to_be_consolidated(device_id);
+    assert_eq!(
+        pending.len(),
+        2,
+        "one pending consolidation per recovered wallet"
+    );
+
+    // The key that decrypts wallet A can't decrypt wallet B, so the batch is
+    // abandoned with a typed error (previously this panicked via `.expect`).
+    let with_key_a = run
+        .coordinator
+        .consolidate_pending_physical_backups(device_id, TEST_ENCRYPTION_KEY);
+    assert!(
+        matches!(
+            with_key_a,
+            Err(ConsolidateError::CannotDecrypt { access_structure_ref }) if access_structure_ref == ref_b
+        ),
+        "the key for wallet A must not be able to consolidate wallet B"
+    );
+
+    // ...and symmetrically for the other key: neither key produces any messages.
+    let with_key_b = run
+        .coordinator
+        .consolidate_pending_physical_backups(device_id, OTHER_KEY);
+    assert!(
+        matches!(
+            with_key_b,
+            Err(ConsolidateError::CannotDecrypt { access_structure_ref }) if access_structure_ref == ref_a
+        ),
+        "the key for wallet B must not be able to consolidate wallet A"
     );
 }
 

--- a/frostsnapp/android/app/src/main/kotlin/com/frostsnap/SecureKeyManager.kt
+++ b/frostsnapp/android/app/src/main/kotlin/com/frostsnap/SecureKeyManager.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.os.Build
 import android.provider.Settings
 import android.security.keystore.KeyGenParameterSpec
@@ -78,6 +79,16 @@ class SecureKeyManager : FlutterPlugin, MethodCallHandler, ActivityAware, Plugin
     
     private fun getOrCreateKey(result: Result) {
         try {
+            // Debug-only escape hatch so tests can force the key-creation-failed
+            // fallback on emulators where hardware key creation succeeds:
+            //   adb shell settings put global frostsnap_force_empty_key 1
+            val debuggable = (appContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+            if (debuggable && Settings.Global.getInt(appContext.contentResolver, "frostsnap_force_empty_key", 0) != 0) {
+                Log.w(TAG, "frostsnap_force_empty_key set, reporting key creation failure")
+                result.error("KEY_CREATION_FAILED", "forced by frostsnap_force_empty_key", null)
+                return
+            }
+
             // Fail fast if there's no device lock screen. KeyGenParameterSpec
             // with setUserAuthenticationRequired(true) cannot bind a key without
             // device credentials, and the resulting low-level exception is opaque,
@@ -94,7 +105,16 @@ class SecureKeyManager : FlutterPlugin, MethodCallHandler, ActivityAware, Plugin
 
             // Create key if it doesn't exist
             if (!keyStore.containsAlias(KEY_ALIAS)) {
-                createKey()
+                try {
+                    createKey()
+                } catch (e: Exception) {
+                    // Old keymasters (e.g. Pixel 2 XL / Android 11) can fail to
+                    // generate this key even in the TEE. Surface a typed error so
+                    // the Dart side can fall back instead of failing keygen.
+                    Log.w(TAG, "Hardware key creation failed", e)
+                    result.error("KEY_CREATION_FAILED", "Failed to create hardware-backed key: ${e.message}", null)
+                    return
+                }
             }
             
             // Try to access the key

--- a/frostsnapp/lib/device_action_backup.dart
+++ b/frostsnapp/lib/device_action_backup.dart
@@ -5,9 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
-import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
 
 class DeviceActionBackupController with ChangeNotifier {
   final AccessStructure accessStructure;
@@ -40,7 +40,12 @@ class DeviceActionBackupController with ChangeNotifier {
         null;
     if (!connected) return false;
 
-    final encryptionKey = await SecureKeyProvider.getEncryptionKey();
+    final encryptionKey = await existingWalletKey(
+      context: context.mounted ? context : null,
+      accessStructureRef: accessStructure.accessStructureRef(),
+      action: 'show this backup',
+    );
+    if (encryptionKey == null) return false;
 
     final controller = FullscreenActionDialogController<bool>(
       context: context,

--- a/frostsnapp/lib/device_action_backup_check.dart
+++ b/frostsnapp/lib/device_action_backup_check.dart
@@ -4,11 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
-import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
 import 'package:frostsnap/src/rust/api/recovery.dart';
 import 'package:frostsnap/stream_ext.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
 
 class DeviceActionBackupCheckController with ChangeNotifier {
   final AccessStructure accessStructure;
@@ -33,7 +33,12 @@ class DeviceActionBackupCheckController with ChangeNotifier {
         null;
     if (!connected) return null;
 
-    final encryptionKey = await SecureKeyProvider.getEncryptionKey();
+    final encryptionKey = await existingWalletKey(
+      context: context.mounted ? context : null,
+      accessStructureRef: accessStructure.accessStructureRef(),
+      action: 'check this backup',
+    );
+    if (encryptionKey == null) return null;
     final shareIndex = accessStructure.getDeviceShareIndex(deviceId: id);
     if (shareIndex == null) return null;
 
@@ -62,16 +67,15 @@ class DeviceActionBackupCheckController with ChangeNotifier {
     _dialogController = controller;
 
     try {
+      final checkStream = coord.tellDeviceToCheckBackup(
+        deviceId: id,
+        accessStructureRef: accessStructure.accessStructureRef(),
+        shareIndex: shareIndex,
+        encryptionKey: encryptionKey,
+      );
+
       final (state, isCancelled) = await select([
-        coord
-            .tellDeviceToCheckBackup(
-              deviceId: id,
-              accessStructureRef: accessStructure.accessStructureRef(),
-              shareIndex: shareIndex,
-              encryptionKey: encryptionKey,
-            )
-            .last
-            .then((s) => (s, true)),
+        checkStream.last.then((s) => (s, true)),
         controller.awaitDismissed().then((_) => (null, false)),
       ], catchError: (_) => (null, true));
 

--- a/frostsnapp/lib/main.dart
+++ b/frostsnapp/lib/main.dart
@@ -14,10 +14,9 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/global.dart';
-import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/serialport.dart';
-import 'package:frostsnap/snackbar.dart';
 import 'package:frostsnap/settings.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
 import 'package:frostsnap/stream_ext.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:frostsnap/wallet.dart';
@@ -87,40 +86,17 @@ Future<void> main() async {
     runApp(MyApp(startupError: startupError));
   } else {
     GlobalStreams.deviceListSubject.forEach((update) {
-      // If we detect a device that's in recovery mode we should tell it to exit
-      // ASAP. Right now we don't confirm with the user this action but maybe in
-      // the future we will.
+      // A device that turned up in recovery mode with pending consolidations
+      // should be taken back out — but only with a key that can decrypt every
+      // wallet it has pending work for (the event carries that set). The empty
+      // set (mid-flow / clearing transitions) is a no-op here.
       for (var change in update.changes) {
         if (change.kind == DeviceListChangeKind.recoveryMode &&
             change.device.recoveryMode) {
-          final deviceId = change.device.id;
-          () async {
-            final SymmetricKey encryptionKey;
-            try {
-              encryptionKey = await SecureKeyProvider.getEncryptionKey();
-            } on PlatformException catch (e) {
-              final expected = e.code == 'NO_LOCK_SCREEN';
-              log(
-                level: expected ? LogLevel.info : LogLevel.error,
-                message:
-                    "skipping exitRecoveryMode for $deviceId: ${e.code} (${e.message})",
-              );
-              final ctx = rootNavKey.currentContext;
-              if (ctx != null) {
-                showErrorSnackbar(
-                  ctx,
-                  expected
-                      ? "Couldn't take device out of recovery mode: screen lock required."
-                      : "Couldn't take device out of recovery mode: ${e.message ?? e.code}",
-                );
-              }
-              return;
-            }
-            coord.exitRecoveryMode(
-              deviceId: deviceId,
-              encryptionKey: encryptionKey,
-            );
-          }();
+          exitRecoveryModeForDevice(
+            deviceId: change.device.id,
+            pendingConsolidations: change.pendingConsolidations,
+          );
         }
       }
 

--- a/frostsnapp/lib/restoration/device_discovery.dart
+++ b/frostsnapp/lib/restoration/device_discovery.dart
@@ -9,6 +9,7 @@ import 'package:frostsnap/restoration/target_device.dart';
 import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/src/rust/api/recovery.dart';
 import 'package:frostsnap/theme.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
 
 class RecoveryFlowWithDiscovery extends StatefulWidget {
   final RecoveryContext recoveryContext;
@@ -143,6 +144,16 @@ class _DeviceDiscoveryWidgetState extends State<DeviceDiscoveryWidget> {
   Future<String?> _validateShare(RecoverShare share) async {
     switch (widget.recoveryContext) {
       case NewRestorationContext():
+        // This flow only checks whether a restoration can start; it does not
+        // decrypt the existing wallet. Keep its duplicate error independent of
+        // whether the app's current encryption key can unlock that wallet.
+        final existingRef = share.heldShare.accessStructureRef;
+        if (existingRef != null &&
+            coord.getAccessStructure(asRef: existingRef) != null) {
+          final wallet = coord.getFrostKey(keyId: existingRef.keyId)!;
+          return "This key share belongs to existing wallet '${wallet.keyName()}' and cannot be used to start a new restoration";
+        }
+
         final encryptionKey = await SecureKeyProvider.getEncryptionKey();
         final error = await coord.checkStartRestoringKeyFromDeviceShare(
           recoverShare: share,
@@ -151,6 +162,11 @@ class _DeviceDiscoveryWidgetState extends State<DeviceDiscoveryWidget> {
         return error?.toString();
 
       case ContinuingRestorationContext(:final restorationId):
+        // A restoration in progress holds only plaintext accumulated shares —
+        // continuing it establishes the finished key rather than decrypting
+        // existing data — so it uses the establish surface, like the final
+        // "Restore" (finishRestoring). With no lock screen the user is asked to
+        // set one up and the restoration continues under the fresh key.
         final encryptionKey = await SecureKeyProvider.getEncryptionKey();
         final error = await coord.checkContinueRestoringWalletFromDeviceShare(
           restorationId: restorationId,
@@ -160,7 +176,14 @@ class _DeviceDiscoveryWidgetState extends State<DeviceDiscoveryWidget> {
         return error?.toString();
 
       case AddingToWalletContext(:final accessStructureRef):
-        final encryptionKey = await SecureKeyProvider.getEncryptionKey();
+        final encryptionKey = await existingWalletKey(
+          context: mounted ? context : null,
+          accessStructureRef: accessStructureRef,
+          action: 'recover this key into the wallet',
+        );
+        if (encryptionKey == null) {
+          return 'This wallet can no longer be unlocked on this phone.';
+        }
         final error = await coord.checkRecoverShare(
           accessStructureRef: accessStructureRef,
           recoverShare: share,

--- a/frostsnapp/lib/restoration/recovery_flow.dart
+++ b/frostsnapp/lib/restoration/recovery_flow.dart
@@ -18,6 +18,7 @@ import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/recovery.dart';
 import 'package:frostsnap/stream_ext.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/theme.dart';
 
@@ -95,22 +96,37 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
   Future<void> _completeDeviceShareEnrollment(RecoverShare candidate) async {
     try {
       RestorationId? restorationId;
-      final encryptionKey = await SecureKeyProvider.getEncryptionKey();
 
       switch (recoveryContext) {
         case ContinuingRestorationContext(:final restorationId):
+          // Adds a share to a restoration in progress — plaintext accumulated
+          // state, so this establishes the finished key rather than decrypting
+          // existing data. Uses the establish surface, like finishRestoring.
           await coord.continueRestoringWalletFromDeviceShare(
             restorationId: restorationId,
             recoverShare: candidate,
-            encryptionKey: encryptionKey,
+            encryptionKey: await SecureKeyProvider.getEncryptionKey(),
           );
         case AddingToWalletContext(:final accessStructureRef):
+          // Recovers a share INTO an existing wallet, decrypting its data — so
+          // it needs the existing key. Guard it: on an unavailable/wrong key
+          // the guard shows delete-and-recover and we abort.
+          final key = await existingWalletKey(
+            context: mounted ? context : null,
+            accessStructureRef: accessStructureRef,
+            action: 'recover this key into the wallet',
+          );
+          if (key == null) {
+            if (mounted) Navigator.pop(context);
+            return;
+          }
           await coord.recoverShare(
             accessStructureRef: accessStructureRef,
             recoverShare: candidate,
-            encryptionKey: encryptionKey,
+            encryptionKey: key,
           );
         case NewRestorationContext():
+          // Establishes a new restoration; needs no encryption key.
           restorationId = await coord.startRestoringWalletFromDeviceShare(
             recoverShare: candidate,
           );
@@ -299,8 +315,15 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
             try {
               switch (recoveryContext) {
                 case AddingToWalletContext(:final accessStructureRef):
-                  final encryptionKey =
-                      await SecureKeyProvider.getEncryptionKey();
+                  final encryptionKey = await existingWalletKey(
+                    context: mounted ? context : null,
+                    accessStructureRef: accessStructureRef,
+                    action: 'add this backup to the wallet',
+                  );
+                  if (encryptionKey == null) {
+                    if (mounted) Navigator.pop(context);
+                    return;
+                  }
                   final isValid = await coord.checkPhysicalBackup(
                     accessStructureRef: accessStructureRef,
                     phase: backupPhase,
@@ -367,6 +390,7 @@ class _WalletRecoveryFlowState extends State<WalletRecoveryFlow> {
                   });
 
                 case ContinuingRestorationContext(:final restorationId):
+                  // Restoration in progress → establish surface (see above).
                   final encryptionKey =
                       await SecureKeyProvider.getEncryptionKey();
                   final error = await coord.checkPhysicalBackupForRestoration(

--- a/frostsnapp/lib/secure_key_provider.dart
+++ b/frostsnapp/lib/secure_key_provider.dart
@@ -6,6 +6,14 @@ import 'package:frostsnap/global.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/lib.dart';
 
+/// The key protecting an already-existing wallet is unavailable — e.g. the
+/// screen lock that bound it was removed, so the Keystore key is gone. This is
+/// unrecoverable for that wallet (a new key can't decrypt the old data), so
+/// callers route to delete-and-recover.
+class WalletKeyUnavailable implements Exception {
+  const WalletKeyUnavailable();
+}
+
 /// Platform-agnostic interface for secure key management
 abstract class SecureKeyProvider {
   /// Get or create the encryption key
@@ -39,12 +47,21 @@ abstract class SecureKeyProvider {
     return _instance!;
   }
 
-  /// Convenience method to get encryption key from global instance.
+  /// The all-zero key used where no hardware-backed key is available: always
+  /// on desktop, and on Android when the Keystore can't create a key.
+  static SymmetricKey get emptyKey =>
+      SymmetricKey(field0: U8Array32(Uint8List(32)));
+
+  /// Get (or establish) the encryption key — for operations that ESTABLISH the
+  /// encrypted state: keygen, saving a newly restored wallet, startup.
   ///
   /// On Android, if there's no device lock screen the Keystore can't bind a
   /// user-auth-required key, so we surface a global blocking dialog asking the
   /// user to set one up. The call is retried after they signal they're ready,
   /// and rethrows the original PlatformException if they cancel.
+  ///
+  /// Do NOT use this for an operation on a wallet that ALREADY EXISTS — use
+  /// [getExistingEncryptionKey], which can't be satisfied by minting a new key.
   static Future<SymmetricKey> getEncryptionKey() async {
     while (true) {
       try {
@@ -54,6 +71,29 @@ abstract class SecureKeyProvider {
         final retry = await _ensureLockScreenDialog();
         if (!retry) rethrow;
       }
+    }
+  }
+
+  /// Get the encryption key for an operation that must DECRYPT an already
+  /// existing wallet's data.
+  ///
+  /// Unlike [getEncryptionKey], this never prompts the user to set up a screen
+  /// lock: for an existing wallet that would be a false promise, since a fresh
+  /// lock screen only mints a DIFFERENT key that can't decrypt the old data.
+  /// With no lock screen it throws [WalletKeyUnavailable] so the caller can
+  /// route to delete-and-recover.
+  ///
+  /// (When a lock screen IS present but the bound key has changed — e.g. it was
+  /// deleted — this still returns that new, wrong key. The caller
+  /// ([existingWalletKey]) preflights it with `canDecryptWallet` and routes to
+  /// delete-and-recover BEFORE running the operation, so there is no typed
+  /// downstream decrypt error.)
+  static Future<SymmetricKey> getExistingEncryptionKey() async {
+    try {
+      return await instance.getOrCreateKey();
+    } on PlatformException catch (e) {
+      if (e.code == _noLockScreenCode) throw const WalletKeyUnavailable();
+      rethrow;
     }
   }
 
@@ -140,15 +180,31 @@ class _NoLockScreenDialog extends StatelessWidget {
 /// Android implementation using the native SecureKeyManager plugin
 class AndroidSecureKeyProvider extends SecureKeyProvider {
   static const _channel = MethodChannel('com.frostsnap/secure_key');
+  static const _keyCreationFailedCode = 'KEY_CREATION_FAILED';
 
   AndroidSecureKeyProvider._();
 
+  /// Build a provider that talks to the real `com.frostsnap/secure_key`
+  /// [MethodChannel], for tests that mock that channel. On desktop hosts
+  /// [SecureKeyProvider.create] returns the desktop provider, so tests can't
+  /// otherwise exercise the Android channel path.
+  @visibleForTesting
+  factory AndroidSecureKeyProvider.forTesting() = AndroidSecureKeyProvider._;
+
   @override
   Future<SymmetricKey> getOrCreateKey() async {
-    final List<int> keyBytes = await _channel.invokeMethod('getOrCreateKey');
-    // Create SymmetricKey directly without Rust call
-    final array = U8Array32(Uint8List.fromList(keyBytes));
-    return SymmetricKey(field0: array);
+    try {
+      final List<int> keyBytes = await _channel.invokeMethod('getOrCreateKey');
+      // Create SymmetricKey directly without Rust call
+      final array = U8Array32(Uint8List.fromList(keyBytes));
+      return SymmetricKey(field0: array);
+    } on PlatformException catch (e) {
+      // Old keymasters (e.g. Pixel 2 XL / Android 11) can fail to create a
+      // hardware-backed key at all. Fall back to the empty key so the app
+      // still works. The wallet-locking migration will retire this path.
+      if (e.code != _keyCreationFailedCode) rethrow;
+      return SecureKeyProvider.emptyKey;
+    }
   }
 
   @override
@@ -174,48 +230,11 @@ class AndroidSecureKeyProvider extends SecureKeyProvider {
 
 /// Desktop implementation using a temporary hardcoded key
 class DesktopSecureKeyProvider extends SecureKeyProvider {
-  static final _tempKeyBytes = [
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-  ];
-
   DesktopSecureKeyProvider._();
 
   @override
   Future<SymmetricKey> getOrCreateKey() async {
-    // Create SymmetricKey directly without Rust call
-    final array = U8Array32(Uint8List.fromList(_tempKeyBytes));
-    return SymmetricKey(field0: array);
+    return SecureKeyProvider.emptyKey;
   }
 
   @override

--- a/frostsnapp/lib/sign_message.dart
+++ b/frostsnapp/lib/sign_message.dart
@@ -6,12 +6,12 @@ import 'package:frostsnap/animated_check.dart';
 import 'package:frostsnap/device_action.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/global.dart';
-import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
 import 'package:frostsnap/src/rust/api/signing.dart';
 import 'package:frostsnap/stream_ext.dart';
 import 'package:frostsnap/theme.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
 import 'hex.dart';
 
 class SignMessagePage extends StatelessWidget {
@@ -227,7 +227,16 @@ Future<List<EncodedSignature>?> showSigningProgressDialog(
 
   stream.forEach((signingState) async {
     sessionId = signingState.sessionId;
-    final encryptionKey = await SecureKeyProvider.getEncryptionKey();
+    final asRef = coord
+        .activeSigningSession(sessionId: sessionId!)
+        ?.accessStructureRef();
+    if (asRef == null) return;
+    final encryptionKey = await existingWalletKey(
+      context: context.mounted ? context : null,
+      accessStructureRef: asRef,
+      action: 'sign this message',
+    );
+    if (encryptionKey == null) return;
     for (final deviceId in signingState.connectedButNeedRequest) {
       coord.requestDeviceSign(
         deviceId: deviceId,

--- a/frostsnapp/lib/wallet_key_mismatch.dart
+++ b/frostsnapp/lib/wallet_key_mismatch.dart
@@ -31,16 +31,28 @@ Future<SymmetricKey?> existingWalletKey({
   showRecovery ??= () =>
       showWalletKeyMismatchDialog(context: context, action: action);
 
+  // The empty-key fallback (see AndroidSecureKeyProvider) isn't persisted, so
+  // a wallet established under it must keep working: probe the empty key
+  // before giving up.
+  SymmetricKey? emptyKeyIfDecrypts() {
+    final emptyKey = SecureKeyProvider.emptyKey;
+    return canDecrypt!(emptyKey) ? emptyKey : null;
+  }
+
   final SymmetricKey key;
   try {
     key = await getKey();
   } on WalletKeyUnavailable {
+    final emptyKey = emptyKeyIfDecrypts();
+    if (emptyKey != null) return emptyKey;
     // Await so a null return means the dialog has been shown AND dismissed —
     // callers that pop their own flow afterwards then can't race it away.
     await showRecovery();
     return null;
   }
   if (!canDecrypt(key)) {
+    final emptyKey = emptyKeyIfDecrypts();
+    if (emptyKey != null) return emptyKey;
     await showRecovery();
     return null;
   }

--- a/frostsnapp/lib/wallet_key_mismatch.dart
+++ b/frostsnapp/lib/wallet_key_mismatch.dart
@@ -96,7 +96,8 @@ Future<void> _show(BuildContext context, String action) async {
         "so it can't $action.\n\n"
         'This usually means the wallet was protected by a key this phone '
         'no longer has. To keep using the wallet, delete it from this app '
-        'and recover it from its Frostsnap devices.',
+        'and recover it from its Frostsnap devices.'
+        '${walletCtx == null ? "\n\nYou can delete it from the wallet's settings." : ''}',
       ),
       actions: [
         TextButton(

--- a/frostsnapp/lib/wallet_key_mismatch.dart
+++ b/frostsnapp/lib/wallet_key_mismatch.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/global.dart';
+import 'package:frostsnap/maybe_fullscreen_dialog.dart';
+import 'package:frostsnap/secure_key_provider.dart';
+import 'package:frostsnap/settings.dart';
+import 'package:frostsnap/src/rust/api.dart';
+
+/// Get the app's encryption key for an operation that must DECRYPT the existing
+/// wallet at [accessStructureRef], after verifying it actually can.
+///
+/// Returns null — and shows the delete-and-recover dialog — when the key is
+/// unavailable (no screen lock, so it can't be produced) or can't decrypt this
+/// wallet (wrong key). A compact, deliberately brittle guard: the
+/// canDecryptWallet probe is a pre-check that can drift from the operation, but
+/// the wallet-locking migration removes the whole per-key encryption concern,
+/// so it isn't worth threading typed errors through the stack for.
+Future<SymmetricKey?> existingWalletKey({
+  BuildContext? context,
+  required AccessStructureRef accessStructureRef,
+  required String action,
+  @visibleForTesting Future<SymmetricKey> Function()? getKey,
+  @visibleForTesting bool Function(SymmetricKey key)? canDecrypt,
+  @visibleForTesting Future<void> Function()? showRecovery,
+}) async {
+  getKey ??= SecureKeyProvider.getExistingEncryptionKey;
+  canDecrypt ??= (key) => coord.canDecryptWallet(
+    accessStructureRef: accessStructureRef,
+    encryptionKey: key,
+  );
+  showRecovery ??= () =>
+      showWalletKeyMismatchDialog(context: context, action: action);
+
+  final SymmetricKey key;
+  try {
+    key = await getKey();
+  } on WalletKeyUnavailable {
+    // Await so a null return means the dialog has been shown AND dismissed —
+    // callers that pop their own flow afterwards then can't race it away.
+    await showRecovery();
+    return null;
+  }
+  if (!canDecrypt(key)) {
+    await showRecovery();
+    return null;
+  }
+  return key;
+}
+
+Future<void>? _pendingDialog;
+
+/// Tells the user the app's encryption key can't unlock this wallet's data
+/// (so it can't [action], e.g. "sign this transaction") and that the wallet
+/// must be deleted and recovered from its devices, routing into the existing
+/// delete flow when a [WalletContext] is in scope.
+///
+/// Falls back to the root navigator when the caller has no [BuildContext]
+/// (e.g. controllers reacting to stream events). Concurrent callers share a
+/// single dialog.
+Future<void> showWalletKeyMismatchDialog({
+  BuildContext? context,
+  required String action,
+}) {
+  final existing = _pendingDialog;
+  if (existing != null) return existing;
+
+  final ctx = context ?? rootNavKey.currentContext;
+  if (ctx == null || !ctx.mounted) return Future.value();
+
+  final future = _show(ctx, action);
+  _pendingDialog = future;
+  future.whenComplete(() => _pendingDialog = null);
+  return future;
+}
+
+Future<void> _show(BuildContext context, String action) async {
+  final walletCtx = WalletContext.of(context);
+  final deleteWallet = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Wallet needs recovery'),
+      content: Text(
+        "This phone's encryption key can't unlock this wallet's data, "
+        "so it can't $action.\n\n"
+        'This usually means the wallet was protected by a key this phone '
+        'no longer has. To keep using the wallet, delete it from this app '
+        'and recover it from its Frostsnap devices.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Not now'),
+        ),
+        if (walletCtx != null)
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete wallet'),
+          ),
+      ],
+    ),
+  );
+
+  if (deleteWallet == true && walletCtx != null && context.mounted) {
+    await MaybeFullscreenDialog.show(
+      context: context,
+      child: walletCtx.wrap(DeleteWalletPage()),
+    );
+  }
+}

--- a/frostsnapp/lib/wallet_key_mismatch.dart
+++ b/frostsnapp/lib/wallet_key_mismatch.dart
@@ -59,6 +59,59 @@ Future<SymmetricKey?> existingWalletKey({
   return key;
 }
 
+/// Reacts to a device turning up in recovery mode with pending physical-backup
+/// consolidations (the deferred re-plug auto-exit) by taking it back out — but
+/// only with a key that can decrypt EVERY wallet it has pending work for.
+///
+/// [pendingConsolidations] is the wallet set carried on the recovery event; an
+/// empty set means there's nothing for the background path to do. A candidate
+/// key is obtained the same guarded way as every other existing-wallet
+/// operation (via [existingWalletKey]). Because a single device can hold pending
+/// work across wallets from different key-eras, the candidate must decrypt all
+/// of them: if any fails we send nothing (the coordinator would refuse a partial
+/// batch anyway) and surface the delete-and-recover dialog.
+Future<void> exitRecoveryModeForDevice({
+  required DeviceId deviceId,
+  required List<AccessStructureRef> pendingConsolidations,
+  BuildContext? context,
+  @visibleForTesting
+  Future<SymmetricKey?> Function(AccessStructureRef ref)? getKey,
+  @visibleForTesting
+  bool Function(AccessStructureRef ref, SymmetricKey key)? canDecrypt,
+  @visibleForTesting void Function(SymmetricKey key)? exit,
+  @visibleForTesting Future<void> Function()? onMismatch,
+}) async {
+  if (pendingConsolidations.isEmpty) return;
+
+  getKey ??= (ref) => existingWalletKey(
+    context: context,
+    accessStructureRef: ref,
+    action: 'take this device out of recovery mode',
+  );
+  canDecrypt ??= (ref, key) =>
+      coord.canDecryptWallet(accessStructureRef: ref, encryptionKey: key);
+  exit ??= (key) => coord.exitRecoveryMode(deviceId: deviceId, encryptionKey: key);
+  onMismatch ??= () => showWalletKeyMismatchDialog(
+    context: context,
+    action: 'take this device out of recovery mode',
+  );
+
+  final key = await getKey(pendingConsolidations.first);
+  // Null means the key was unavailable or couldn't decrypt the first wallet —
+  // existingWalletKey has already surfaced that. Don't auto-exit.
+  if (key == null) return;
+
+  // The candidate decrypted the first wallet; it must decrypt the rest too, or
+  // this is a genuine whole-set mismatch: send nothing and show the dialog.
+  for (final ref in pendingConsolidations) {
+    if (!canDecrypt(ref, key)) {
+      await onMismatch();
+      return;
+    }
+  }
+  exit(key);
+}
+
 Future<void>? _pendingDialog;
 
 /// Tells the user the app's encryption key can't unlock this wallet's data

--- a/frostsnapp/lib/wallet_key_mismatch.dart
+++ b/frostsnapp/lib/wallet_key_mismatch.dart
@@ -90,7 +90,8 @@ Future<void> exitRecoveryModeForDevice({
   );
   canDecrypt ??= (ref, key) =>
       coord.canDecryptWallet(accessStructureRef: ref, encryptionKey: key);
-  exit ??= (key) => coord.exitRecoveryMode(deviceId: deviceId, encryptionKey: key);
+  exit ??= (key) =>
+      coord.exitRecoveryMode(deviceId: deviceId, encryptionKey: key);
   onMismatch ??= () => showWalletKeyMismatchDialog(
     context: context,
     action: 'take this device out of recovery mode',

--- a/frostsnapp/lib/wallet_send_controllers.dart
+++ b/frostsnapp/lib/wallet_send_controllers.dart
@@ -10,9 +10,9 @@ import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
 import 'package:frostsnap/src/rust/api/device_list.dart';
 import 'package:frostsnap/src/rust/api/signing.dart';
-import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/src/rust/api/transaction.dart';
 import 'package:frostsnap/theme.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
 
 const satoshisInOneBtc = 100000000;
 
@@ -494,7 +494,16 @@ class SigningSessionController with ChangeNotifier {
 
   void maybeRequestDeviceSign() async {
     if (_state != null) {
-      final encryptionKey = await SecureKeyProvider.getEncryptionKey();
+      final asRef = coord
+          .activeSigningSession(sessionId: _state!.sessionId)
+          ?.accessStructureRef();
+      if (asRef == null) return;
+      // no BuildContext here; the dialog falls back to the root navigator
+      final encryptionKey = await existingWalletKey(
+        accessStructureRef: asRef,
+        action: 'sign this transaction',
+      );
+      if (encryptionKey == null) return;
       for (final neededFrom in _state!.connectedButNeedRequest) {
         if (_connectedDevices.contains(neededFrom)) {
           coord.requestDeviceSign(

--- a/frostsnapp/lib/wallet_tx_details.dart
+++ b/frostsnapp/lib/wallet_tx_details.dart
@@ -11,7 +11,6 @@ import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
-import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/psbt.dart';
 import 'package:frostsnap/snackbar.dart';
 import 'package:frostsnap/src/rust/api.dart';
@@ -21,6 +20,7 @@ import 'package:frostsnap/src/rust/api/psbt_manager.dart';
 import 'package:frostsnap/src/rust/api/signing.dart';
 import 'package:frostsnap/src/rust/api/super_wallet.dart';
 import 'package:frostsnap/theme.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
 import 'package:frostsnap/wallet.dart';
 import 'package:glowy_borders/glowy_borders.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -380,14 +380,20 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
       if (psbt != null) this.psbt = psbt;
     });
 
-    final encryptionKey = await SecureKeyProvider.getEncryptionKey();
-    data.connectedButNeedRequest.forEach(
-      (id) => coord.requestDeviceSign(
-        deviceId: id,
-        sessionId: data.sessionId,
-        encryptionKey: encryptionKey,
-      ),
+    final encryptionKey = await existingWalletKey(
+      context: mounted ? context : null,
+      accessStructureRef: widget.signingParams!.accessStructureRef,
+      action: 'sign this transaction',
     );
+    if (encryptionKey != null) {
+      data.connectedButNeedRequest.forEach(
+        (id) => coord.requestDeviceSign(
+          deviceId: id,
+          sessionId: data.sessionId,
+          encryptionKey: encryptionKey,
+        ),
+      );
+    }
     await actionDialogController?.batchRemoveActionNeeded(data.gotShares);
 
     return null;

--- a/frostsnapp/rust/src/api/coordinator.rs
+++ b/frostsnapp/rust/src/api/coordinator.rs
@@ -166,7 +166,8 @@ impl Coordinator {
     /// deliberately brittle pre-check for operations that must decrypt an
     /// existing wallet, so the app can show delete-and-recover up front instead
     /// of letting the operation fail opaquely. Wraps the existing
-    /// `root_shared_key` (None on the wrong key) — no core changes. The
+    /// `root_shared_key` — `false` also covers a missing key/access
+    /// structure, not just the wrong key. No core changes. The
     /// wallet-locking migration removes the whole per-key encryption concern.
     #[frb(sync)]
     pub fn can_decrypt_wallet(

--- a/frostsnapp/rust/src/api/coordinator.rs
+++ b/frostsnapp/rust/src/api/coordinator.rs
@@ -10,7 +10,7 @@ use frostsnap_core::{
     coordinator::CoordFrostKey,
     schnorr_fun::frost::{ShareIndex, SharedKey},
     tweak::Xpub,
-    AccessStructureId, AccessStructureRef, DeviceId, KeyId, MasterAppkey,
+    AccessStructureId, AccessStructureRef, DeviceId, KeyId, MasterAppkey, SymmetricKey,
 };
 use std::collections::BTreeMap;
 use tracing::{event, Level};
@@ -160,6 +160,24 @@ pub struct Coordinator(pub(crate) FfiCoordinator);
 impl Coordinator {
     pub fn start_thread(&self) -> Result<()> {
         self.0.start()
+    }
+
+    /// Whether `encryption_key` can decrypt this wallet's data. A quick,
+    /// deliberately brittle pre-check for operations that must decrypt an
+    /// existing wallet, so the app can show delete-and-recover up front instead
+    /// of letting the operation fail opaquely. Wraps the existing
+    /// `root_shared_key` (None on the wrong key) — no core changes. The
+    /// wallet-locking migration removes the whole per-key encryption concern.
+    #[frb(sync)]
+    pub fn can_decrypt_wallet(
+        &self,
+        access_structure_ref: AccessStructureRef,
+        encryption_key: SymmetricKey,
+    ) -> bool {
+        self.0
+            .inner()
+            .root_shared_key(access_structure_ref, encryption_key)
+            .is_some()
     }
 
     pub fn update_name_preview(&self, id: DeviceId, name: String) -> Result<()> {

--- a/frostsnapp/rust/src/api/device_list.rs
+++ b/frostsnapp/rust/src/api/device_list.rs
@@ -2,7 +2,7 @@ pub use crate::api::firmware::{FirmwareUpgradeEligibility, FirmwareVersion};
 use anyhow::Result;
 use flutter_rust_bridge::frb;
 use frostsnap_coordinator::DeviceMode;
-use frostsnap_core::DeviceId;
+use frostsnap_core::{AccessStructureRef, DeviceId};
 
 use crate::{frb_generated::StreamSink, sink_wrap::SinkWrap};
 
@@ -19,6 +19,12 @@ pub struct DeviceListChange {
     pub kind: DeviceListChangeKind,
     pub index: u32,
     pub device: ConnectedDevice,
+    /// On a re-plug `RecoveryMode` change, the wallets this device has pending
+    /// physical-backup consolidations for (deduped). A non-empty set means the
+    /// background auto-exit should act; the app must hold a key that decrypts
+    /// *every* one of these before taking the device out of recovery mode.
+    /// Empty for all other changes.
+    pub pending_consolidations: Vec<AccessStructureRef>,
 }
 
 #[derive(Clone, Debug)]

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -197,8 +197,21 @@ impl FfiCoordinator {
                         device_list.consume_manager_event(change.clone());
                         match change {
                             DeviceChange::Registered { id, .. } => {
-                                if coordinator.has_backups_that_need_to_be_consolidated(id) {
-                                    device_list.set_recovery_mode(id, true);
+                                // The device turned up with pending physical-backup
+                                // consolidations, so it's in recovery mode. Carry the
+                                // full unique wallet set on the event: the app must
+                                // hold a key that decrypts *all* of them before the
+                                // background auto-exit acts (a device can hold pending
+                                // work across wallets from different key-eras).
+                                let pending_consolidations: Vec<_> = coordinator
+                                    .backups_that_need_to_be_consolidated(id)
+                                    .into_iter()
+                                    .map(|consolidation| consolidation.access_structure_ref)
+                                    .collect::<BTreeSet<_>>()
+                                    .into_iter()
+                                    .collect();
+                                if !pending_consolidations.is_empty() {
+                                    device_list.set_recovery_mode(id, true, pending_consolidations);
                                 }
 
                                 ui_stack.connected(
@@ -1084,10 +1097,12 @@ impl FfiCoordinator {
                 // When/if the physical backup has been saved on the device this means the device
                 // has entered recovery mode. We need to set recovery mode so that the device can be
                 // brought out of recovery mode when the time comes.
+                // Mid-flow: this flow threads the key itself, so the background
+                // auto-exit must not act — carry an empty set.
                 device_list
                     .lock()
                     .unwrap()
-                    .set_recovery_mode(device_id, true);
+                    .set_recovery_mode(device_id, true, vec![]);
 
                 let coordinator = coordinator.lock().unwrap();
                 // We need to update the recovering key's state the ui gets updated
@@ -1170,10 +1185,12 @@ impl FfiCoordinator {
             false
         });
         if success {
+            // Mid-flow: this flow threads the key itself, so the background
+            // auto-exit must not act — carry an empty set.
             self.device_list
                 .lock()
                 .unwrap()
-                .set_recovery_mode(phase.from, true);
+                .set_recovery_mode(phase.from, true, vec![]);
 
             self.emit_key_state();
         }
@@ -1251,10 +1268,22 @@ impl FfiCoordinator {
 
         let msgs = {
             let coord = self.coordinator.lock().unwrap();
-            coord
-                .consolidate_pending_physical_backups(device_id, encryption_key)
-                .into_iter()
-                .collect::<Vec<_>>()
+            match coord.consolidate_pending_physical_backups(device_id, encryption_key) {
+                Ok(msgs) => msgs,
+                // The key can't decrypt one of the device's pending wallets, so
+                // there's nothing safe to send. Leave the device in recovery
+                // mode; a later attempt with the right key can consolidate it.
+                Err(e) => {
+                    event!(
+                        Level::WARN,
+                        id = device_id.to_string(),
+                        name = device.name,
+                        error = %e,
+                        "not taking device out of recovery mode: key can't decrypt a pending wallet"
+                    );
+                    return;
+                }
+            }
         };
 
         if msgs.is_empty() {
@@ -1286,10 +1315,11 @@ impl FfiCoordinator {
                 "device exited recovery mode"
             );
 
+            // Clearing transition — never triggers the background auto-exit.
             self.device_list
                 .lock()
                 .unwrap()
-                .set_recovery_mode(device_id, false);
+                .set_recovery_mode(device_id, false, vec![]);
 
             self.ui_stack
                 .lock()

--- a/frostsnapp/rust/src/device_list.rs
+++ b/frostsnapp/rust/src/device_list.rs
@@ -1,6 +1,9 @@
 #![allow(unused)]
 use crate::api::device_list as api;
-use frostsnap_coordinator::{frostsnap_core::DeviceId, DeviceChange};
+use frostsnap_coordinator::{
+    frostsnap_core::{AccessStructureRef, DeviceId},
+    DeviceChange,
+};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Default)]
@@ -105,6 +108,7 @@ impl DeviceList {
                         kind: api::DeviceListChangeKind::Named,
                         index: index as u32,
                         device: connected.clone(),
+                        pending_consolidations: vec![],
                     });
                 }
             }
@@ -132,6 +136,7 @@ impl DeviceList {
                                 kind: api::DeviceListChangeKind::Named,
                                 index: index as u32,
                                 device: connected.clone(),
+                                pending_consolidations: vec![],
                             });
                         }
                     }
@@ -149,6 +154,7 @@ impl DeviceList {
                         kind: api::DeviceListChangeKind::Removed,
                         index: index as u32,
                         device: device.expect("invariant"),
+                        pending_consolidations: vec![],
                     })
                 }
             }
@@ -175,11 +181,23 @@ impl DeviceList {
                 kind: api::DeviceListChangeKind::Added,
                 index: (self.devices.len() - 1) as u32,
                 device: self.get_device(id).expect("invariant"),
+                pending_consolidations: vec![],
             });
         }
     }
 
-    pub fn set_recovery_mode(&mut self, id: DeviceId, recovery_mode: bool) {
+    /// `pending_consolidations` is the deduped set of wallets the device has
+    /// pending physical-backup consolidations for. It should be non-empty only
+    /// for the deferred re-plug auto-exit (`recovery_mode == true` because the
+    /// device turned up with pending work); every other transition — mid-flow
+    /// entries and the clearing exit — passes an empty set so the background
+    /// auto-exit stays out of it.
+    pub fn set_recovery_mode(
+        &mut self,
+        id: DeviceId,
+        recovery_mode: bool,
+        pending_consolidations: Vec<AccessStructureRef>,
+    ) {
         if let Some(connected_device) = self.connected.get_mut(&id) {
             if connected_device.recovery_mode != recovery_mode {
                 connected_device.recovery_mode = recovery_mode;
@@ -188,6 +206,7 @@ impl DeviceList {
                     kind: api::DeviceListChangeKind::RecoveryMode,
                     index: self.index_of(id).expect("invariant") as u32,
                     device: connected_device,
+                    pending_consolidations,
                 })
             }
         }

--- a/frostsnapp/test/secure_key_fallback_test.dart
+++ b/frostsnapp/test/secure_key_fallback_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frostsnap/secure_key_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.frostsnap/secure_key');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  group('AndroidSecureKeyProvider.getOrCreateKey', () {
+    test('returns the 32 key bytes the channel provides', () async {
+      final bytes = Uint8List.fromList(List.generate(32, (i) => i + 1));
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, 'getOrCreateKey');
+        return bytes;
+      });
+
+      final key = await AndroidSecureKeyProvider.forTesting().getOrCreateKey();
+
+      expect(key.field0, orderedEquals(bytes));
+    });
+
+    test('falls back to the empty key on KEY_CREATION_FAILED', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        throw PlatformException(code: 'KEY_CREATION_FAILED');
+      });
+
+      final key = await AndroidSecureKeyProvider.forTesting().getOrCreateKey();
+
+      expect(key.field0.length, 32);
+      expect(key.field0.every((b) => b == 0), isTrue);
+      expect(key.field0, orderedEquals(SecureKeyProvider.emptyKey.field0));
+    });
+
+    test('rethrows a PlatformException with a different code', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        throw PlatformException(code: 'NO_LOCK_SCREEN');
+      });
+
+      await expectLater(
+        AndroidSecureKeyProvider.forTesting().getOrCreateKey(),
+        throwsA(
+          isA<PlatformException>().having((e) => e.code, 'code', 'NO_LOCK_SCREEN'),
+        ),
+      );
+    });
+  });
+}

--- a/frostsnapp/test/wallet_key_mismatch_test.dart
+++ b/frostsnapp/test/wallet_key_mismatch_test.dart
@@ -1,0 +1,67 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frostsnap/secure_key_provider.dart';
+import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/src/rust/lib.dart';
+import 'package:frostsnap/wallet_key_mismatch.dart';
+
+SymmetricKey _key(int fill) =>
+    SymmetricKey(field0: U8Array32(Uint8List(32)..fillRange(0, 32, fill)));
+
+AccessStructureRef _asRef() => AccessStructureRef(
+  keyId: KeyId(field0: U8Array32(Uint8List(32))),
+  accessStructureId: AccessStructureId(field0: U8Array32(Uint8List(32))),
+);
+
+void main() {
+  group('existingWalletKey routing', () {
+    test('key unavailable -> shows recovery and returns null', () async {
+      var recoveryShown = 0;
+      final result = await existingWalletKey(
+        accessStructureRef: _asRef(),
+        action: 'sign this message',
+        getKey: () async => throw const WalletKeyUnavailable(),
+        canDecrypt: (_) =>
+            fail('canDecrypt must not run when the key is unavailable'),
+        showRecovery: () async => recoveryShown++,
+      );
+
+      expect(result, isNull);
+      expect(recoveryShown, 1);
+    });
+
+    test('wrong key (cannot decrypt) -> shows recovery and returns null', () async {
+      final wrongKey = _key(9);
+      var recoveryShown = 0;
+      final result = await existingWalletKey(
+        accessStructureRef: _asRef(),
+        action: 'sign this message',
+        getKey: () async => wrongKey,
+        canDecrypt: (key) {
+          expect(key, same(wrongKey));
+          return false;
+        },
+        showRecovery: () async => recoveryShown++,
+      );
+
+      expect(result, isNull);
+      expect(recoveryShown, 1);
+    });
+
+    test('correct key (can decrypt) -> returns the key, no recovery', () async {
+      final goodKey = _key(7);
+      var recoveryShown = 0;
+      final result = await existingWalletKey(
+        accessStructureRef: _asRef(),
+        action: 'sign this message',
+        getKey: () async => goodKey,
+        canDecrypt: (_) => true,
+        showRecovery: () async => recoveryShown++,
+      );
+
+      expect(result, same(goodKey));
+      expect(recoveryShown, 0);
+    });
+  });
+}

--- a/frostsnapp/test/wallet_key_mismatch_test.dart
+++ b/frostsnapp/test/wallet_key_mismatch_test.dart
@@ -22,24 +22,9 @@ void main() {
         accessStructureRef: _asRef(),
         action: 'sign this message',
         getKey: () async => throw const WalletKeyUnavailable(),
-        canDecrypt: (_) =>
-            fail('canDecrypt must not run when the key is unavailable'),
-        showRecovery: () async => recoveryShown++,
-      );
-
-      expect(result, isNull);
-      expect(recoveryShown, 1);
-    });
-
-    test('wrong key (cannot decrypt) -> shows recovery and returns null', () async {
-      final wrongKey = _key(9);
-      var recoveryShown = 0;
-      final result = await existingWalletKey(
-        accessStructureRef: _asRef(),
-        action: 'sign this message',
-        getKey: () async => wrongKey,
+        // Only the empty-key fallback probe may run when the key is unavailable.
         canDecrypt: (key) {
-          expect(key, same(wrongKey));
+          expect(key.field0, orderedEquals(SecureKeyProvider.emptyKey.field0));
           return false;
         },
         showRecovery: () async => recoveryShown++,
@@ -48,6 +33,76 @@ void main() {
       expect(result, isNull);
       expect(recoveryShown, 1);
     });
+
+    test(
+      'wrong key (cannot decrypt) -> shows recovery and returns null',
+      () async {
+        final wrongKey = _key(9);
+        final probedKeys = <SymmetricKey>[];
+        var recoveryShown = 0;
+        final result = await existingWalletKey(
+          accessStructureRef: _asRef(),
+          action: 'sign this message',
+          getKey: () async => wrongKey,
+          canDecrypt: (key) {
+            probedKeys.add(key);
+            return false;
+          },
+          showRecovery: () async => recoveryShown++,
+        );
+
+        expect(result, isNull);
+        expect(recoveryShown, 1);
+        // The fetched key first, then the empty-key fallback probe.
+        expect(probedKeys.first, same(wrongKey));
+        expect(
+          probedKeys.last.field0,
+          orderedEquals(SecureKeyProvider.emptyKey.field0),
+        );
+      },
+    );
+
+    test(
+      'key unavailable but empty key decrypts -> returns empty key, no recovery',
+      () async {
+        var recoveryShown = 0;
+        final result = await existingWalletKey(
+          accessStructureRef: _asRef(),
+          action: 'sign this message',
+          getKey: () async => throw const WalletKeyUnavailable(),
+          canDecrypt: (key) => key.field0.every((b) => b == 0),
+          showRecovery: () async => recoveryShown++,
+        );
+
+        expect(result, isNotNull);
+        expect(
+          result!.field0,
+          orderedEquals(SecureKeyProvider.emptyKey.field0),
+        );
+        expect(recoveryShown, 0);
+      },
+    );
+
+    test(
+      'wrong key but empty key decrypts -> returns empty key, no recovery',
+      () async {
+        var recoveryShown = 0;
+        final result = await existingWalletKey(
+          accessStructureRef: _asRef(),
+          action: 'sign this message',
+          getKey: () async => _key(9),
+          canDecrypt: (key) => key.field0.every((b) => b == 0),
+          showRecovery: () async => recoveryShown++,
+        );
+
+        expect(result, isNotNull);
+        expect(
+          result!.field0,
+          orderedEquals(SecureKeyProvider.emptyKey.field0),
+        );
+        expect(recoveryShown, 0);
+      },
+    );
 
     test('correct key (can decrypt) -> returns the key, no recovery', () async {
       final goodKey = _key(7);

--- a/frostsnapp/test/wallet_key_mismatch_test.dart
+++ b/frostsnapp/test/wallet_key_mismatch_test.dart
@@ -9,10 +9,14 @@ import 'package:frostsnap/wallet_key_mismatch.dart';
 SymmetricKey _key(int fill) =>
     SymmetricKey(field0: U8Array32(Uint8List(32)..fillRange(0, 32, fill)));
 
-AccessStructureRef _asRef() => AccessStructureRef(
-  keyId: KeyId(field0: U8Array32(Uint8List(32))),
-  accessStructureId: AccessStructureId(field0: U8Array32(Uint8List(32))),
+AccessStructureRef _asRef([int fill = 0]) => AccessStructureRef(
+  keyId: KeyId(field0: U8Array32(Uint8List(32)..fillRange(0, 32, fill))),
+  accessStructureId: AccessStructureId(
+    field0: U8Array32(Uint8List(32)..fillRange(0, 32, fill)),
+  ),
 );
+
+DeviceId _deviceId() => DeviceId(field0: U8Array33(Uint8List(33)));
 
 void main() {
   group('existingWalletKey routing', () {
@@ -117,6 +121,86 @@ void main() {
 
       expect(result, same(goodKey));
       expect(recoveryShown, 0);
+    });
+  });
+
+  group('exitRecoveryModeForDevice', () {
+    test('empty set -> no key fetch, no exit', () async {
+      var gotKey = 0;
+      var exited = 0;
+      await exitRecoveryModeForDevice(
+        deviceId: _deviceId(),
+        pendingConsolidations: const [],
+        getKey: (_) async {
+          gotKey++;
+          return _key(1);
+        },
+        canDecrypt: (_, _) => true,
+        exit: (_) => exited++,
+        onMismatch: () async {},
+      );
+      expect(gotKey, 0);
+      expect(exited, 0);
+    });
+
+    test('key decrypts every wallet -> exits with that key', () async {
+      final key = _key(7);
+      SymmetricKey? exitedWith;
+      var mismatchShown = 0;
+      final checked = <AccessStructureRef>[];
+      await exitRecoveryModeForDevice(
+        deviceId: _deviceId(),
+        pendingConsolidations: [_asRef(1), _asRef(2)],
+        getKey: (_) async => key,
+        canDecrypt: (ref, _) {
+          checked.add(ref);
+          return true;
+        },
+        exit: (k) => exitedWith = k,
+        onMismatch: () async => mismatchShown++,
+      );
+      expect(exitedWith, same(key));
+      expect(mismatchShown, 0);
+      // Every wallet was verified before exiting.
+      expect(checked.length, 2);
+    });
+
+    test(
+      'key decrypts the first wallet but not a later one -> no exit, shows mismatch',
+      () async {
+        final key = _key(7);
+        final refA = _asRef(1);
+        final refB = _asRef(2);
+        var exited = 0;
+        var mismatchShown = 0;
+        await exitRecoveryModeForDevice(
+          deviceId: _deviceId(),
+          pendingConsolidations: [refA, refB],
+          getKey: (_) async => key,
+          // Decrypts wallet A but not wallet B: a genuine whole-set mismatch.
+          canDecrypt: (ref, _) => ref == refA,
+          exit: (_) => exited++,
+          onMismatch: () async => mismatchShown++,
+        );
+        expect(exited, 0);
+        expect(mismatchShown, 1);
+      },
+    );
+
+    test('no candidate key (null) -> no exit, no mismatch dialog here', () async {
+      var exited = 0;
+      var mismatchShown = 0;
+      await exitRecoveryModeForDevice(
+        deviceId: _deviceId(),
+        pendingConsolidations: [_asRef(1)],
+        // existingWalletKey returning null means it already surfaced the problem.
+        getKey: (_) async => null,
+        canDecrypt: (_, _) => true,
+        exit: (_) => exited++,
+        onMismatch: () async => mismatchShown++,
+      );
+      expect(exited, 0);
+      expect(mismatchShown, 0);
     });
   });
 }


### PR DESCRIPTION
Follow-on to #511 that closes the `exitRecoveryMode` gap raised in review, and hardens the shared consolidation primitive so a key mismatch can never panic. Opened against the `keystore-empty-key-upstream` branch so it stacks on the empty-key probe — happy to squash/rebase however you prefer.

## Why

`exit_recovery_mode` needs the app decryption key, and every caller supplies it from a wallet-aware context — **except** the `main.dart` device-list `RecoveryMode` listener (the deferred auto-exit that fires when a device with pending consolidations re-plugs). It reached into the global `SecureKeyProvider.getEncryptionKey()` with no wallet context, so it:

1. used the *establishing* key variant (which can mint a fresh key) for what is really an existing-wallet decrypt;
2. could **panic** via `root_shared_key(..).expect("invariant")` inside `consolidate_pending_physical_backups` on a key that can't decrypt; and
3. never went through the `existingWalletKey` guard, so it missed the empty-key probe this PR adds.

Because a wallet can be sealed under the empty-key fallback *or* a hardware key, one device can hold pending consolidations across different key-eras — so no single key is guaranteed to decrypt the whole set, and "check the first, then loop the rest" still panics on a later entry.

## What

- **core** — `consolidate_pending_physical_backups` preflights every pending consolidation and returns a typed `ConsolidateError` instead of `.expect`: all-or-nothing, **zero messages emitted** on any undecryptable ref. `exit_recovery_mode` treats the error as a logged no-op (sends nothing, does not flip recovery mode off), so `recover_share`/`finish_restoring` are fail-safe too. `has_backups_that_need_to_be_consolidated -> bool` becomes `backups_that_need_to_be_consolidated -> Vec<PendingConsolidation>`.
- **event** — the `RecoveryMode` device-list change now carries the full **unique** set of pending access-structure refs (the wallet identity the emitter already holds). The re-plug site supplies it; the mid-flow and exit transitions carry an empty set.
- **app** — the listener routes through a new `exitRecoveryModeForDevice`, which acquires a candidate via `existingWalletKey` and verifies it decrypts **every** pending ref before auto-exiting. On a whole-set mismatch it sends nothing and surfaces the "wallet needs recovery" dialog.

## Tests

- **core:** a mixed-key regression test — one device recovering two wallets sealed under different keys — asserts each key yields `Err(CannotDecrypt { other wallet })` with no messages and no panic (this case previously panicked).
- **app:** `exitRecoveryModeForDevice` unit tests (empty set → no-op; all-decrypt → exits; first-ok/later-fail → no exit + dialog; unavailable → no exit). `flutter analyze` clean, `flutter test` green.

Behavior note: the whole-set-mismatch dialog is the default and is cleanly swappable (an `onMismatch` callback) if you'd rather the background reaction stay silent.
