### PR TITLE
Show Device Colours and Genuine Checks

### DIFF
--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -572,10 +572,32 @@ impl<'a> DeviceLoop<'a> {
                     if let (Some(hw_rsa), Some(cert)) =
                         (self.hardware_rsa.as_mut(), self.certificate.as_ref())
                     {
-                        let signature = hw_rsa.sign(&challenge.0, self.sha256);
+                        use frostsnap_core::schnorr_fun;
+                        // Genuine-hardware proof: DS (RSA) signature over
+                        // `tag ‖ challenge ‖ device_id` (see genuine_challenge_message).
+                        let bound_message =
+                            frostsnap_comms::genuine_certificate::genuine_challenge_message(
+                                **challenge,
+                                self.device_id,
+                            );
+                        let rsa_signature = hw_rsa.sign(&bound_message, self.sha256);
+
+                        // Identity proof: schnorr signature over the challenge with
+                        // our DeviceId key (proof of possession).
+                        let schnorr = schnorr_fun::new_with_deterministic_nonces::<
+                            frostsnap_core::sha2::Sha256,
+                        >();
+                        let identity_signature =
+                            frostsnap_comms::genuine_certificate::sign_identity_challenge(
+                                &schnorr,
+                                self.signer.keypair(),
+                                **challenge,
+                            );
+
                         self.upstream_connection.send_to_coordinator([
-                            DeviceSendBody::SignedChallenge {
-                                signature: Box::new(signature),
+                            DeviceSendBody::GenuineProof {
+                                rsa_signature: Box::new(rsa_signature),
+                                identity_signature,
                                 certificate: Box::new(cert.clone()),
                             },
                         ]);

--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -558,10 +558,32 @@ impl<'a> DeviceLoop<'a> {
                     if let (Some(hw_rsa), Some(cert)) =
                         (self.hardware_rsa.as_mut(), self.certificate.as_ref())
                     {
-                        let signature = hw_rsa.sign(&challenge.0, self.sha256);
+                        use frostsnap_core::schnorr_fun;
+                        // Genuine-hardware proof: DS (RSA) signature over
+                        // `challenge ‖ device_id` (see genuine_challenge_message).
+                        let bound_message =
+                            frostsnap_comms::genuine_certificate::genuine_challenge_message(
+                                **challenge,
+                                self.device_id,
+                            );
+                        let rsa_signature = hw_rsa.sign(&bound_message, self.sha256);
+
+                        // Identity proof: schnorr signature over the challenge with
+                        // our DeviceId key (proof of possession).
+                        let schnorr = schnorr_fun::new_with_deterministic_nonces::<
+                            frostsnap_core::sha2::Sha256,
+                        >();
+                        let identity_signature =
+                            frostsnap_comms::genuine_certificate::sign_identity_challenge(
+                                &schnorr,
+                                self.signer.keypair(),
+                                **challenge,
+                            );
+
                         self.upstream_connection.send_to_coordinator([
-                            DeviceSendBody::SignedChallenge {
-                                signature: Box::new(signature),
+                            DeviceSendBody::GenuineProof {
+                                rsa_signature: Box::new(rsa_signature),
+                                identity_signature,
                                 certificate: Box::new(cert.clone()),
                             },
                         ]);

--- a/frostsnap_comms/src/genuine_certificate.rs
+++ b/frostsnap_comms/src/genuine_certificate.rs
@@ -76,6 +76,12 @@ impl Certificate {
     pub fn unverified_raw_serial(&self) -> String {
         self.body.raw_serial()
     }
+
+    /// The case colour claimed by the certificate, without verifying it (colour
+    /// is cosmetic identity, shown regardless of genuine status).
+    pub fn unverified_case_color(&self) -> CaseColor {
+        self.body.case_color()
+    }
 }
 
 #[derive(bincode::Encode, bincode::Decode, Debug, Copy, Clone, PartialEq)]
@@ -182,14 +188,10 @@ pub fn verify_certificate(
 /// Tag for the device-identity (schnorr) proof-of-possession over the challenge.
 pub const GENUINE_IDENTITY_MESSAGE_TAG: &str = "frostsnap-genuine-identity";
 
-/// The message the device's DS (RSA) key signs for a genuine check: the random
-/// coordinator challenge concatenated with the responding device's own DeviceId
-/// (33-byte compressed pubkey).
-///
-/// Binding the DeviceId is what defeats the relay/MITM: a malicious device cannot
-/// obtain a genuine device's signature on *its* behalf, because a genuine device
-/// only ever signs over its own id. So `RSA_DS(challenge ‖ id)` proves "genuine
-/// hardware attests to DeviceId `id`", not merely "some genuine device exists".
+/// The message the device's DS (RSA) key signs: the coordinator challenge
+/// concatenated with the responder's own DeviceId. Binding the id is what defeats
+/// relay/MITM: a genuine device only ever signs over its own id, so its proof
+/// can't be replayed for another id.
 pub fn genuine_challenge_message(
     challenge: crate::GenuineChallenge,
     device_id: frostsnap_core::DeviceId,
@@ -200,13 +202,9 @@ pub fn genuine_challenge_message(
     message
 }
 
-/// Sign the genuine-check challenge with the device's identity (DeviceId) keypair,
-/// proving the responder actually holds the DeviceId secret and that the response
-/// is fresh. BIP340 schnorr over the even-y form of the device key — the same
-/// primitive keygen already trusts for device identity.
-///
-/// This is the device-side counterpart to [`verify_identity`]. Callable from
-/// firmware (no `coordinator` feature required).
+/// Sign the challenge with the device's identity (DeviceId) keypair, proving the
+/// responder holds the DeviceId secret. Device-side counterpart to
+/// [`verify_identity`].
 pub fn sign_identity_challenge<NG: NonceGen>(
     schnorr: &Schnorr<Sha256, NG>,
     device_keypair: &KeyPair,
@@ -217,9 +215,8 @@ pub fn sign_identity_challenge<NG: NonceGen>(
     schnorr.sign(&xonly_keypair, message)
 }
 
-/// Why a genuine check failed. Distinguishing these helps diagnostics: an unknown
-/// factory key (a device from a factory whose key we don't ship) is very different
-/// from a bad signature (a counterfeit or a relay attempt).
+/// Why a genuine check failed. Worth distinguishing: an unknown factory key is a
+/// device we can't judge, quite different from a bad signature.
 #[cfg(feature = "coordinator")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GenuineError {
@@ -256,15 +253,12 @@ impl core::fmt::Display for GenuineError {
 #[cfg(feature = "coordinator")]
 impl core::error::Error for GenuineError {}
 
-/// Verify a full *bound* genuine proof in one step:
-/// 1. the certificate is signed by the expected factory key,
-/// 2. the DS (RSA) key certified therein signed `challenge ‖ device_id` — genuine
-///    hardware, bound to this specific DeviceId (defeats relay/MITM), and
-/// 3. the DeviceId key itself signed the challenge — proof the responder holds the
-///    DeviceId secret, so the `from` we're talking to is authenticated.
+/// Verify a full *bound* genuine proof: the factory-signed certificate, the DS
+/// (RSA) signature over `challenge ‖ device_id`, and the DeviceId's own signature
+/// over the challenge.
 ///
-/// `device_id` must be the id of the device the coordinator is actually talking to
-/// (the connection's `from`), not a value taken from the message body.
+/// `device_id` must be the connection's `from` (the device we're actually talking
+/// to), never a value from the message body.
 #[cfg(feature = "coordinator")]
 pub fn verify_genuine_bound(
     certificate: &Certificate,
@@ -436,7 +430,6 @@ mod test {
             factory_keypair,
         );
 
-        // The genuine device and its id.
         let device_keypair = KeyPair::new(Scalar::random(&mut test_rng));
         let device_id = frostsnap_core::DeviceId::new(device_keypair.public_key());
 
@@ -486,10 +479,8 @@ mod test {
             Err(GenuineError::ChallengeSignatureInvalid),
         );
 
-        // Genuine hardware proof present but identity proof forged (attacker holds
-        // the DS relay but not the DeviceId secret): the identity signature won't
-        // verify against the claimed id. Simulate by using a valid RSA sig for
-        // `device_id` but an identity sig from a different key.
+        // Genuine RSA proof but a forged identity proof (a relay holder lacks the
+        // DeviceId secret): the identity signature fails against the claimed id.
         let bad_identity = {
             let s = schnorr_fun::new_with_deterministic_nonces::<sha2::Sha256>();
             sign_identity_challenge(&s, &attacker_keypair, challenge)

--- a/frostsnap_comms/src/genuine_certificate.rs
+++ b/frostsnap_comms/src/genuine_certificate.rs
@@ -45,6 +45,18 @@ impl CertificateBody {
             CertificateBody::Frontier { ds_public_key, .. } => ds_public_key,
         }
     }
+
+    pub fn case_color(&self) -> CaseColor {
+        match self {
+            CertificateBody::Frontier { case_color, .. } => *case_color,
+        }
+    }
+
+    pub fn revision(&self) -> &str {
+        match self {
+            CertificateBody::Frontier { revision, .. } => revision,
+        }
+    }
 }
 
 #[derive(bincode::Encode, bincode::Decode, Debug, Clone, PartialEq)]

--- a/frostsnap_comms/src/genuine_certificate.rs
+++ b/frostsnap_comms/src/genuine_certificate.rs
@@ -45,6 +45,18 @@ impl CertificateBody {
             CertificateBody::Frontier { ds_public_key, .. } => ds_public_key,
         }
     }
+
+    pub fn case_color(&self) -> CaseColor {
+        match self {
+            CertificateBody::Frontier { case_color, .. } => *case_color,
+        }
+    }
+
+    pub fn revision(&self) -> &str {
+        match self {
+            CertificateBody::Frontier { revision, .. } => revision,
+        }
+    }
 }
 
 #[derive(bincode::Encode, bincode::Decode, Debug, Clone, PartialEq)]
@@ -63,6 +75,12 @@ impl Certificate {
     /// Should not be trusted, but useful in logging factory failures
     pub fn unverified_raw_serial(&self) -> String {
         self.body.raw_serial()
+    }
+
+    /// The case colour claimed by the certificate, without verifying it (colour
+    /// is cosmetic identity, shown regardless of genuine status).
+    pub fn unverified_case_color(&self) -> CaseColor {
+        self.body.case_color()
     }
 }
 
@@ -167,38 +185,170 @@ pub fn verify_certificate(
     }
 }
 
-/// Verify a certificate and its challenge-response in one step.
-/// Returns the verified certificate body on success.
+/// Tag for the device-identity (schnorr) proof-of-possession over the challenge.
+pub const GENUINE_IDENTITY_MESSAGE_TAG: &str = "frostsnap-genuine-identity";
+
+/// Domain-separation tag for the DS (RSA) genuine-proof message. The DS key signs
+/// nothing else today; the tag guarantees any future use of the key can never
+/// collide with a genuine proof.
+pub const GENUINE_CHALLENGE_MESSAGE_TAG: &[u8; 20] = b"frostsnap-genuine-v1";
+
+/// The message the device's DS (RSA) key signs: a fixed domain tag, then the
+/// coordinator challenge, then the responder's own DeviceId. Binding the id is
+/// what defeats relay/MITM: a genuine device only ever signs over its own id, so
+/// its proof can't be replayed for another id.
+pub fn genuine_challenge_message(
+    challenge: crate::GenuineChallenge,
+    device_id: frostsnap_core::DeviceId,
+) -> [u8; 85] {
+    let mut message = [0u8; 85];
+    message[..20].copy_from_slice(GENUINE_CHALLENGE_MESSAGE_TAG);
+    message[20..52].copy_from_slice(&challenge.0);
+    message[52..].copy_from_slice(device_id.as_bytes());
+    message
+}
+
+/// Sign the challenge with the device's identity (DeviceId) keypair, proving the
+/// responder holds the DeviceId secret. Device-side counterpart to
+/// [`verify_identity`].
+pub fn sign_identity_challenge<NG: NonceGen>(
+    schnorr: &Schnorr<Sha256, NG>,
+    device_keypair: &KeyPair,
+    challenge: crate::GenuineChallenge,
+) -> Signature {
+    let xonly_keypair: KeyPair<EvenY> = (*device_keypair).into();
+    let message = Message::new(GENUINE_IDENTITY_MESSAGE_TAG, &challenge.0);
+    schnorr.sign(&xonly_keypair, message)
+}
+
+/// Why a genuine check failed. Worth distinguishing: an unknown factory key is a
+/// device we can't judge, quite different from a bad signature.
 #[cfg(feature = "coordinator")]
-pub fn verify_genuine(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GenuineError {
+    /// The certificate was signed by a factory key we don't recognise.
+    UnknownFactoryKey,
+    /// The factory signature over the certificate body didn't verify.
+    CertificateSignatureInvalid,
+    /// The certificate's DS public key couldn't be parsed.
+    MalformedDsKey,
+    /// The RSA challenge-response (genuine-hardware proof, bound to the DeviceId)
+    /// didn't verify.
+    ChallengeSignatureInvalid,
+    /// The schnorr identity proof (that the responder holds the DeviceId secret)
+    /// didn't verify.
+    IdentitySignatureInvalid,
+}
+
+#[cfg(feature = "coordinator")]
+impl core::fmt::Display for GenuineError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let s = match self {
+            GenuineError::UnknownFactoryKey => "certificate signed by an unknown factory key",
+            GenuineError::CertificateSignatureInvalid => "factory certificate signature invalid",
+            GenuineError::MalformedDsKey => "malformed DS public key in certificate",
+            GenuineError::ChallengeSignatureInvalid => {
+                "genuine-hardware challenge signature invalid"
+            }
+            GenuineError::IdentitySignatureInvalid => "device identity signature invalid",
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[cfg(feature = "coordinator")]
+impl core::error::Error for GenuineError {}
+
+/// Verify a full *bound* genuine proof: the factory-signed certificate, the DS
+/// (RSA) signature over `tag ‖ challenge ‖ device_id`, and the DeviceId's own signature
+/// over the challenge.
+///
+/// `device_id` must be the connection's `from` (the device we're actually talking
+/// to), never a value from the message body.
+#[cfg(feature = "coordinator")]
+pub fn verify_genuine_bound(
     certificate: &Certificate,
     factory_key: Point<EvenY>,
     challenge: crate::GenuineChallenge,
-    signature: &[u8; 384],
-) -> Option<CertificateBody> {
-    let body = verify_certificate(certificate, factory_key)?;
-    verify_challenge(&body, challenge, signature).ok()?;
-    Some(body)
+    device_id: frostsnap_core::DeviceId,
+    rsa_signature: &[u8; 384],
+    identity_signature: &Signature,
+) -> Result<CertificateBody, GenuineError> {
+    let body = verify_certificate_detailed(certificate, factory_key)?;
+    verify_challenge_bound(&body, challenge, device_id, rsa_signature)?;
+    verify_identity(device_id, challenge, identity_signature)?;
+    Ok(body)
 }
 
-/// Verify the RSA challenge-response signature from a device.
-/// The device signs SHA256(challenge) with its DS private key.
+/// Like [`verify_certificate`] but returns a typed [`GenuineError`] distinguishing
+/// an unknown factory key from an invalid signature.
 #[cfg(feature = "coordinator")]
-pub fn verify_challenge(
+pub fn verify_certificate_detailed(
+    certificate: &Certificate,
+    factory_key: Point<EvenY>,
+) -> Result<CertificateBody, GenuineError> {
+    match &certificate.factory_signature {
+        frostsnap_core::Versioned::V0(factory_signature) => {
+            if factory_key != factory_signature.factory_key {
+                return Err(GenuineError::UnknownFactoryKey);
+            }
+            let certificate_bytes =
+                bincode::encode_to_vec(&certificate.body, CERTIFICATE_BINCODE_CONFIG).unwrap();
+            let message = Message::new("frostsnap-genuine-key", &certificate_bytes);
+            let schnorr = Schnorr::<Sha256>::verify_only();
+            if schnorr.verify(&factory_key, message, &factory_signature.signature) {
+                Ok(certificate.body.clone())
+            } else {
+                Err(GenuineError::CertificateSignatureInvalid)
+            }
+        }
+    }
+}
+
+/// Verify the RSA challenge-response, bound to `device_id`. The device signs
+/// `SHA256(tag ‖ challenge ‖ device_id)` with its DS private key (see
+/// [`genuine_challenge_message`]).
+#[cfg(feature = "coordinator")]
+pub fn verify_challenge_bound(
     certificate_body: &CertificateBody,
     challenge: crate::GenuineChallenge,
+    device_id: frostsnap_core::DeviceId,
     signature: &[u8; 384],
-) -> Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+) -> Result<(), GenuineError> {
     use rsa::pkcs1::DecodeRsaPublicKey;
     use sha2::Digest;
 
-    let ds_public_key = rsa::RsaPublicKey::from_pkcs1_der(certificate_body.ds_public_key())?;
+    let ds_public_key = rsa::RsaPublicKey::from_pkcs1_der(certificate_body.ds_public_key())
+        .map_err(|_| GenuineError::MalformedDsKey)?;
     let padding = rsa::Pkcs1v15Sign::new::<sha2::Sha256>();
-    let message_digest: [u8; 32] = sha2::Sha256::digest(challenge.0).into();
+    let message = genuine_challenge_message(challenge, device_id);
+    let message_digest: [u8; 32] = sha2::Sha256::digest(message).into();
     ds_public_key
         .verify(padding, &message_digest, signature.as_ref())
-        .map_err(|e| alloc::format!("Challenge signature verification failed: {e}"))?;
-    Ok(())
+        .map_err(|_| GenuineError::ChallengeSignatureInvalid)
+}
+
+/// Verify the device-identity schnorr proof against `device_id`'s public key.
+/// Counterpart to [`sign_identity_challenge`].
+#[cfg(feature = "coordinator")]
+pub fn verify_identity(
+    device_id: frostsnap_core::DeviceId,
+    challenge: crate::GenuineChallenge,
+    signature: &Signature,
+) -> Result<(), GenuineError> {
+    // Reject a malformed DeviceId explicitly rather than relying on
+    // `DeviceId::pubkey()`'s fallback, which returns a nullish point (the
+    // generator, whose secret key is the known value 1) for invalid bytes.
+    let point: Point =
+        Point::from_bytes(*device_id.as_bytes()).ok_or(GenuineError::IdentitySignatureInvalid)?;
+    let (xonly, _) = point.into_point_with_even_y();
+    let message = Message::new(GENUINE_IDENTITY_MESSAGE_TAG, &challenge.0);
+    let schnorr = Schnorr::<Sha256>::verify_only();
+    if schnorr.verify(&xonly, message, signature) {
+        Ok(())
+    } else {
+        Err(GenuineError::IdentitySignatureInvalid)
+    }
 }
 
 #[cfg(test)]
@@ -239,5 +389,143 @@ mod test {
         let verified_cert = verify_certificate(&certificate, factory_keypair.public_key()).unwrap();
 
         std::dbg!(verified_cert.serial_number());
+    }
+
+    /// Simulate the device side of a bound genuine proof: RSA-sign
+    /// `SHA256(tag ‖ challenge ‖ device_id)` with the DS key and schnorr-sign the
+    /// challenge with the device identity key.
+    fn make_bound_proof(
+        ds_private: &RsaPrivateKey,
+        device_keypair: &KeyPair,
+        challenge: crate::GenuineChallenge,
+    ) -> (alloc::boxed::Box<[u8; 384]>, Signature) {
+        use rsa::Pkcs1v15Sign;
+        use sha2::Digest;
+
+        let device_id = frostsnap_core::DeviceId::new(device_keypair.public_key());
+        let message = genuine_challenge_message(challenge, device_id);
+        let digest: [u8; 32] = sha2::Sha256::digest(message).into();
+        let sig_vec = ds_private
+            .sign(Pkcs1v15Sign::new::<sha2::Sha256>(), &digest)
+            .unwrap();
+        let rsa_signature: alloc::boxed::Box<[u8; 384]> =
+            alloc::boxed::Box::new(sig_vec.try_into().expect("3072-bit key => 384-byte sig"));
+
+        let schnorr = schnorr_fun::new_with_deterministic_nonces::<sha2::Sha256>();
+        let identity_signature = sign_identity_challenge(&schnorr, device_keypair, challenge);
+
+        (rsa_signature, identity_signature)
+    }
+
+    #[test]
+    pub fn bound_genuine_proof_roundtrip_and_relay_resistance() {
+        let mut test_rng = ChaCha20Rng::from_seed([7u8; 32]);
+
+        let factory_keypair = KeyPair::new_xonly(Scalar::random(&mut test_rng));
+        let ds_private =
+            RsaPrivateKey::new(&mut test_rng, crate::factory::DS_KEY_SIZE_BITS).unwrap();
+
+        let schnorr = schnorr_fun::new_with_deterministic_nonces::<sha2::Sha256>();
+        let certificate = sign_certificate(
+            schnorr,
+            ds_private.to_public_key().to_pkcs1_der().unwrap().to_vec(),
+            CaseColor::Blue,
+            "2.7-1625".to_string(),
+            "220825002".to_string(),
+            1971,
+            factory_keypair,
+        );
+
+        let device_keypair = KeyPair::new(Scalar::random(&mut test_rng));
+        let device_id = frostsnap_core::DeviceId::new(device_keypair.public_key());
+
+        let challenge = crate::GenuineChallenge([9u8; 32]);
+        let (rsa_signature, identity_signature) =
+            make_bound_proof(&ds_private, &device_keypair, challenge);
+
+        // Happy path: the coordinator verifies against the id it is talking to.
+        let body = verify_genuine_bound(
+            &certificate,
+            factory_keypair.public_key(),
+            challenge,
+            device_id,
+            &rsa_signature,
+            &identity_signature,
+        )
+        .expect("valid bound proof must verify");
+        assert_eq!(body.case_color(), CaseColor::Blue);
+
+        // Relay/MITM: a malicious device forwards this genuine device's proof but
+        // claims a *different* id. The RSA signature is over the genuine id, so it
+        // must fail when checked against the attacker's id.
+        let attacker_keypair = KeyPair::new(Scalar::random(&mut test_rng));
+        let attacker_id = frostsnap_core::DeviceId::new(attacker_keypair.public_key());
+        assert_eq!(
+            verify_genuine_bound(
+                &certificate,
+                factory_keypair.public_key(),
+                challenge,
+                attacker_id,
+                &rsa_signature,
+                &identity_signature,
+            ),
+            Err(GenuineError::ChallengeSignatureInvalid),
+        );
+
+        // Wrong challenge (stale/replayed) fails.
+        assert_eq!(
+            verify_genuine_bound(
+                &certificate,
+                factory_keypair.public_key(),
+                crate::GenuineChallenge([1u8; 32]),
+                device_id,
+                &rsa_signature,
+                &identity_signature,
+            ),
+            Err(GenuineError::ChallengeSignatureInvalid),
+        );
+
+        // Genuine RSA proof but a forged identity proof (a relay holder lacks the
+        // DeviceId secret): the identity signature fails against the claimed id.
+        let bad_identity = {
+            let s = schnorr_fun::new_with_deterministic_nonces::<sha2::Sha256>();
+            sign_identity_challenge(&s, &attacker_keypair, challenge)
+        };
+        assert_eq!(
+            verify_genuine_bound(
+                &certificate,
+                factory_keypair.public_key(),
+                challenge,
+                device_id,
+                &rsa_signature,
+                &bad_identity,
+            ),
+            Err(GenuineError::IdentitySignatureInvalid),
+        );
+
+        // Unknown factory key is distinguished from a bad signature.
+        let other_factory = KeyPair::new_xonly(Scalar::random(&mut test_rng));
+        assert_eq!(
+            verify_genuine_bound(
+                &certificate,
+                other_factory.public_key(),
+                challenge,
+                device_id,
+                &rsa_signature,
+                &identity_signature,
+            ),
+            Err(GenuineError::UnknownFactoryKey),
+        );
+
+        // A malformed DeviceId is rejected outright, not silently treated as a
+        // nullish key.
+        assert_eq!(
+            verify_identity(
+                frostsnap_core::DeviceId([0u8; 33]),
+                challenge,
+                &identity_signature,
+            ),
+            Err(GenuineError::IdentitySignatureInvalid),
+        );
     }
 }

--- a/frostsnap_comms/src/genuine_certificate.rs
+++ b/frostsnap_comms/src/genuine_certificate.rs
@@ -179,38 +179,176 @@ pub fn verify_certificate(
     }
 }
 
-/// Verify a certificate and its challenge-response in one step.
-/// Returns the verified certificate body on success.
+/// Tag for the device-identity (schnorr) proof-of-possession over the challenge.
+pub const GENUINE_IDENTITY_MESSAGE_TAG: &str = "frostsnap-genuine-identity";
+
+/// The message the device's DS (RSA) key signs for a genuine check: the random
+/// coordinator challenge concatenated with the responding device's own DeviceId
+/// (33-byte compressed pubkey).
+///
+/// Binding the DeviceId is what defeats the relay/MITM: a malicious device cannot
+/// obtain a genuine device's signature on *its* behalf, because a genuine device
+/// only ever signs over its own id. So `RSA_DS(challenge ‖ id)` proves "genuine
+/// hardware attests to DeviceId `id`", not merely "some genuine device exists".
+pub fn genuine_challenge_message(
+    challenge: crate::GenuineChallenge,
+    device_id: frostsnap_core::DeviceId,
+) -> [u8; 65] {
+    let mut message = [0u8; 65];
+    message[..32].copy_from_slice(&challenge.0);
+    message[32..].copy_from_slice(device_id.as_bytes());
+    message
+}
+
+/// Sign the genuine-check challenge with the device's identity (DeviceId) keypair,
+/// proving the responder actually holds the DeviceId secret and that the response
+/// is fresh. BIP340 schnorr over the even-y form of the device key — the same
+/// primitive keygen already trusts for device identity.
+///
+/// This is the device-side counterpart to [`verify_identity`]. Callable from
+/// firmware (no `coordinator` feature required).
+pub fn sign_identity_challenge<NG: NonceGen>(
+    schnorr: &Schnorr<Sha256, NG>,
+    device_keypair: &KeyPair,
+    challenge: crate::GenuineChallenge,
+) -> Signature {
+    let xonly_keypair: KeyPair<EvenY> = (*device_keypair).into();
+    let message = Message::new(GENUINE_IDENTITY_MESSAGE_TAG, &challenge.0);
+    schnorr.sign(&xonly_keypair, message)
+}
+
+/// Why a genuine check failed. Distinguishing these helps diagnostics: an unknown
+/// factory key (a device from a factory whose key we don't ship) is very different
+/// from a bad signature (a counterfeit or a relay attempt).
 #[cfg(feature = "coordinator")]
-pub fn verify_genuine(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GenuineError {
+    /// The certificate was signed by a factory key we don't recognise.
+    UnknownFactoryKey,
+    /// The factory signature over the certificate body didn't verify.
+    CertificateSignatureInvalid,
+    /// The certificate's DS public key couldn't be parsed.
+    MalformedDsKey,
+    /// The RSA challenge-response (genuine-hardware proof, bound to the DeviceId)
+    /// didn't verify.
+    ChallengeSignatureInvalid,
+    /// The schnorr identity proof (that the responder holds the DeviceId secret)
+    /// didn't verify.
+    IdentitySignatureInvalid,
+}
+
+#[cfg(feature = "coordinator")]
+impl core::fmt::Display for GenuineError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let s = match self {
+            GenuineError::UnknownFactoryKey => "certificate signed by an unknown factory key",
+            GenuineError::CertificateSignatureInvalid => "factory certificate signature invalid",
+            GenuineError::MalformedDsKey => "malformed DS public key in certificate",
+            GenuineError::ChallengeSignatureInvalid => {
+                "genuine-hardware challenge signature invalid"
+            }
+            GenuineError::IdentitySignatureInvalid => "device identity signature invalid",
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[cfg(feature = "coordinator")]
+impl core::error::Error for GenuineError {}
+
+/// Verify a full *bound* genuine proof in one step:
+/// 1. the certificate is signed by the expected factory key,
+/// 2. the DS (RSA) key certified therein signed `challenge ‖ device_id` — genuine
+///    hardware, bound to this specific DeviceId (defeats relay/MITM), and
+/// 3. the DeviceId key itself signed the challenge — proof the responder holds the
+///    DeviceId secret, so the `from` we're talking to is authenticated.
+///
+/// `device_id` must be the id of the device the coordinator is actually talking to
+/// (the connection's `from`), not a value taken from the message body.
+#[cfg(feature = "coordinator")]
+pub fn verify_genuine_bound(
     certificate: &Certificate,
     factory_key: Point<EvenY>,
     challenge: crate::GenuineChallenge,
-    signature: &[u8; 384],
-) -> Option<CertificateBody> {
-    let body = verify_certificate(certificate, factory_key)?;
-    verify_challenge(&body, challenge, signature).ok()?;
-    Some(body)
+    device_id: frostsnap_core::DeviceId,
+    rsa_signature: &[u8; 384],
+    identity_signature: &Signature,
+) -> Result<CertificateBody, GenuineError> {
+    let body = verify_certificate_detailed(certificate, factory_key)?;
+    verify_challenge_bound(&body, challenge, device_id, rsa_signature)?;
+    verify_identity(device_id, challenge, identity_signature)?;
+    Ok(body)
 }
 
-/// Verify the RSA challenge-response signature from a device.
-/// The device signs SHA256(challenge) with its DS private key.
+/// Like [`verify_certificate`] but returns a typed [`GenuineError`] distinguishing
+/// an unknown factory key from an invalid signature.
 #[cfg(feature = "coordinator")]
-pub fn verify_challenge(
+pub fn verify_certificate_detailed(
+    certificate: &Certificate,
+    factory_key: Point<EvenY>,
+) -> Result<CertificateBody, GenuineError> {
+    match &certificate.factory_signature {
+        frostsnap_core::Versioned::V0(factory_signature) => {
+            if factory_key != factory_signature.factory_key {
+                return Err(GenuineError::UnknownFactoryKey);
+            }
+            let certificate_bytes =
+                bincode::encode_to_vec(&certificate.body, CERTIFICATE_BINCODE_CONFIG).unwrap();
+            let message = Message::new("frostsnap-genuine-key", &certificate_bytes);
+            let schnorr = Schnorr::<Sha256>::verify_only();
+            if schnorr.verify(&factory_key, message, &factory_signature.signature) {
+                Ok(certificate.body.clone())
+            } else {
+                Err(GenuineError::CertificateSignatureInvalid)
+            }
+        }
+    }
+}
+
+/// Verify the RSA challenge-response, bound to `device_id`. The device signs
+/// `SHA256(challenge ‖ device_id)` with its DS private key (see
+/// [`genuine_challenge_message`]).
+#[cfg(feature = "coordinator")]
+pub fn verify_challenge_bound(
     certificate_body: &CertificateBody,
     challenge: crate::GenuineChallenge,
+    device_id: frostsnap_core::DeviceId,
     signature: &[u8; 384],
-) -> Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+) -> Result<(), GenuineError> {
     use rsa::pkcs1::DecodeRsaPublicKey;
     use sha2::Digest;
 
-    let ds_public_key = rsa::RsaPublicKey::from_pkcs1_der(certificate_body.ds_public_key())?;
+    let ds_public_key = rsa::RsaPublicKey::from_pkcs1_der(certificate_body.ds_public_key())
+        .map_err(|_| GenuineError::MalformedDsKey)?;
     let padding = rsa::Pkcs1v15Sign::new::<sha2::Sha256>();
-    let message_digest: [u8; 32] = sha2::Sha256::digest(challenge.0).into();
+    let message = genuine_challenge_message(challenge, device_id);
+    let message_digest: [u8; 32] = sha2::Sha256::digest(message).into();
     ds_public_key
         .verify(padding, &message_digest, signature.as_ref())
-        .map_err(|e| alloc::format!("Challenge signature verification failed: {e}"))?;
-    Ok(())
+        .map_err(|_| GenuineError::ChallengeSignatureInvalid)
+}
+
+/// Verify the device-identity schnorr proof against `device_id`'s public key.
+/// Counterpart to [`sign_identity_challenge`].
+#[cfg(feature = "coordinator")]
+pub fn verify_identity(
+    device_id: frostsnap_core::DeviceId,
+    challenge: crate::GenuineChallenge,
+    signature: &Signature,
+) -> Result<(), GenuineError> {
+    // Reject a malformed DeviceId explicitly rather than relying on
+    // `DeviceId::pubkey()`'s fallback, which returns a nullish point (the
+    // generator, whose secret key is the known value 1) for invalid bytes.
+    let point: Point =
+        Point::from_bytes(*device_id.as_bytes()).ok_or(GenuineError::IdentitySignatureInvalid)?;
+    let (xonly, _) = point.into_point_with_even_y();
+    let message = Message::new(GENUINE_IDENTITY_MESSAGE_TAG, &challenge.0);
+    let schnorr = Schnorr::<Sha256>::verify_only();
+    if schnorr.verify(&xonly, message, signature) {
+        Ok(())
+    } else {
+        Err(GenuineError::IdentitySignatureInvalid)
+    }
 }
 
 #[cfg(test)]
@@ -251,5 +389,146 @@ mod test {
         let verified_cert = verify_certificate(&certificate, factory_keypair.public_key()).unwrap();
 
         std::dbg!(verified_cert.serial_number());
+    }
+
+    /// Simulate the device side of a bound genuine proof: RSA-sign
+    /// `SHA256(challenge ‖ device_id)` with the DS key and schnorr-sign the
+    /// challenge with the device identity key.
+    fn make_bound_proof(
+        ds_private: &RsaPrivateKey,
+        device_keypair: &KeyPair,
+        challenge: crate::GenuineChallenge,
+    ) -> (alloc::boxed::Box<[u8; 384]>, Signature) {
+        use rsa::Pkcs1v15Sign;
+        use sha2::Digest;
+
+        let device_id = frostsnap_core::DeviceId::new(device_keypair.public_key());
+        let message = genuine_challenge_message(challenge, device_id);
+        let digest: [u8; 32] = sha2::Sha256::digest(message).into();
+        let sig_vec = ds_private
+            .sign(Pkcs1v15Sign::new::<sha2::Sha256>(), &digest)
+            .unwrap();
+        let rsa_signature: alloc::boxed::Box<[u8; 384]> =
+            alloc::boxed::Box::new(sig_vec.try_into().expect("3072-bit key => 384-byte sig"));
+
+        let schnorr = schnorr_fun::new_with_deterministic_nonces::<sha2::Sha256>();
+        let identity_signature = sign_identity_challenge(&schnorr, device_keypair, challenge);
+
+        (rsa_signature, identity_signature)
+    }
+
+    #[test]
+    pub fn bound_genuine_proof_roundtrip_and_relay_resistance() {
+        let mut test_rng = ChaCha20Rng::from_seed([7u8; 32]);
+
+        let factory_keypair = KeyPair::new_xonly(Scalar::random(&mut test_rng));
+        let ds_private =
+            RsaPrivateKey::new(&mut test_rng, crate::factory::DS_KEY_SIZE_BITS).unwrap();
+
+        let schnorr = schnorr_fun::new_with_deterministic_nonces::<sha2::Sha256>();
+        let certificate = sign_certificate(
+            schnorr,
+            ds_private.to_public_key().to_pkcs1_der().unwrap().to_vec(),
+            CaseColor::Blue,
+            "2.7-1625".to_string(),
+            "220825002".to_string(),
+            1971,
+            factory_keypair,
+        );
+
+        // The genuine device and its id.
+        let device_keypair = KeyPair::new(Scalar::random(&mut test_rng));
+        let device_id = frostsnap_core::DeviceId::new(device_keypair.public_key());
+
+        let challenge = crate::GenuineChallenge([9u8; 32]);
+        let (rsa_signature, identity_signature) =
+            make_bound_proof(&ds_private, &device_keypair, challenge);
+
+        // Happy path: the coordinator verifies against the id it is talking to.
+        let body = verify_genuine_bound(
+            &certificate,
+            factory_keypair.public_key(),
+            challenge,
+            device_id,
+            &rsa_signature,
+            &identity_signature,
+        )
+        .expect("valid bound proof must verify");
+        assert_eq!(body.case_color(), CaseColor::Blue);
+
+        // Relay/MITM: a malicious device forwards this genuine device's proof but
+        // claims a *different* id. The RSA signature is over the genuine id, so it
+        // must fail when checked against the attacker's id.
+        let attacker_keypair = KeyPair::new(Scalar::random(&mut test_rng));
+        let attacker_id = frostsnap_core::DeviceId::new(attacker_keypair.public_key());
+        assert_eq!(
+            verify_genuine_bound(
+                &certificate,
+                factory_keypair.public_key(),
+                challenge,
+                attacker_id,
+                &rsa_signature,
+                &identity_signature,
+            ),
+            Err(GenuineError::ChallengeSignatureInvalid),
+        );
+
+        // Wrong challenge (stale/replayed) fails.
+        assert_eq!(
+            verify_genuine_bound(
+                &certificate,
+                factory_keypair.public_key(),
+                crate::GenuineChallenge([1u8; 32]),
+                device_id,
+                &rsa_signature,
+                &identity_signature,
+            ),
+            Err(GenuineError::ChallengeSignatureInvalid),
+        );
+
+        // Genuine hardware proof present but identity proof forged (attacker holds
+        // the DS relay but not the DeviceId secret): the identity signature won't
+        // verify against the claimed id. Simulate by using a valid RSA sig for
+        // `device_id` but an identity sig from a different key.
+        let bad_identity = {
+            let s = schnorr_fun::new_with_deterministic_nonces::<sha2::Sha256>();
+            sign_identity_challenge(&s, &attacker_keypair, challenge)
+        };
+        assert_eq!(
+            verify_genuine_bound(
+                &certificate,
+                factory_keypair.public_key(),
+                challenge,
+                device_id,
+                &rsa_signature,
+                &bad_identity,
+            ),
+            Err(GenuineError::IdentitySignatureInvalid),
+        );
+
+        // Unknown factory key is distinguished from a bad signature.
+        let other_factory = KeyPair::new_xonly(Scalar::random(&mut test_rng));
+        assert_eq!(
+            verify_genuine_bound(
+                &certificate,
+                other_factory.public_key(),
+                challenge,
+                device_id,
+                &rsa_signature,
+                &identity_signature,
+            ),
+            Err(GenuineError::UnknownFactoryKey),
+        );
+
+        // A malformed DeviceId is rejected outright, not silently treated as a
+        // nullish key.
+        assert_eq!(
+            verify_identity(
+                frostsnap_core::DeviceId([0u8; 33]),
+                challenge,
+                &identity_signature,
+            ),
+            Err(GenuineError::IdentitySignatureInvalid),
+        );
     }
 }

--- a/frostsnap_comms/src/genuine_certificate.rs
+++ b/frostsnap_comms/src/genuine_certificate.rs
@@ -110,7 +110,9 @@ impl core::fmt::Display for CaseColor {
             CaseColor::Silver => "Silver",
             CaseColor::Blue => "Blue",
             CaseColor::Red => "Red",
-            _ => "Black",
+            // Colours this build has no name for. Only reachable from a newer
+            // device; never store this string (see `FromStr`, which rejects it).
+            _ => "Unknown",
         };
         write!(f, "{}", s)
     }

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -549,6 +549,12 @@ impl Gist for DeviceSendBody {
         match self {
             DeviceSendBody::Core(msg) => msg.gist(),
             DeviceSendBody::Debug { message } => format!("debug: {message}"),
+            DeviceSendBody::SignedChallenge { certificate, .. } => {
+                format!(
+                    "SignedChallenge(serial={})",
+                    certificate.unverified_raw_serial()
+                )
+            }
             _ => format!("{self:?}"),
         }
     }

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -22,6 +22,7 @@ pub use fixed_string::{
     DeviceName, FixedString, StringTooLong, DEVICE_NAME_MAX_LENGTH, KEY_NAME_MAX_LENGTH,
 };
 
+use frostsnap_core::schnorr_fun::Signature;
 use genuine_certificate::Certificate;
 
 /// We choose this baudrate because esp32c3 freezes interrupts during flash
@@ -448,8 +449,21 @@ pub enum DeviceSendBody {
     NeedName,
     _LegacyAckUpgradeMode, // Used by earliest devices
     Misc(CommsMisc),
-    SignedChallenge {
+    /// Retired unbound genuine response (RSA over the bare challenge, no DeviceId
+    /// binding), superseded by [`Self::GenuineProof`] and never trusted (it's
+    /// relay-able). Kept only to decode pre-binding firmware; its wire position
+    /// must be preserved so it doesn't shift `GenuineProof`'s discriminant.
+    _LegacyGenuineProof {
         signature: Box<[u8; 384]>,
+        certificate: Box<Certificate>,
+    },
+    /// Bound genuine proof responding to a [`CoordinatorSendBody::Challenge`].
+    /// `rsa_signature` is the hardware DS key over `SHA256(tag ‖ challenge ‖ device_id)`
+    /// (bound to this DeviceId, defeating relay/MITM); `identity_signature` is the
+    /// DeviceId key over the challenge (proof of possession).
+    GenuineProof {
+        rsa_signature: Box<[u8; 384]>,
+        identity_signature: Signature,
         certificate: Box<Certificate>,
     },
 }
@@ -547,6 +561,18 @@ impl Gist for DeviceSendBody {
         match self {
             DeviceSendBody::Core(msg) => msg.gist(),
             DeviceSendBody::Debug { message } => format!("debug: {message}"),
+            DeviceSendBody::_LegacyGenuineProof { certificate, .. } => {
+                format!(
+                    "_LegacyGenuineProof(serial={})",
+                    certificate.unverified_raw_serial()
+                )
+            }
+            DeviceSendBody::GenuineProof { certificate, .. } => {
+                format!(
+                    "GenuineProof(serial={})",
+                    certificate.unverified_raw_serial()
+                )
+            }
             _ => format!("{self:?}"),
         }
     }

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -21,6 +21,7 @@ pub use fixed_string::{
     DeviceName, FixedString, StringTooLong, DEVICE_NAME_MAX_LENGTH, KEY_NAME_MAX_LENGTH,
 };
 
+use frostsnap_core::schnorr_fun::Signature;
 use genuine_certificate::Certificate;
 
 /// We choose this baudrate because esp32c3 freezes interrupts during flash
@@ -450,8 +451,21 @@ pub enum DeviceSendBody {
     NeedName,
     _LegacyAckUpgradeMode, // Used by earliest devices
     Misc(CommsMisc),
-    SignedChallenge {
+    /// Retired unbound genuine response (RSA over the bare challenge, no DeviceId
+    /// binding), superseded by [`Self::GenuineProof`] and never trusted (it's
+    /// relay-able). Kept only to decode pre-binding firmware; its wire position
+    /// must be preserved so it doesn't shift `GenuineProof`'s discriminant.
+    _LegacyGenuineProof {
         signature: Box<[u8; 384]>,
+        certificate: Box<Certificate>,
+    },
+    /// Bound genuine proof responding to a [`CoordinatorSendBody::Challenge`].
+    /// `rsa_signature` is the hardware DS key over `SHA256(challenge ‖ device_id)`
+    /// (bound to this DeviceId, defeating relay/MITM); `identity_signature` is the
+    /// DeviceId key over the challenge (proof of possession).
+    GenuineProof {
+        rsa_signature: Box<[u8; 384]>,
+        identity_signature: Signature,
         certificate: Box<Certificate>,
     },
 }
@@ -549,9 +563,15 @@ impl Gist for DeviceSendBody {
         match self {
             DeviceSendBody::Core(msg) => msg.gist(),
             DeviceSendBody::Debug { message } => format!("debug: {message}"),
-            DeviceSendBody::SignedChallenge { certificate, .. } => {
+            DeviceSendBody::_LegacyGenuineProof { certificate, .. } => {
                 format!(
-                    "SignedChallenge(serial={})",
+                    "_LegacyGenuineProof(serial={})",
+                    certificate.unverified_raw_serial()
+                )
+            }
+            DeviceSendBody::GenuineProof { certificate, .. } => {
+                format!(
+                    "GenuineProof(serial={})",
                     certificate.unverified_raw_serial()
                 )
             }

--- a/frostsnap_coordinator/src/frostsnap_persist.rs
+++ b/frostsnap_coordinator/src/frostsnap_persist.rs
@@ -175,6 +175,7 @@ impl TakeStaged<Option<ActiveSignSession>> for Option<ActiveSignSession> {
 #[derive(Default)]
 pub struct DeviceNames {
     names: HashMap<DeviceId, String>,
+    case_colors: HashMap<DeviceId, String>,
     mutations: VecDeque<(DeviceId, String)>,
 }
 
@@ -185,8 +186,19 @@ impl DeviceNames {
         }
     }
 
+    /// Sets case color in memory only. The color gets persisted to DB when the
+    /// device name is next written (see `persist_update`), since `name` is NOT
+    /// NULL and the genuine check fires before the device has a name.
+    pub fn set_case_color(&mut self, device_id: DeviceId, case_color: String) {
+        self.case_colors.insert(device_id, case_color);
+    }
+
     pub fn get(&self, device_id: DeviceId) -> Option<String> {
         self.names.get(&device_id).cloned()
+    }
+
+    pub fn get_case_color(&self, device_id: DeviceId) -> Option<String> {
+        self.case_colors.get(&device_id).cloned()
     }
 }
 
@@ -212,6 +224,8 @@ impl Persist<rusqlite::Connection> for DeviceNames {
                 id BLOB PRIMARY KEY, \
                 name TEXT NOT NULL \
             )",
+            // Version 1: persist genuine device info
+            "ALTER TABLE fs_devices ADD COLUMN case_color TEXT",
         ];
 
         let db_tx = conn.transaction()?;
@@ -224,18 +238,22 @@ impl Persist<rusqlite::Connection> for DeviceNames {
     where
         Self: Sized,
     {
-        let mut stmt = conn.prepare("SELECT id, name FROM fs_devices")?;
+        let mut stmt = conn.prepare("SELECT id, name, case_color FROM fs_devices")?;
         let mut device_names = DeviceNames::default();
 
         let row_iter = stmt.query_map([], |row| {
             let device_id = row.get::<_, DeviceId>(0)?;
             let name = row.get::<_, String>(1)?;
-            Ok((device_id, name))
+            let case_color = row.get::<_, Option<String>>(2)?;
+            Ok((device_id, name, case_color))
         })?;
 
         for row in row_iter {
-            let (device_id, name) = row?;
+            let (device_id, name, case_color) = row?;
             device_names.names.insert(device_id, name);
+            if let Some(color) = case_color {
+                device_names.case_colors.insert(device_id, color);
+            }
         }
 
         Ok(device_names)
@@ -247,9 +265,15 @@ impl Persist<rusqlite::Connection> for DeviceNames {
         update: Self::Update,
     ) -> anyhow::Result<()> {
         for (id, name) in update {
+            // Also persist any known case_color from memory alongside the name.
+            // Case color is set via `MUTATE_NO_PERSIST` when the genuine check
+            // completes, because the genuine check fires before the device has
+            // a name (so we can't create the DB row yet). The color lives in
+            // memory until this name write carries it to the DB.
+            let case_color = self.case_colors.get(&id);
             conn.execute(
-                "INSERT OR REPLACE INTO fs_devices (id, name) VALUES (?1, ?2)",
-                params![id, name],
+                "INSERT OR REPLACE INTO fs_devices (id, name, case_color) VALUES (?1, ?2, ?3)",
+                params![id, name, case_color],
             )?;
         }
 

--- a/frostsnap_coordinator/src/frostsnap_persist.rs
+++ b/frostsnap_coordinator/src/frostsnap_persist.rs
@@ -256,3 +256,203 @@ impl Persist<rusqlite::Connection> for DeviceNames {
         Ok(())
     }
 }
+
+/// What a device's verified certificate told us about it.
+///
+/// Display data, deliberately: it is what lets the app show a known device's colour
+/// and serial the moment it appears — and while it is disconnected — without
+/// spending a DS exponentiation. It is never evidence. A stored record does not
+/// suppress a challenge and does not by itself render a "genuine" verdict; see
+/// [`crate::genuine_check`] for why honouring a remembered verdict would be worse
+/// than having no check at all.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GenuineRecord {
+    /// The case colour's name, via `CaseColor`'s `Display`. A colour this build has
+    /// no name for stores as "Unknown" and reads back as no colour — `FromStr`
+    /// rejects it — rather than being recorded as the wrong one. Nothing is lost by
+    /// that: a device is re-challenged on every connect, so a later build that does
+    /// know the colour learns it the next time the device is plugged in.
+    pub case_color: String,
+    pub serial: String,
+    pub revision: String,
+}
+
+/// Persisted [`GenuineRecord`]s keyed by [`DeviceId`].
+///
+/// Kept apart from `DeviceNames` on purpose: the check resolves before a device is
+/// named, and a device may never be named at all, so storing this alongside the name
+/// would drop the colour for exactly the devices the user most needs to tell apart.
+#[derive(Default)]
+pub struct GenuineDeviceInfo {
+    info: HashMap<DeviceId, GenuineRecord>,
+    /// `None` means "delete this row".
+    mutations: VecDeque<(DeviceId, Option<GenuineRecord>)>,
+}
+
+impl GenuineDeviceInfo {
+    pub fn set(&mut self, device_id: DeviceId, record: GenuineRecord) {
+        if self.info.get(&device_id) != Some(&record) {
+            self.info.insert(device_id, record.clone());
+            self.mutations.push_back((device_id, Some(record)));
+        }
+    }
+
+    /// Forget a device, e.g. after it failed a live check or was erased. What we
+    /// stored describes hardware we can no longer vouch for, so it should stop
+    /// being shown rather than linger as a stale colour.
+    pub fn remove(&mut self, device_id: DeviceId) {
+        if self.info.remove(&device_id).is_some() {
+            self.mutations.push_back((device_id, None));
+        }
+    }
+
+    pub fn get(&self, device_id: DeviceId) -> Option<&GenuineRecord> {
+        self.info.get(&device_id)
+    }
+}
+
+impl TakeStaged<VecDeque<(DeviceId, Option<GenuineRecord>)>> for GenuineDeviceInfo {
+    fn take_staged_update(&mut self) -> Option<VecDeque<(DeviceId, Option<GenuineRecord>)>> {
+        if self.mutations.is_empty() {
+            None
+        } else {
+            Some(core::mem::take(&mut self.mutations))
+        }
+    }
+}
+
+impl Persist<rusqlite::Connection> for GenuineDeviceInfo {
+    type Update = VecDeque<(DeviceId, Option<GenuineRecord>)>;
+    type LoadParams = ();
+
+    fn migrate(conn: &mut rusqlite::Connection) -> anyhow::Result<()> {
+        const SCHEMA_NAME: &str = "frostsnap_genuine_devices";
+        const MIGRATIONS: &[&str] = &[
+            // Version 0
+            "CREATE TABLE IF NOT EXISTS fs_genuine_devices ( \
+                id BLOB PRIMARY KEY, \
+                case_color TEXT NOT NULL, \
+                serial TEXT NOT NULL, \
+                revision TEXT NOT NULL \
+            )",
+        ];
+
+        let db_tx = conn.transaction()?;
+        migrate_schema(&db_tx, SCHEMA_NAME, MIGRATIONS)?;
+        db_tx.commit()?;
+        Ok(())
+    }
+
+    fn load(conn: &mut rusqlite::Connection, _params: Self::LoadParams) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut stmt =
+            conn.prepare("SELECT id, case_color, serial, revision FROM fs_genuine_devices")?;
+        let mut genuine = GenuineDeviceInfo::default();
+
+        let row_iter = stmt.query_map([], |row| {
+            let device_id = row.get::<_, DeviceId>(0)?;
+            let record = GenuineRecord {
+                case_color: row.get::<_, String>(1)?,
+                serial: row.get::<_, String>(2)?,
+                revision: row.get::<_, String>(3)?,
+            };
+            Ok((device_id, record))
+        })?;
+
+        for row in row_iter {
+            let (device_id, record) = row?;
+            genuine.info.insert(device_id, record);
+        }
+
+        Ok(genuine)
+    }
+
+    fn persist_update(
+        &self,
+        conn: &mut rusqlite::Connection,
+        update: Self::Update,
+    ) -> anyhow::Result<()> {
+        for (id, record) in update {
+            match record {
+                Some(record) => conn.execute(
+                    "INSERT OR REPLACE INTO fs_genuine_devices (id, case_color, serial, revision) \
+                     VALUES (?1, ?2, ?3, ?4)",
+                    params![id, record.case_color, record.serial, record.revision],
+                )?,
+                None => conn.execute(
+                    "DELETE FROM fs_genuine_devices WHERE id = ?1",
+                    params![id],
+                )?,
+            };
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod genuine_device_info_test {
+    use super::*;
+    use crate::persist::Persist;
+    use tempfile::NamedTempFile;
+
+    fn record(color: &str) -> GenuineRecord {
+        GenuineRecord {
+            case_color: color.to_string(),
+            serial: "220825002".to_string(),
+            revision: "2.7-1625".to_string(),
+        }
+    }
+
+    fn device(byte: u8) -> DeviceId {
+        DeviceId([byte; 33])
+    }
+
+    #[test]
+    fn records_survive_a_reload_and_removal_is_persisted() -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let mut conn = rusqlite::Connection::open(temp_file.path())?;
+        GenuineDeviceInfo::migrate(&mut conn)?;
+
+        let mut info = GenuineDeviceInfo::load(&mut conn, ())?;
+        info.set(device(1), record("Orange"));
+        info.set(device(2), record("Red"));
+        // Re-setting the same value shouldn't stage a redundant write.
+        info.set(device(1), record("Orange"));
+        let update = info.take_staged_update().expect("two devices staged");
+        assert_eq!(update.len(), 2);
+        info.persist_update(&mut conn, update)?;
+
+        let reloaded = GenuineDeviceInfo::load(&mut conn, ())?;
+        assert_eq!(reloaded.get(device(1)), Some(&record("Orange")));
+        assert_eq!(reloaded.get(device(2)), Some(&record("Red")));
+
+        // A device that fails a live check stops being vouched for, and that has to
+        // reach the database — otherwise it comes back on next launch.
+        let mut info = reloaded;
+        info.remove(device(1));
+        let update = info.take_staged_update().expect("removal staged");
+        info.persist_update(&mut conn, update)?;
+
+        let reloaded = GenuineDeviceInfo::load(&mut conn, ())?;
+        assert_eq!(reloaded.get(device(1)), None);
+        assert_eq!(reloaded.get(device(2)), Some(&record("Red")));
+
+        Ok(())
+    }
+
+    /// A colour this build has no name for must read back as no colour, never as
+    /// some other colour — colour is what the user matches against the object in
+    /// their hand.
+    #[test]
+    fn an_unrecognised_colour_reads_back_as_no_colour() {
+        use frostsnap_comms::genuine_certificate::CaseColor;
+        use std::str::FromStr;
+
+        let stored = CaseColor::Unused3.to_string();
+        assert!(CaseColor::from_str(&stored).is_err());
+        assert!(CaseColor::from_str(&CaseColor::Orange.to_string()).is_ok());
+    }
+}

--- a/frostsnap_coordinator/src/frostsnap_persist.rs
+++ b/frostsnap_coordinator/src/frostsnap_persist.rs
@@ -175,7 +175,6 @@ impl TakeStaged<Option<ActiveSignSession>> for Option<ActiveSignSession> {
 #[derive(Default)]
 pub struct DeviceNames {
     names: HashMap<DeviceId, String>,
-    case_colors: HashMap<DeviceId, String>,
     mutations: VecDeque<(DeviceId, String)>,
 }
 
@@ -186,19 +185,8 @@ impl DeviceNames {
         }
     }
 
-    /// Sets case color in memory only. The color gets persisted to DB when the
-    /// device name is next written (see `persist_update`), since `name` is NOT
-    /// NULL and the genuine check fires before the device has a name.
-    pub fn set_case_color(&mut self, device_id: DeviceId, case_color: String) {
-        self.case_colors.insert(device_id, case_color);
-    }
-
     pub fn get(&self, device_id: DeviceId) -> Option<String> {
         self.names.get(&device_id).cloned()
-    }
-
-    pub fn get_case_color(&self, device_id: DeviceId) -> Option<String> {
-        self.case_colors.get(&device_id).cloned()
     }
 }
 
@@ -224,8 +212,6 @@ impl Persist<rusqlite::Connection> for DeviceNames {
                 id BLOB PRIMARY KEY, \
                 name TEXT NOT NULL \
             )",
-            // Version 1: persist genuine device info
-            "ALTER TABLE fs_devices ADD COLUMN case_color TEXT",
         ];
 
         let db_tx = conn.transaction()?;
@@ -238,22 +224,18 @@ impl Persist<rusqlite::Connection> for DeviceNames {
     where
         Self: Sized,
     {
-        let mut stmt = conn.prepare("SELECT id, name, case_color FROM fs_devices")?;
+        let mut stmt = conn.prepare("SELECT id, name FROM fs_devices")?;
         let mut device_names = DeviceNames::default();
 
         let row_iter = stmt.query_map([], |row| {
             let device_id = row.get::<_, DeviceId>(0)?;
             let name = row.get::<_, String>(1)?;
-            let case_color = row.get::<_, Option<String>>(2)?;
-            Ok((device_id, name, case_color))
+            Ok((device_id, name))
         })?;
 
         for row in row_iter {
-            let (device_id, name, case_color) = row?;
+            let (device_id, name) = row?;
             device_names.names.insert(device_id, name);
-            if let Some(color) = case_color {
-                device_names.case_colors.insert(device_id, color);
-            }
         }
 
         Ok(device_names)
@@ -265,15 +247,122 @@ impl Persist<rusqlite::Connection> for DeviceNames {
         update: Self::Update,
     ) -> anyhow::Result<()> {
         for (id, name) in update {
-            // Also persist any known case_color from memory alongside the name.
-            // Case color is set via `MUTATE_NO_PERSIST` when the genuine check
-            // completes, because the genuine check fires before the device has
-            // a name (so we can't create the DB row yet). The color lives in
-            // memory until this name write carries it to the DB.
-            let case_color = self.case_colors.get(&id);
             conn.execute(
-                "INSERT OR REPLACE INTO fs_devices (id, name, case_color) VALUES (?1, ?2, ?3)",
-                params![id, name, case_color],
+                "INSERT OR REPLACE INTO fs_devices (id, name) VALUES (?1, ?2)",
+                params![id, name],
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A genuine device's attested info, extracted from its verified certificate.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GenuineRecord {
+    pub case_color: String,
+    pub serial: String,
+    pub revision: String,
+}
+
+/// Persisted genuine-device info keyed by [`DeviceId`], written the instant a
+/// device passes the genuine check.
+///
+/// Decoupled from [`DeviceNames`] on purpose: the check fires before a device is
+/// named (and it may never be named), so storing this with the name would drop
+/// the colour for unnamed devices. Its own table means a known device shows its
+/// colour on reconnect and while disconnected.
+#[derive(Default)]
+pub struct GenuineDeviceInfo {
+    info: HashMap<DeviceId, GenuineRecord>,
+    mutations: VecDeque<(DeviceId, GenuineRecord)>,
+}
+
+impl GenuineDeviceInfo {
+    pub fn set(&mut self, device_id: DeviceId, record: GenuineRecord) {
+        if self.info.get(&device_id) != Some(&record) {
+            self.info.insert(device_id, record.clone());
+            self.mutations.push_back((device_id, record));
+        }
+    }
+
+    pub fn get(&self, device_id: DeviceId) -> Option<&GenuineRecord> {
+        self.info.get(&device_id)
+    }
+
+    pub fn get_case_color(&self, device_id: DeviceId) -> Option<String> {
+        self.info.get(&device_id).map(|r| r.case_color.clone())
+    }
+}
+
+impl TakeStaged<VecDeque<(DeviceId, GenuineRecord)>> for GenuineDeviceInfo {
+    fn take_staged_update(&mut self) -> Option<VecDeque<(DeviceId, GenuineRecord)>> {
+        if self.mutations.is_empty() {
+            None
+        } else {
+            Some(core::mem::take(&mut self.mutations))
+        }
+    }
+}
+
+impl Persist<rusqlite::Connection> for GenuineDeviceInfo {
+    type Update = VecDeque<(DeviceId, GenuineRecord)>;
+    type LoadParams = ();
+
+    fn migrate(conn: &mut rusqlite::Connection) -> anyhow::Result<()> {
+        const SCHEMA_NAME: &str = "frostsnap_genuine_devices";
+        const MIGRATIONS: &[&str] = &[
+            // Version 0
+            "CREATE TABLE IF NOT EXISTS fs_genuine_devices ( \
+                id BLOB PRIMARY KEY, \
+                case_color TEXT NOT NULL, \
+                serial TEXT NOT NULL, \
+                revision TEXT NOT NULL \
+            )",
+        ];
+
+        let db_tx = conn.transaction()?;
+        migrate_schema(&db_tx, SCHEMA_NAME, MIGRATIONS)?;
+        db_tx.commit()?;
+        Ok(())
+    }
+
+    fn load(conn: &mut rusqlite::Connection, _params: Self::LoadParams) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut stmt =
+            conn.prepare("SELECT id, case_color, serial, revision FROM fs_genuine_devices")?;
+        let mut genuine = GenuineDeviceInfo::default();
+
+        let row_iter = stmt.query_map([], |row| {
+            let device_id = row.get::<_, DeviceId>(0)?;
+            let record = GenuineRecord {
+                case_color: row.get::<_, String>(1)?,
+                serial: row.get::<_, String>(2)?,
+                revision: row.get::<_, String>(3)?,
+            };
+            Ok((device_id, record))
+        })?;
+
+        for row in row_iter {
+            let (device_id, record) = row?;
+            genuine.info.insert(device_id, record);
+        }
+
+        Ok(genuine)
+    }
+
+    fn persist_update(
+        &self,
+        conn: &mut rusqlite::Connection,
+        update: Self::Update,
+    ) -> anyhow::Result<()> {
+        for (id, record) in update {
+            conn.execute(
+                "INSERT OR REPLACE INTO fs_genuine_devices (id, case_color, serial, revision) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![id, record.case_color, record.serial, record.revision],
             )?;
         }
 

--- a/frostsnap_coordinator/src/frostsnap_persist.rs
+++ b/frostsnap_coordinator/src/frostsnap_persist.rs
@@ -293,6 +293,11 @@ impl GenuineDeviceInfo {
     pub fn get_case_color(&self, device_id: DeviceId) -> Option<String> {
         self.info.get(&device_id).map(|r| r.case_color.clone())
     }
+
+    /// Ids of all devices with a stored genuine verdict.
+    pub fn device_ids(&self) -> impl Iterator<Item = DeviceId> + '_ {
+        self.info.keys().copied()
+    }
 }
 
 impl TakeStaged<VecDeque<(DeviceId, GenuineRecord)>> for GenuineDeviceInfo {

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -2,11 +2,10 @@
 const USB_VID: u16 = 12346;
 const USB_PID: u16 = 4097;
 
-// The genuine check as currently implemented is vulnerable to a MITM:
-// a malicious device can forward a received challenge to a genuine
-// device and relay the response back, passing the check without
-// actually holding the DS key. The signature needs to be over the
-// device's own DeviceId to bind it. Disabled until that's fixed.
+// The genuine check now binds each device's DeviceId into the proof it returns,
+// so a relayed proof won't verify against the relayer's id (see
+// `genuine_certificate::verify_genuine_bound`). Still disabled here until the app
+// surfaces the result; the factory performs the check during provisioning.
 const DO_GENUINE_CHECK: bool = false;
 
 use crate::firmware::ValidatedFirmwareBin;
@@ -413,8 +412,21 @@ impl UsbSerialManager {
                                         body: AppMessageBody::Misc(inner),
                                     }))
                                 }
-                                DeviceSendBody::SignedChallenge {
-                                    signature,
+                                DeviceSendBody::_LegacyGenuineProof { .. } => {
+                                    // Legacy unbound response from pre-binding
+                                    // firmware: relay-able, so never trusted. The
+                                    // device needs a firmware upgrade to be verified.
+                                    self.challenges.remove(&message.from);
+                                    event!(
+                                        Level::INFO,
+                                        device = message.from.to_string(),
+                                        "received legacy unbound genuine response; \
+                                         firmware upgrade required to verify genuineness"
+                                    );
+                                }
+                                DeviceSendBody::GenuineProof {
+                                    rsa_signature,
+                                    identity_signature,
                                     certificate,
                                 } => {
                                     let Some(challenge) = self.challenges.remove(&message.from)
@@ -422,19 +434,24 @@ impl UsbSerialManager {
                                         event!(
                                             Level::WARN,
                                             device = message.from.to_string(),
-                                            "received SignedChallenge but no challenge was pending"
+                                            "received GenuineProof but no challenge was pending"
                                         );
                                         continue;
                                     };
-                                    match self.genuine_cert_key.and_then(|key| {
-                                        frostsnap_comms::genuine_certificate::verify_genuine(
-                                            &certificate,
-                                            key,
-                                            challenge,
-                                            &signature,
-                                        )
-                                    }) {
-                                        Some(certificate_body) => {
+                                    let Some(key) = self.genuine_cert_key else {
+                                        continue;
+                                    };
+                                    // Verify against `message.from`, the device
+                                    // we're actually talking to, not the message body.
+                                    match frostsnap_comms::genuine_certificate::verify_genuine_bound(
+                                        &certificate,
+                                        key,
+                                        challenge,
+                                        message.from,
+                                        &rsa_signature,
+                                        &identity_signature,
+                                    ) {
+                                        Ok(certificate_body) => {
                                             self.genuine_devices
                                                 .insert(message.from, certificate_body.clone());
                                             device_changes.push(DeviceChange::GenuineDevice {
@@ -442,8 +459,13 @@ impl UsbSerialManager {
                                                 certificate: certificate_body,
                                             });
                                         }
-                                        None => {
-                                            event!(Level::WARN, device = message.from.to_string(), "genuine check failed — invalid certificate or challenge response");
+                                        Err(e) => {
+                                            event!(
+                                                Level::WARN,
+                                                device = message.from.to_string(),
+                                                error = e.to_string(),
+                                                "genuine check failed"
+                                            );
                                         }
                                     }
                                 }

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -2,12 +2,13 @@
 const USB_VID: u16 = 12346;
 const USB_PID: u16 = 4097;
 
-// The genuine check as currently implemented is vulnerable to a MITM:
-// a malicious device can forward a received challenge to a genuine
-// device and relay the response back, passing the check without
-// actually holding the DS key. The signature needs to be over the
-// device's own DeviceId to bind it. Disabled until that's fixed.
-const DO_GENUINE_CHECK: bool = false;
+// The genuine check binds the device's own DeviceId into both proofs it returns
+// (see `genuine_certificate::verify_genuine_bound`): the DS (RSA) signature is
+// over `challenge ‖ device_id`, and the device also schnorr-signs the challenge
+// with its DeviceId key. This defeats the relay/MITM where a malicious device
+// forwards a challenge to a genuine device — a genuine device only ever signs
+// over its own id, so the relayed proof won't verify against the attacker's id.
+const DO_GENUINE_CHECK: bool = true;
 
 use crate::firmware::ValidatedFirmwareBin;
 use crate::PortOpenError;
@@ -413,8 +414,24 @@ impl UsbSerialManager {
                                         body: AppMessageBody::Misc(inner),
                                     }))
                                 }
-                                DeviceSendBody::SignedChallenge {
-                                    signature,
+                                DeviceSendBody::_LegacyGenuineProof { .. } => {
+                                    // Legacy unbound genuine response from pre-
+                                    // DeviceId-binding firmware. It can't be
+                                    // verified safely (the signature isn't bound
+                                    // to the device's id, so it's relay-able), so
+                                    // we neither trust nor fail it — the device
+                                    // needs a firmware upgrade to be verifiable.
+                                    self.challenges.remove(&message.from);
+                                    event!(
+                                        Level::INFO,
+                                        device = message.from.to_string(),
+                                        "received legacy unbound genuine response; \
+                                         firmware upgrade required to verify genuineness"
+                                    );
+                                }
+                                DeviceSendBody::GenuineProof {
+                                    rsa_signature,
+                                    identity_signature,
                                     certificate,
                                 } => {
                                     let Some(challenge) = self.challenges.remove(&message.from)
@@ -422,19 +439,25 @@ impl UsbSerialManager {
                                         event!(
                                             Level::WARN,
                                             device = message.from.to_string(),
-                                            "received SignedChallenge but no challenge was pending"
+                                            "received GenuineProof but no challenge was pending"
                                         );
                                         continue;
                                     };
-                                    match self.genuine_cert_key.and_then(|key| {
-                                        frostsnap_comms::genuine_certificate::verify_genuine(
-                                            &certificate,
-                                            key,
-                                            challenge,
-                                            &signature,
-                                        )
-                                    }) {
-                                        Some(certificate_body) => {
+                                    let Some(key) = self.genuine_cert_key else {
+                                        continue;
+                                    };
+                                    // Verify against `message.from` — the id of the
+                                    // device we're actually talking to, not a value
+                                    // from the message body.
+                                    match frostsnap_comms::genuine_certificate::verify_genuine_bound(
+                                        &certificate,
+                                        key,
+                                        challenge,
+                                        message.from,
+                                        &rsa_signature,
+                                        &identity_signature,
+                                    ) {
+                                        Ok(certificate_body) => {
                                             self.genuine_devices
                                                 .insert(message.from, certificate_body.clone());
                                             device_changes.push(DeviceChange::GenuineDevice {
@@ -442,8 +465,16 @@ impl UsbSerialManager {
                                                 certificate: certificate_body,
                                             });
                                         }
-                                        None => {
-                                            event!(Level::WARN, device = message.from.to_string(), "genuine check failed — invalid certificate or challenge response");
+                                        Err(e) => {
+                                            event!(
+                                                Level::WARN,
+                                                device = message.from.to_string(),
+                                                error = e.to_string(),
+                                                "genuine check failed"
+                                            );
+                                            device_changes.push(DeviceChange::GenuineCheckFailed {
+                                                id: message.from,
+                                            });
                                         }
                                     }
                                 }
@@ -849,6 +880,12 @@ pub enum DeviceChange {
     GenuineDevice {
         id: DeviceId,
         certificate: frostsnap_comms::genuine_certificate::CertificateBody,
+    },
+    /// The device responded to the genuine challenge but the proof did not verify
+    /// (counterfeit hardware, a relay/MITM attempt, or an unknown factory key —
+    /// see the WARN log for the specific reason).
+    GenuineCheckFailed {
+        id: DeviceId,
     },
 }
 

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -58,10 +58,15 @@ pub struct UsbSerialManager {
     firmware_bin: Option<ValidatedFirmwareBin>,
     /// Genuine certificate public key for verifying device certificates
     genuine_cert_key: Option<Point<EvenY>>,
-    /// Ongoing genuine check challenges to devices
+    /// Genuine challenges we are waiting on answers to, keyed by the device we
+    /// sent them to.
+    ///
+    /// Per connection, and dropped by [`Self::forget_device`] the moment a device
+    /// goes away, so a device is challenged afresh every time it connects. Never
+    /// keyed on a remembered verdict: `from` is self-asserted and a DeviceId is
+    /// public, so honouring a past pass would make announcing a known id a cheaper
+    /// attack than the relay `verify_genuine_bound` exists to stop.
     challenges: HashMap<DeviceId, frostsnap_comms::GenuineChallenge>,
-    /// Devices that passed genuine certificate verification
-    genuine_devices: HashMap<DeviceId, frostsnap_comms::genuine_certificate::CertificateBody>,
 }
 
 pub struct DevicePort {
@@ -97,7 +102,6 @@ impl UsbSerialManager {
             firmware_bin: None,
             genuine_cert_key: None,
             challenges: Default::default(),
-            genuine_devices: Default::default(),
         }
     }
 
@@ -129,9 +133,7 @@ impl UsbSerialManager {
                 if self.device_ports.remove(&device_id).is_some() {
                     changes.push(DeviceChange::Disconnected { id: device_id });
                 }
-                self.registered_devices.remove(&device_id);
-                self.challenges.remove(&device_id);
-                self.genuine_devices.remove(&device_id);
+                self.forget_device(device_id);
                 event!(
                     Level::DEBUG,
                     port = port,
@@ -140,6 +142,35 @@ impl UsbSerialManager {
                 )
             }
         }
+    }
+
+    /// Drop every piece of per-connection state we hold for a device that has gone
+    /// away. Must be called from *every* path that removes a device, not just port
+    /// disconnection — the downstream disconnect below removes devices too, and used
+    /// to leave their entries behind.
+    fn forget_device(&mut self, device_id: DeviceId) {
+        self.registered_devices.remove(&device_id);
+        self.challenges.remove(&device_id);
+    }
+
+    /// Consume the challenge we are waiting on from `device_id`.
+    ///
+    /// `None` for an unsolicited proof, or for a second proof after we already
+    /// consumed the first — a device cannot use an extra answer to replace an
+    /// earlier verdict.
+    fn take_pending_challenge(
+        &mut self,
+        device_id: DeviceId,
+    ) -> Option<frostsnap_comms::GenuineChallenge> {
+        let pending = self.challenges.remove(&device_id);
+        if pending.is_none() {
+            event!(
+                Level::WARN,
+                device = device_id.to_string(),
+                "ignoring genuine proof: no challenge was pending"
+            );
+        }
+        pending
     }
 
     pub fn active_ports(&self) -> HashSet<String> {
@@ -351,13 +382,17 @@ impl UsbSerialManager {
                                             .find(|(_, device_id)| **device_id == message.from)
                                         {
                                             let index_of_disconnection = i + 1;
+                                            let mut disconnected = vec![];
                                             while device_list.len() > index_of_disconnection {
                                                 let device_id = device_list.pop().unwrap();
                                                 self.device_ports.remove(&device_id);
-                                                self.registered_devices.remove(&device_id);
+                                                disconnected.push(device_id);
                                                 device_changes.push(DeviceChange::Disconnected {
                                                     id: device_id,
                                                 });
+                                            }
+                                            for device_id in disconnected {
+                                                self.forget_device(device_id);
                                             }
                                         }
                                     }
@@ -412,35 +447,55 @@ impl UsbSerialManager {
                                         body: AppMessageBody::Misc(inner),
                                     }))
                                 }
-                                DeviceSendBody::_LegacyGenuineProof { .. } => {
+                                DeviceSendBody::_LegacyGenuineProof { certificate, .. } => {
                                     // Legacy unbound response from pre-binding
                                     // firmware: relay-able, so never trusted. The
                                     // device needs a firmware upgrade to be verified.
-                                    self.challenges.remove(&message.from);
+                                    // Report that distinctly — the device isn't
+                                    // suspect, it just can't answer the question.
+                                    if self.take_pending_challenge(message.from).is_none() {
+                                        continue;
+                                    }
                                     event!(
                                         Level::INFO,
                                         device = message.from.to_string(),
                                         "received legacy unbound genuine response; \
                                          firmware upgrade required to verify genuineness"
                                     );
+                                    // Colour is cosmetic identity, not a trust
+                                    // signal, so we take it from the unverified
+                                    // certificate here as we do below.
+                                    device_changes.push(DeviceChange::CaseColor {
+                                        id: message.from,
+                                        color: certificate.unverified_case_color(),
+                                    });
+                                    device_changes.push(DeviceChange::GenuineCheck {
+                                        id: message.from,
+                                        outcome: GenuineOutcome::FirmwareTooOld,
+                                    });
                                 }
                                 DeviceSendBody::GenuineProof {
                                     rsa_signature,
                                     identity_signature,
                                     certificate,
                                 } => {
-                                    let Some(challenge) = self.challenges.remove(&message.from)
+                                    let Some(challenge) = self.take_pending_challenge(message.from)
                                     else {
-                                        event!(
-                                            Level::WARN,
-                                            device = message.from.to_string(),
-                                            "received GenuineProof but no challenge was pending"
-                                        );
                                         continue;
                                     };
                                     let Some(key) = self.genuine_cert_key else {
                                         continue;
                                     };
+                                    // The colour the device claims. Shown whatever
+                                    // the verdict — it is how the user tells their
+                                    // own devices apart, and withholding it until a
+                                    // proof lands would leave every device on old
+                                    // firmware permanently colourless. Trust is
+                                    // carried by the check below, never by colour.
+                                    device_changes.push(DeviceChange::CaseColor {
+                                        id: message.from,
+                                        color: certificate.unverified_case_color(),
+                                    });
                                     // Verify against `message.from`, the device
                                     // we're actually talking to, not the message body.
                                     match frostsnap_comms::genuine_certificate::verify_genuine_bound(
@@ -452,11 +507,11 @@ impl UsbSerialManager {
                                         &identity_signature,
                                     ) {
                                         Ok(certificate_body) => {
-                                            self.genuine_devices
-                                                .insert(message.from, certificate_body.clone());
-                                            device_changes.push(DeviceChange::GenuineDevice {
+                                            device_changes.push(DeviceChange::GenuineCheck {
                                                 id: message.from,
-                                                certificate: certificate_body,
+                                                outcome: GenuineOutcome::Genuine(Box::new(
+                                                    certificate_body,
+                                                )),
                                             });
                                         }
                                         Err(e) => {
@@ -466,6 +521,10 @@ impl UsbSerialManager {
                                                 error = e.to_string(),
                                                 "genuine check failed"
                                             );
+                                            device_changes.push(DeviceChange::GenuineCheck {
+                                                id: message.from,
+                                                outcome: GenuineOutcome::Failed,
+                                            });
                                         }
                                     }
                                 }
@@ -626,14 +685,20 @@ impl UsbSerialManager {
             .unwrap();
 
         if DO_GENUINE_CHECK && self.genuine_cert_key.is_some() {
-            let challenge = frostsnap_comms::GenuineChallenge::random(&mut rand::thread_rng());
-            self.challenges.insert(from, challenge);
-            self.outbox_sender
-                .send(CoordinatorSendMessage::to(
-                    from,
-                    CoordinatorSendBody::Challenge(Box::new(challenge)),
-                ))
-                .unwrap();
+            // Don't replace a challenge we're still waiting on. A device
+            // re-announces when its connection re-handshakes, and the device would
+            // be answering the first challenge while we'd be checking against the
+            // second — reporting a genuine device as not genuine.
+            if let std::collections::hash_map::Entry::Vacant(entry) = self.challenges.entry(from) {
+                let challenge = frostsnap_comms::GenuineChallenge::random(&mut rand::thread_rng());
+                entry.insert(challenge);
+                self.outbox_sender
+                    .send(CoordinatorSendMessage::to(
+                        from,
+                        CoordinatorSendBody::Challenge(Box::new(challenge)),
+                    ))
+                    .unwrap();
+            }
         }
 
         self.reverse_device_ports
@@ -868,10 +933,31 @@ pub enum DeviceChange {
         id: DeviceId,
     },
     AppMessage(AppMessage),
-    GenuineDevice {
+    /// The device's claimed case colour, learned from a certificate we have not
+    /// (yet) verified. Cosmetic identity only — emitted separately from
+    /// [`Self::GenuineCheck`] so that displaying a colour never implies a verdict.
+    CaseColor {
         id: DeviceId,
-        certificate: frostsnap_comms::genuine_certificate::CertificateBody,
+        color: frostsnap_comms::genuine_certificate::CaseColor,
     },
+    /// The genuine check for this connection resolved.
+    GenuineCheck {
+        id: DeviceId,
+        outcome: GenuineOutcome,
+    },
+}
+
+/// How the genuine check turned out for one connection.
+#[derive(Debug, Clone)]
+pub enum GenuineOutcome {
+    /// Proof verified against the id we are talking to.
+    Genuine(Box<frostsnap_comms::genuine_certificate::CertificateBody>),
+    /// The device answered but the proof did not verify: counterfeit, tampered, or
+    /// a relay attempt.
+    Failed,
+    /// Pre-binding firmware: it can only produce the retired unbound proof, so we
+    /// cannot judge it either way until it is upgraded.
+    FirmwareTooOld,
 }
 
 #[derive(Debug, Clone)]

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -2,11 +2,12 @@
 const USB_VID: u16 = 12346;
 const USB_PID: u16 = 4097;
 
-// The genuine check now binds each device's DeviceId into the proof it returns,
-// so a relayed proof won't verify against the relayer's id (see
-// `genuine_certificate::verify_genuine_bound`). Still disabled here until the app
-// surfaces the result; the factory performs the check during provisioning.
-const DO_GENUINE_CHECK: bool = false;
+// Each device binds its own DeviceId into the proof it returns, so a relayed proof
+// won't verify against the relayer's id (see
+// `genuine_certificate::verify_genuine_bound`), and the app now surfaces the result.
+// A build with no genuine certificate key compiled in still never challenges
+// anything — see `UsbSerialManager::genuine_cert_key`.
+const DO_GENUINE_CHECK: bool = true;
 
 use crate::firmware::ValidatedFirmwareBin;
 use crate::PortOpenError;

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -61,6 +61,10 @@ pub struct UsbSerialManager {
     challenges: HashMap<DeviceId, frostsnap_comms::GenuineChallenge>,
     /// Devices that passed genuine certificate verification
     genuine_devices: HashMap<DeviceId, frostsnap_comms::genuine_certificate::CertificateBody>,
+    /// Device ids already known genuine, from a persisted verdict or this
+    /// session. We skip re-challenging these; failures are never recorded here,
+    /// so Unknown/Failed devices are retried on every connect.
+    known_genuine: HashSet<DeviceId>,
 }
 
 pub struct DevicePort {
@@ -97,6 +101,7 @@ impl UsbSerialManager {
             genuine_cert_key: None,
             challenges: Default::default(),
             genuine_devices: Default::default(),
+            known_genuine: Default::default(),
         }
     }
 
@@ -108,6 +113,12 @@ impl UsbSerialManager {
     pub fn with_genuine_cert_key(mut self, key: Point<EvenY>) -> Self {
         self.genuine_cert_key = Some(key);
         self
+    }
+
+    /// Seed the ids we already consider genuine (from persisted verdicts) so we
+    /// don't re-challenge them on connect.
+    pub fn set_known_genuine(&mut self, ids: impl IntoIterator<Item = DeviceId>) {
+        self.known_genuine.extend(ids);
     }
 
     pub fn usb_sender(&self) -> UsbSender {
@@ -465,6 +476,7 @@ impl UsbSerialManager {
                                         Ok(certificate_body) => {
                                             self.genuine_devices
                                                 .insert(message.from, certificate_body.clone());
+                                            self.known_genuine.insert(message.from);
                                             device_changes.push(DeviceChange::GenuineDevice {
                                                 id: message.from,
                                                 certificate: certificate_body,
@@ -651,7 +663,12 @@ impl UsbSerialManager {
             ))
             .unwrap();
 
-        if DO_GENUINE_CHECK && self.genuine_cert_key.is_some() {
+        // Already-verified devices are trusted from their persisted verdict and
+        // not re-challenged; Unknown/Failed devices (never recorded) are retried.
+        if DO_GENUINE_CHECK
+            && self.genuine_cert_key.is_some()
+            && !self.known_genuine.contains(&from)
+        {
             let challenge = frostsnap_comms::GenuineChallenge::random(&mut rand::thread_rng());
             self.challenges.insert(from, challenge);
             self.outbox_sender

--- a/frostsnap_coordinator/src/usb_serial_manager.rs
+++ b/frostsnap_coordinator/src/usb_serial_manager.rs
@@ -2,12 +2,9 @@
 const USB_VID: u16 = 12346;
 const USB_PID: u16 = 4097;
 
-// The genuine check binds the device's own DeviceId into both proofs it returns
-// (see `genuine_certificate::verify_genuine_bound`): the DS (RSA) signature is
-// over `challenge ‖ device_id`, and the device also schnorr-signs the challenge
-// with its DeviceId key. This defeats the relay/MITM where a malicious device
-// forwards a challenge to a genuine device — a genuine device only ever signs
-// over its own id, so the relayed proof won't verify against the attacker's id.
+// The genuine check binds each device's DeviceId into the proof it returns, so a
+// relayed proof won't verify against the relayer's id (see
+// `genuine_certificate::verify_genuine_bound`).
 const DO_GENUINE_CHECK: bool = true;
 
 use crate::firmware::ValidatedFirmwareBin;
@@ -414,14 +411,17 @@ impl UsbSerialManager {
                                         body: AppMessageBody::Misc(inner),
                                     }))
                                 }
-                                DeviceSendBody::_LegacyGenuineProof { .. } => {
-                                    // Legacy unbound genuine response from pre-
-                                    // DeviceId-binding firmware. It can't be
-                                    // verified safely (the signature isn't bound
-                                    // to the device's id, so it's relay-able), so
-                                    // we neither trust nor fail it — the device
-                                    // needs a firmware upgrade to be verifiable.
+                                DeviceSendBody::_LegacyGenuineProof { certificate, .. } => {
+                                    // Legacy unbound response from pre-binding
+                                    // firmware: relay-able, so we neither trust nor
+                                    // fail it. The device needs a firmware upgrade.
+                                    // Case colour is cosmetic, so still surface it
+                                    // (badge stays Unknown).
                                     self.challenges.remove(&message.from);
+                                    device_changes.push(DeviceChange::CaseColor {
+                                        id: message.from,
+                                        color: certificate.unverified_case_color(),
+                                    });
                                     event!(
                                         Level::INFO,
                                         device = message.from.to_string(),
@@ -434,6 +434,12 @@ impl UsbSerialManager {
                                     identity_signature,
                                     certificate,
                                 } => {
+                                    // Surface the case colour up front, independent
+                                    // of the genuine-check outcome below.
+                                    device_changes.push(DeviceChange::CaseColor {
+                                        id: message.from,
+                                        color: certificate.unverified_case_color(),
+                                    });
                                     let Some(challenge) = self.challenges.remove(&message.from)
                                     else {
                                         event!(
@@ -446,9 +452,8 @@ impl UsbSerialManager {
                                     let Some(key) = self.genuine_cert_key else {
                                         continue;
                                     };
-                                    // Verify against `message.from` — the id of the
-                                    // device we're actually talking to, not a value
-                                    // from the message body.
+                                    // Verify against `message.from`, the device
+                                    // we're actually talking to, not the message body.
                                     match frostsnap_comms::genuine_certificate::verify_genuine_bound(
                                         &certificate,
                                         key,
@@ -464,6 +469,18 @@ impl UsbSerialManager {
                                                 id: message.from,
                                                 certificate: certificate_body,
                                             });
+                                        }
+                                        // An unknown factory key isn't a failure,
+                                        // just a device we can't judge (third-party,
+                                        // or a different Frostsnap factory); leave
+                                        // it Unknown. Only a bad signature fails.
+                                        Err(frostsnap_comms::genuine_certificate::GenuineError::UnknownFactoryKey) => {
+                                            event!(
+                                                Level::INFO,
+                                                device = message.from.to_string(),
+                                                "genuine check: certificate from an unrecognised \
+                                                 factory key, leaving status unknown"
+                                            );
                                         }
                                         Err(e) => {
                                             event!(
@@ -881,9 +898,14 @@ pub enum DeviceChange {
         id: DeviceId,
         certificate: frostsnap_comms::genuine_certificate::CertificateBody,
     },
-    /// The device responded to the genuine challenge but the proof did not verify
-    /// (counterfeit hardware, a relay/MITM attempt, or an unknown factory key —
-    /// see the WARN log for the specific reason).
+    /// The device's case colour from its (unverified) certificate. Emitted for any
+    /// certificate-bearing response, so colour shows regardless of genuine status.
+    CaseColor {
+        id: DeviceId,
+        color: frostsnap_comms::genuine_certificate::CaseColor,
+    },
+    /// The device responded but its proof did not verify (counterfeit or a relay
+    /// attempt; see the WARN log for the reason).
     GenuineCheckFailed {
         id: DeviceId,
     },

--- a/frostsnap_factory/src/genuine_check.rs
+++ b/frostsnap_factory/src/genuine_check.rs
@@ -5,6 +5,7 @@ use frostsnap_comms::{
 };
 use frostsnap_coordinator::{DesktopSerial, FramedSerialPort, Serial};
 use frostsnap_core::schnorr_fun::fun::{marker::EvenY, Point};
+use frostsnap_core::schnorr_fun::Signature;
 use std::time::Instant;
 
 use crate::{USB_PID, USB_VID};
@@ -108,36 +109,31 @@ pub fn poll_genuine_check(
         } => {
             match port.try_read_message() {
                 Ok(Some(ReceiveSerial::Message(msg))) => {
-                    if let Ok(DeviceSendBody::SignedChallenge {
-                        signature,
+                    if let Ok(DeviceSendBody::GenuineProof {
+                        rsa_signature,
+                        identity_signature,
                         certificate,
                     }) = msg.body.decode()
                     {
-                        let certificate_body = match genuine_certificate::verify_certificate(
+                        // Verify the bound proof against the id of the device we
+                        // are talking to (`msg.from`).
+                        match genuine_certificate::verify_genuine_bound(
                             &certificate,
                             genuine_key,
+                            *challenge,
+                            msg.from,
+                            &rsa_signature,
+                            &identity_signature,
                         ) {
-                            Some(body) => body,
-                            None => {
-                                return GenuineCheckPollResult::Failed(
-                                    Some(certificate.unverified_raw_serial()),
-                                    "genuine check failed to verify!".to_string(),
-                                );
-                            }
-                        };
-                        let serial = certificate_body.raw_serial();
-
-                        match verify_challenge_signature(&certificate_body, *challenge, &signature)
-                        {
-                            Ok(_) => {
+                            Ok(certificate_body) => {
                                 *state = GenuineCheckState::Complete {
                                     firmware_digest: *firmware_digest,
-                                    serial: serial.to_string(),
+                                    serial: certificate_body.raw_serial(),
                                 };
                             }
                             Err(e) => {
                                 return GenuineCheckPollResult::Failed(
-                                    Some(serial.clone()),
+                                    Some(certificate.unverified_raw_serial()),
                                     format!("Device failed genuine check: {e}"),
                                 );
                             }
@@ -213,24 +209,26 @@ fn wait_for_announce(
     }
 }
 
-type SignedChallengeResponse = (
+type GenuineProofResponse = (
     frostsnap_comms::genuine_certificate::Certificate,
     Box<[u8; 384]>,
+    Signature,
 );
 
-fn wait_for_signed_challenge(
+fn wait_for_genuine_proof(
     port: &mut FramedSerialPort<Downstream>,
-) -> Result<SignedChallengeResponse, Box<dyn std::error::Error>> {
+) -> Result<GenuineProofResponse, Box<dyn std::error::Error>> {
     loop {
         port.poll_send()?;
         match port.try_read_message() {
             Ok(Some(ReceiveSerial::Message(msg))) => {
-                if let Ok(DeviceSendBody::SignedChallenge {
-                    signature,
+                if let Ok(DeviceSendBody::GenuineProof {
+                    rsa_signature,
+                    identity_signature,
                     certificate,
                 }) = msg.body.decode()
                 {
-                    return Ok((*certificate, signature));
+                    return Ok((*certificate, rsa_signature, identity_signature));
                 }
             }
             Ok(_) => {}
@@ -249,14 +247,6 @@ fn try_verify_certificate<'a>(
         }
     }
     Err("Certificate not signed by any known genuine key".into())
-}
-
-pub fn verify_challenge_signature(
-    certificate_body: &CertificateBody,
-    challenge: GenuineChallenge,
-    signature: &[u8; 384],
-) -> Result<(), Box<dyn std::error::Error>> {
-    genuine_certificate::verify_challenge(certificate_body, challenge, signature)
 }
 
 pub struct GenuineCheckResult {
@@ -304,11 +294,17 @@ pub fn run_genuine_check(
         .into(),
     );
 
-    println!("Waiting for signed challenge...");
-    let (certificate, signature) = wait_for_signed_challenge(&mut port)?;
+    println!("Waiting for genuine proof...");
+    let (certificate, rsa_signature, identity_signature) = wait_for_genuine_proof(&mut port)?;
 
     let (env_name, certificate_body) = try_verify_certificate(&certificate, known_keys)?;
-    verify_challenge_signature(&certificate_body, challenge, &signature)?;
+    genuine_certificate::verify_challenge_bound(
+        &certificate_body,
+        challenge,
+        device_id,
+        &rsa_signature,
+    )?;
+    genuine_certificate::verify_identity(device_id, challenge, &identity_signature)?;
 
     let CertificateBody::Frontier {
         case_color,

--- a/frostsnapp/lib/access_structures.dart
+++ b/frostsnapp/lib/access_structures.dart
@@ -3,6 +3,7 @@ import 'package:frostsnap/backup_workflow.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/wallet_add.dart';
 
 class AccessStructureListWidget extends StatelessWidget {
@@ -95,15 +96,17 @@ class _DeviceChip extends StatelessWidget {
     final shareIndex = accessStructure.getDeviceShortShareIndex(
       deviceId: deviceId,
     );
-    final theme = Theme.of(context);
+    final colors = DeviceColorScheme.fromDeviceId(context, deviceId);
 
     return Chip(
       label: DeviceWithShareIndex(
         shareIndex: shareIndex,
         deviceName: deviceName,
       ),
-      backgroundColor: theme.colorScheme.surfaceContainer,
-      deleteIcon: const Icon(Icons.close, size: 18),
+      side: colors.accent != null
+          ? BorderSide(color: colors.accent!.withValues(alpha: 0.5))
+          : null,
+      deleteIcon: Icon(Icons.close, size: 18, color: colors.accent),
       onDeleted: () => _showDeleteDialog(context, deviceName),
     );
   }

--- a/frostsnapp/lib/access_structures.dart
+++ b/frostsnapp/lib/access_structures.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frostsnap/backup_workflow.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
@@ -96,6 +97,7 @@ class _DeviceChip extends StatelessWidget {
       deviceId: deviceId,
     );
     final theme = Theme.of(context);
+    final accent = caseAccentColor(deviceId);
 
     return Chip(
       label: DeviceWithShareIndex(
@@ -103,6 +105,9 @@ class _DeviceChip extends StatelessWidget {
         deviceName: deviceName,
       ),
       backgroundColor: theme.colorScheme.surfaceContainer,
+      side: accent == null
+          ? null
+          : BorderSide(color: accent.withValues(alpha: 0.5)),
       deleteIcon: const Icon(Icons.close, size: 18),
       onDeleted: () => _showDeleteDialog(context, deviceName),
     );

--- a/frostsnapp/lib/device.dart
+++ b/frostsnapp/lib/device.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/device_colors.dart';
+import 'package:frostsnap/genuine_badge.dart';
 import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/id_ext.dart';
@@ -165,7 +167,40 @@ class _DeviceDetailsState extends State<DeviceDetails> {
       ),
     ];
 
+    // Authenticity is about the hardware, not the wallet on it, so it shows for a
+    // fresh device just as much as a named one.
+    final authenticityRows = genuineCheckEnabled
+        ? [
+            Builder(
+              builder: (context) {
+                final (title, subtitle) = device.genuine.explanation;
+                return ListTile(
+                  contentPadding: EdgeInsets.symmetric(horizontal: 16),
+                  title: Text(title),
+                  subtitle: Text(
+                    subtitle.split('\n\n').first,
+                    style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                  ),
+                  leading: Icon(
+                    device.genuine.icon,
+                    color: device.genuine.color(theme.colorScheme),
+                  ),
+                  trailing: Icon(Icons.info_outline_rounded),
+                  onTap: () => showGenuineExplanation(context, device.genuine),
+                );
+              },
+            ),
+          ]
+        : <Widget>[];
+
     final advancedHidden = [
+      if (device.caseColor != null)
+        ListTile(
+          contentPadding: EdgeInsets.symmetric(horizontal: 16),
+          title: Text('Case Colour'),
+          subtitle: Text(device.caseColor!.label, style: monospaceTextStyle),
+          leading: Icon(Icons.circle, color: device.caseColor!.color),
+        ),
       CopyListTile(
         data: device.id.toHex(),
         contentPadding: EdgeInsets.symmetric(horizontal: 16),
@@ -228,6 +263,7 @@ class _DeviceDetailsState extends State<DeviceDetails> {
       mainAxisSize: MainAxisSize.min,
       children: [
         ...(isEmpty ? emptyRows : nonEmptyRows),
+        ...authenticityRows,
         CopyListTile(
           data: device.firmware.digest.toString(),
           contentPadding: EdgeInsets.symmetric(horizontal: 16),

--- a/frostsnapp/lib/device.dart
+++ b/frostsnapp/lib/device.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/copy_feedback.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
@@ -112,6 +113,7 @@ class _DeviceDetailsState extends State<DeviceDetails> {
 
   Widget _buildColumn(BuildContext context, ConnectedDevice device) {
     final theme = Theme.of(context);
+    final colors = DeviceColorScheme.fromDevice(context, device);
     final homeCtx = HomeContext.of(context)!;
     final deviceName = device.name;
     final wallet = coord
@@ -127,7 +129,7 @@ class _DeviceDetailsState extends State<DeviceDetails> {
         contentPadding: EdgeInsets.symmetric(horizontal: 16),
         title: Text('Fresh Device'),
         subtitle: Text('Can be used to create a wallet'),
-        leading: Icon(Icons.ac_unit_rounded),
+        leading: Icon(Icons.ac_unit_rounded, color: colors.accent),
         enabled: false,
       ),
     ];
@@ -143,7 +145,7 @@ class _DeviceDetailsState extends State<DeviceDetails> {
             color: device.name == null ? theme.disabledColor : null,
           ),
         ),
-        leading: Icon(Icons.label_rounded),
+        leading: Icon(Icons.label_rounded, color: colors.accent),
       ),
       ListTile(
         contentPadding: EdgeInsets.symmetric(horizontal: 16),
@@ -154,7 +156,7 @@ class _DeviceDetailsState extends State<DeviceDetails> {
             color: hasWallet ? null : theme.disabledColor,
           ),
         ),
-        leading: Icon(Icons.wallet_rounded),
+        leading: Icon(Icons.wallet_rounded, color: colors.accent),
         trailing: hasWallet ? Icon(Icons.chevron_right_rounded) : null,
         onTap: hasWallet
             ? () {
@@ -175,7 +177,7 @@ class _DeviceDetailsState extends State<DeviceDetails> {
           overflow: TextOverflow.ellipsis,
           style: monospaceTextStyle,
         ),
-        leading: Icon(Icons.fingerprint_rounded),
+        leading: Icon(Icons.fingerprint_rounded, color: colors.accent),
       ),
       if (!isEmpty)
         CopyListTile(
@@ -183,14 +185,14 @@ class _DeviceDetailsState extends State<DeviceDetails> {
           contentPadding: EdgeInsets.symmetric(horizontal: 16),
           title: Text('Nonces'),
           subtitle: Text('$noncesAvailable'),
-          leading: Icon(Icons.numbers_rounded),
+          leading: Icon(Icons.numbers_rounded, color: colors.accent),
         ),
       if (!isEmpty)
         ListTile(
           contentPadding: EdgeInsets.symmetric(horizontal: 16),
           title: Text('Erase device'),
           subtitle: Text('Delete everything from this device'),
-          leading: Icon(Icons.delete_forever_rounded),
+          leading: Icon(Icons.delete_forever_rounded, color: colors.accent),
           trailing: TextButton(
             onPressed: () => showEraseDialog(context, device.id),
             child: Text('Erase'),
@@ -231,7 +233,7 @@ class _DeviceDetailsState extends State<DeviceDetails> {
         CopyListTile(
           data: device.firmware.digest.toString(),
           contentPadding: EdgeInsets.symmetric(horizontal: 16),
-          leading: Icon(Icons.system_update_rounded),
+          leading: Icon(Icons.system_update_rounded, color: colors.accent),
           title: Row(
             children: [
               Text('Firmware'),

--- a/frostsnapp/lib/device.dart
+++ b/frostsnapp/lib/device.dart
@@ -226,9 +226,20 @@ class _DeviceDetailsState extends State<DeviceDetails> {
       ),
     ];
 
+    final genuineRow = colors.genuineRow(context);
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
+        if (genuineRow != null)
+          ListTile(
+            contentPadding: EdgeInsets.symmetric(horizontal: 16),
+            leading: Icon(genuineRow.icon, color: genuineRow.color),
+            title: Text(genuineRow.title),
+            subtitle: Text(genuineRow.subtitle),
+            trailing: Icon(Icons.chevron_right_rounded),
+            onTap: () => colors.showGenuineExplanation(context),
+          ),
         ...(isEmpty ? emptyRows : nonEmptyRows),
         CopyListTile(
           data: device.firmware.digest.toString(),

--- a/frostsnapp/lib/device_colors.dart
+++ b/frostsnapp/lib/device_colors.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:frostsnap/global.dart';
+import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/src/rust/api/device_list.dart';
+
+/// Colors and styling for a device based on its case color
+class DeviceColorScheme {
+  final Color deviceColor;
+  final CaseColor? caseColor;
+
+  DeviceColorScheme({required this.deviceColor, this.caseColor});
+
+  /// Get device color scheme from a DeviceId (works even when disconnected)
+  factory DeviceColorScheme.fromDeviceId(
+    BuildContext context,
+    DeviceId deviceId,
+  ) {
+    final deviceList = coord.deviceListState();
+
+    ConnectedDevice? connectedDevice;
+    try {
+      connectedDevice = deviceList.devices.firstWhere((d) => d.id == deviceId);
+    } catch (_) {
+      connectedDevice = null;
+    }
+
+    // Try connected device color, then fall back to persisted color
+    final caseColor =
+        connectedDevice?.caseColor ?? coord.getDeviceCaseColor(id: deviceId);
+
+    return DeviceColorScheme(
+      deviceColor: caseColor?.toColor() ?? Colors.transparent,
+      caseColor: caseColor,
+    );
+  }
+
+  /// Get device color scheme from a ConnectedDevice
+  factory DeviceColorScheme.fromDevice(
+    BuildContext context,
+    ConnectedDevice? device,
+  ) {
+    final caseColor = device?.caseColor;
+    return DeviceColorScheme(
+      deviceColor: caseColor?.toColor() ?? Colors.transparent,
+      caseColor: caseColor,
+    );
+  }
+
+  /// Device color for icon tinting; null if device has no color
+  Color? get accent => caseColor != null ? deviceColor : null;
+
+  /// Card with colored border and glow effect
+  Widget buildGlowCard({
+    required Widget child,
+    EdgeInsets margin = EdgeInsets.zero,
+    Clip clipBehavior = Clip.hardEdge,
+  }) {
+    if (caseColor == null) {
+      return Card.filled(
+        margin: margin,
+        clipBehavior: clipBehavior,
+        child: child,
+      );
+    }
+    final card = Card.filled(
+      margin: EdgeInsets.zero,
+      clipBehavior: clipBehavior,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: deviceColor.withValues(alpha: 0.6),
+          width: 1.5,
+        ),
+      ),
+      child: child,
+    );
+    return Container(
+      margin: margin,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: deviceColor.withValues(alpha: 0.5),
+            blurRadius: 6,
+          ),
+        ],
+      ),
+      child: card,
+    );
+  }
+}
+
+extension CaseColorExt on CaseColor {
+  Color toColor() => switch (this) {
+    CaseColor.black => const Color(0xFF2C2C2C),
+    CaseColor.orange => const Color(0xFFE8731A),
+    CaseColor.silver => const Color(0xFFB0B0B8),
+    CaseColor.blue => const Color(0xFF2E6FD4),
+    CaseColor.red => const Color(0xFFCC2936),
+  };
+}

--- a/frostsnapp/lib/device_colors.dart
+++ b/frostsnapp/lib/device_colors.dart
@@ -5,6 +5,10 @@ import 'package:frostsnap/src/rust/api/device_list.dart';
 
 /// Colors and styling for a device based on its case color
 class DeviceColorScheme {
+  /// Caution amber (not panic red) for a device that failed verification: even a
+  /// failed device can't compromise a multi-device wallet on its own.
+  static const Color failedColor = Color(0xFFD98A00);
+
   final Color deviceColor;
   final CaseColor? caseColor;
   final GenuineStatus? genuine;
@@ -25,7 +29,6 @@ class DeviceColorScheme {
       connectedDevice = null;
     }
 
-    // Try connected device color, then fall back to persisted color
     final caseColor =
         connectedDevice?.caseColor ?? coord.getDeviceCaseColor(id: deviceId);
 
@@ -49,44 +52,162 @@ class DeviceColorScheme {
     );
   }
 
-  /// True when the device responded to the genuine check but did not verify —
-  /// counterfeit hardware, a relay/MITM attempt, or an unknown factory key.
+  /// True when the device responded but its proof did not verify (counterfeit or
+  /// a relay attempt).
   bool get genuineFailed => genuine == GenuineStatus.failed;
 
-  /// Device color for icon tinting; null if device has no color
+  /// Device color for icon tinting.
   Color? get accent => caseColor != null ? deviceColor : null;
 
-  /// A warning banner to show for a device that failed the genuine check, or
-  /// null if the device is fine. Callers place this near the device's title.
-  Widget? genuineWarning(BuildContext context) {
-    if (!genuineFailed) return null;
+  /// Compact status pill (Genuine / Unknown / Not genuine). Null when this build
+  /// doesn't run the check, so we never imply authenticity we didn't verify.
+  Widget? genuineBadge(BuildContext context) {
+    if (!coord.genuineCheckEnabled()) return null;
     final scheme = Theme.of(context).colorScheme;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(Icons.gpp_bad_rounded, size: 16, color: scheme.error),
-        const SizedBox(width: 4),
-        Flexible(
-          child: Text(
-            'Could not verify authenticity',
-            style: TextStyle(color: scheme.error, fontSize: 12),
-          ),
+    final (icon, color) = _statusIconColor(scheme);
+    // Unknown is neutral by design: usually benign (old firmware, no cert, a
+    // third-party device) and never something the user must act on.
+    final label = switch (genuine) {
+      GenuineStatus.genuine => 'Genuine',
+      GenuineStatus.failed => 'Not genuine',
+      _ => 'Unknown',
+    };
+    // Opens the same explanation dialog as the device-details Authenticity row.
+    return GestureDetector(
+      onTap: () => showGenuineExplanation(context),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: color.withValues(alpha: 0.4)),
         ),
-      ],
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 14, color: color),
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: TextStyle(
+                color: color,
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
-  /// Card with colored border and glow effect. A device that failed the genuine
-  /// check is bordered/glowed in the theme error color instead of its case color.
+  /// Icon + colour for the current status. Shared by badge, row, and dialog.
+  (IconData, Color) _statusIconColor(ColorScheme scheme) => switch (genuine) {
+    GenuineStatus.genuine => (
+      Icons.verified_rounded,
+      caseColor != null ? deviceColor : scheme.primary,
+    ),
+    GenuineStatus.failed => (Icons.gpp_bad_rounded, failedColor),
+    _ => (Icons.gpp_maybe_rounded, scheme.onSurfaceVariant),
+  };
+
+  /// Show the status explanation dialog. Shared by the badge and the
+  /// device-details Authenticity row. Styled to match the app's dialogs
+  /// (see `showErrorDialog` in theme.dart).
+  void showGenuineExplanation(BuildContext context) {
+    final (title, body) = genuineExplanation();
+    showDialog(
+      context: context,
+      builder: (context) {
+        final theme = Theme.of(context);
+        final cs = theme.colorScheme;
+        final (icon, color) = _statusIconColor(cs);
+        return AlertDialog(
+          constraints: const BoxConstraints(maxWidth: 560),
+          icon: Icon(icon, color: color, size: 28),
+          iconPadding: const EdgeInsets.only(top: 24),
+          title: Text(
+            title,
+            style: theme.textTheme.headlineSmall?.copyWith(color: cs.onSurface),
+          ),
+          content: Text(
+            body,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: cs.onSurfaceVariant,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Got it'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// User-facing (title, body) explaining the current genuine status.
+  (String, String) genuineExplanation() {
+    switch (genuine) {
+      case GenuineStatus.genuine:
+        return (
+          'Genuine Device',
+          'This device proved it is genuine Frostsnap hardware, signed by the '
+              'factory.',
+        );
+      case GenuineStatus.failed:
+        return (
+          'Not Genuine',
+          'This device answered the authenticity challenge but its proof did '
+              'not verify. It may be counterfeit or tampered with.\n\n'
+              'Be cautious about relying on it, and get in touch if you did '
+              'not expect this.',
+        );
+      default:
+        return (
+          'Unverified Device',
+          'The device has not proven that it was manufactured by Frostsnap.\n\n'
+              'If you are a developer, or using an open-source or third-party '
+              'device, or a device on older firmware, this is expected.\n\n'
+              'Otherwise, treat it with caution.',
+        );
+    }
+  }
+
+  /// Content for the device-details authenticity row, where the status itself
+  /// is the title. Null when the check isn't active in this build.
+  ({IconData icon, Color color, String title, String subtitle})? genuineRow(
+    BuildContext context,
+  ) {
+    if (!coord.genuineCheckEnabled()) return null;
+    final scheme = Theme.of(context).colorScheme;
+    final (icon, color) = _statusIconColor(scheme);
+    final (title, subtitle) = switch (genuine) {
+      GenuineStatus.genuine => (
+        'Genuine Device',
+        'Verified genuine Frostsnap hardware.',
+      ),
+      GenuineStatus.failed => (
+        'Not Genuine',
+        'This device may be counterfeit or tampered with.',
+      ),
+      _ => (
+        'Unknown Device',
+        'Could not verify this is a genuine Frostsnap device.',
+      ),
+    };
+    return (icon: icon, color: color, title: title, subtitle: subtitle);
+  }
+
+  /// Card with a coloured border and glow in the device's case colour. The glow
+  /// is identity, not trust (the badge carries that).
   Widget buildGlowCard({
     required Widget child,
     EdgeInsets margin = EdgeInsets.zero,
     Clip clipBehavior = Clip.hardEdge,
-    Color? errorColor,
   }) {
-    final glowColor = genuineFailed
-        ? errorColor
-        : (caseColor != null ? deviceColor : null);
+    final glowColor = caseColor != null ? deviceColor : null;
     if (glowColor == null) {
       return Card.filled(
         margin: margin,

--- a/frostsnapp/lib/device_colors.dart
+++ b/frostsnapp/lib/device_colors.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:frostsnap/global.dart';
+import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/src/rust/api/device_list.dart';
+
+/// Case colour for a device we may only hold an id for, taken from the persisted
+/// record so it works while the device is disconnected and costs no round-trip to
+/// the device itself.
+///
+/// `null` when we've never verified it — a device only tells us its colour as part
+/// of a certificate — or when it claims a colour this build has no name for. Prefer
+/// [ConnectedDevice.caseColor] when you have the device in hand; it is live.
+Color? caseAccentColor(DeviceId id) => coord.getDeviceCaseColor(id: id)?.color;
+
+/// The physical colours a Frostsnap case comes in.
+///
+/// Cosmetic identity only — this is how someone tells their own devices apart on a
+/// desk. It is read from a device's certificate *before* and *regardless of*
+/// verification, so a device effectively chooses the colour it claims.
+///
+/// Nothing here may be used to signal trust. That lives in `genuine_badge.dart`,
+/// which deliberately imports nothing from this file: a device must not be able to
+/// influence how its own authenticity is rendered.
+extension CaseColorExt on CaseColor {
+  /// Tuned for the app's dark theme. Black is rendered as a very dark grey rather
+  /// than true black, which would be indistinguishable from "no colour known"
+  /// against a dark surface — the one thing the colour exists to tell you.
+  ///
+  /// Exhaustive with no `default` on purpose: adding a case colour should be a
+  /// compile error here, not a silently wrong render.
+  Color get color => switch (this) {
+    CaseColor.black => const Color(0xFF3A3A42),
+    CaseColor.orange => const Color(0xFFE8731A),
+    CaseColor.silver => const Color(0xFFB0B0B8),
+    CaseColor.blue => const Color(0xFF2E6FD4),
+    CaseColor.red => const Color(0xFFCC2936),
+  };
+
+  String get label => switch (this) {
+    CaseColor.black => 'Black',
+    CaseColor.orange => 'Orange',
+    CaseColor.silver => 'Silver',
+    CaseColor.blue => 'Blue',
+    CaseColor.red => 'Red',
+  };
+}
+
+/// A card outlined and softly glowing in the device's case colour, so a device on
+/// screen can be matched to the one in your hand.
+///
+/// Falls back to a plain filled card when the colour isn't known — which is the
+/// normal state for a device we have never verified, and for one whose firmware
+/// claims a colour this build has no name for.
+class DeviceGlowCard extends StatelessWidget {
+  const DeviceGlowCard({
+    super.key,
+    required this.child,
+    this.caseColor,
+    this.margin = EdgeInsets.zero,
+    this.clipBehavior = Clip.hardEdge,
+  });
+
+  final Widget child;
+  final CaseColor? caseColor;
+  final EdgeInsets margin;
+  final Clip clipBehavior;
+
+  static final BorderRadius _radius = BorderRadius.circular(12);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final glow = caseColor?.color;
+
+    if (glow == null) {
+      return Card.filled(
+        margin: margin,
+        color: theme.colorScheme.surfaceContainerHigh,
+        clipBehavior: clipBehavior,
+        child: child,
+      );
+    }
+
+    return Container(
+      margin: margin,
+      decoration: BoxDecoration(
+        borderRadius: _radius,
+        boxShadow: [
+          BoxShadow(color: glow.withValues(alpha: 0.5), blurRadius: 6),
+        ],
+      ),
+      child: Card.filled(
+        margin: EdgeInsets.zero,
+        color: theme.colorScheme.surfaceContainerHigh,
+        clipBehavior: clipBehavior,
+        shape: RoundedRectangleBorder(
+          borderRadius: _radius,
+          side: BorderSide(color: glow.withValues(alpha: 0.6), width: 1.5),
+        ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/frostsnapp/lib/device_colors.dart
+++ b/frostsnapp/lib/device_colors.dart
@@ -7,8 +7,9 @@ import 'package:frostsnap/src/rust/api/device_list.dart';
 class DeviceColorScheme {
   final Color deviceColor;
   final CaseColor? caseColor;
+  final GenuineStatus? genuine;
 
-  DeviceColorScheme({required this.deviceColor, this.caseColor});
+  DeviceColorScheme({required this.deviceColor, this.caseColor, this.genuine});
 
   /// Get device color scheme from a DeviceId (works even when disconnected)
   factory DeviceColorScheme.fromDeviceId(
@@ -31,6 +32,7 @@ class DeviceColorScheme {
     return DeviceColorScheme(
       deviceColor: caseColor?.toColor() ?? Colors.transparent,
       caseColor: caseColor,
+      genuine: connectedDevice?.genuine,
     );
   }
 
@@ -43,19 +45,49 @@ class DeviceColorScheme {
     return DeviceColorScheme(
       deviceColor: caseColor?.toColor() ?? Colors.transparent,
       caseColor: caseColor,
+      genuine: device?.genuine,
     );
   }
+
+  /// True when the device responded to the genuine check but did not verify —
+  /// counterfeit hardware, a relay/MITM attempt, or an unknown factory key.
+  bool get genuineFailed => genuine == GenuineStatus.failed;
 
   /// Device color for icon tinting; null if device has no color
   Color? get accent => caseColor != null ? deviceColor : null;
 
-  /// Card with colored border and glow effect
+  /// A warning banner to show for a device that failed the genuine check, or
+  /// null if the device is fine. Callers place this near the device's title.
+  Widget? genuineWarning(BuildContext context) {
+    if (!genuineFailed) return null;
+    final scheme = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.gpp_bad_rounded, size: 16, color: scheme.error),
+        const SizedBox(width: 4),
+        Flexible(
+          child: Text(
+            'Could not verify authenticity',
+            style: TextStyle(color: scheme.error, fontSize: 12),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Card with colored border and glow effect. A device that failed the genuine
+  /// check is bordered/glowed in the theme error color instead of its case color.
   Widget buildGlowCard({
     required Widget child,
     EdgeInsets margin = EdgeInsets.zero,
     Clip clipBehavior = Clip.hardEdge,
+    Color? errorColor,
   }) {
-    if (caseColor == null) {
+    final glowColor = genuineFailed
+        ? errorColor
+        : (caseColor != null ? deviceColor : null);
+    if (glowColor == null) {
       return Card.filled(
         margin: margin,
         clipBehavior: clipBehavior,
@@ -67,10 +99,7 @@ class DeviceColorScheme {
       clipBehavior: clipBehavior,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: deviceColor.withValues(alpha: 0.6),
-          width: 1.5,
-        ),
+        side: BorderSide(color: glowColor.withValues(alpha: 0.6), width: 1.5),
       ),
       child: child,
     );
@@ -79,10 +108,7 @@ class DeviceColorScheme {
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
         boxShadow: [
-          BoxShadow(
-            color: deviceColor.withValues(alpha: 0.5),
-            blurRadius: 6,
-          ),
+          BoxShadow(color: glowColor.withValues(alpha: 0.5), blurRadius: 6),
         ],
       ),
       child: card,

--- a/frostsnapp/lib/device_list.dart
+++ b/frostsnapp/lib/device_list.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/device.dart';
 import 'package:frostsnap/device_action_upgrade.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/src/rust/api/device_list.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:frostsnap/wallet_device_list.dart';
@@ -48,6 +49,7 @@ class _DeviceListPageState extends State<DeviceListPage> {
   Widget _buildDevice(BuildContext context, ConnectedDevice device) {
     final theme = Theme.of(context);
     final homeCtx = HomeContext.of(context)!;
+    final colors = DeviceColorScheme.fromDevice(context, device);
     final upgradeEligibility = device.firmwareUpgradeEligibility();
     final walletName = coord
         .frostKeysInvolvingDevice(deviceId: device.id)
@@ -56,28 +58,26 @@ class _DeviceListPageState extends State<DeviceListPage> {
     final hasWallet = walletName != null;
     final hasKey = device.name != null;
 
-    return Card.filled(
+    return colors.buildGlowCard(
       margin: EdgeInsets.symmetric(vertical: 8),
-      color: theme.colorScheme.surfaceContainerHigh,
-      clipBehavior: Clip.hardEdge,
       child: ListTile(
         title: Text(
           device.name ?? 'Unnamed',
-          style: monospaceTextStyle.copyWith(
-            color: hasKey ? null : theme.disabledColor,
-          ),
+          style: hasKey
+              ? monospaceTextStyle
+              : monospaceTextStyle.copyWith(color: theme.disabledColor),
         ),
         subtitle: Text(
           device.name == null
               ? '~'
               : walletName == null
-              ? 'Wallet available for recovery'
-              : walletName,
+                  ? 'Wallet available for recovery'
+                  : walletName,
           style: TextStyle(
             color: hasKey && hasWallet ? null : theme.disabledColor,
           ),
         ),
-        leading: Icon(Icons.key),
+        leading: Icon(Icons.key, color: colors.accent),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           spacing: 8,

--- a/frostsnapp/lib/device_list.dart
+++ b/frostsnapp/lib/device_list.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/device.dart';
 import 'package:frostsnap/device_action_upgrade.dart';
+import 'package:frostsnap/device_colors.dart';
+import 'package:frostsnap/genuine_badge.dart';
 import 'package:frostsnap/src/rust/api/device_list.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:frostsnap/wallet_device_list.dart';
@@ -56,16 +58,24 @@ class _DeviceListPageState extends State<DeviceListPage> {
     final hasWallet = walletName != null;
     final hasKey = device.name != null;
 
-    return Card.filled(
+    return DeviceGlowCard(
       margin: EdgeInsets.symmetric(vertical: 8),
-      color: theme.colorScheme.surfaceContainerHigh,
-      clipBehavior: Clip.hardEdge,
+      caseColor: device.caseColor,
       child: ListTile(
-        title: Text(
-          device.name ?? 'Unnamed',
-          style: monospaceTextStyle.copyWith(
-            color: hasKey ? null : theme.disabledColor,
-          ),
+        title: Row(
+          spacing: 8,
+          children: [
+            Flexible(
+              child: Text(
+                device.name ?? 'Unnamed',
+                overflow: TextOverflow.ellipsis,
+                style: monospaceTextStyle.copyWith(
+                  color: hasKey ? null : theme.disabledColor,
+                ),
+              ),
+            ),
+            GenuineBadge(status: device.genuine),
+          ],
         ),
         subtitle: Text(
           device.name == null

--- a/frostsnapp/lib/device_list.dart
+++ b/frostsnapp/lib/device_list.dart
@@ -58,10 +58,13 @@ class _DeviceListPageState extends State<DeviceListPage> {
     final hasWallet = walletName != null;
     final hasKey = device.name != null;
 
-    final genuineWarning = colors.genuineWarning(context);
+    final genuineBadge = colors.genuineBadge(context);
+    // No subtitle for unnamed devices (rather than a meaningless "~").
+    final subtitleText = device.name == null
+        ? null
+        : (walletName ?? 'Wallet available for recovery');
     return colors.buildGlowCard(
       margin: EdgeInsets.symmetric(vertical: 8),
-      errorColor: theme.colorScheme.error,
       child: ListTile(
         title: Text(
           device.name ?? 'Unnamed',
@@ -69,26 +72,23 @@ class _DeviceListPageState extends State<DeviceListPage> {
               ? monospaceTextStyle
               : monospaceTextStyle.copyWith(color: theme.disabledColor),
         ),
-        subtitle:
-            genuineWarning ??
-            Text(
-              device.name == null
-                  ? '~'
-                  : walletName == null
-                  ? 'Wallet available for recovery'
-                  : walletName,
-              style: TextStyle(
-                color: hasKey && hasWallet ? null : theme.disabledColor,
+        subtitle: subtitleText == null
+            ? null
+            : Text(
+                subtitleText,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: hasKey && hasWallet ? null : theme.disabledColor,
+                ),
               ),
-            ),
-        leading: Icon(
-          colors.genuineFailed ? Icons.gpp_bad_rounded : Icons.key,
-          color: colors.genuineFailed ? theme.colorScheme.error : colors.accent,
-        ),
+        leading: Icon(Icons.key, color: colors.accent),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           spacing: 8,
           children: [
+            // Genuine status on the right, so the left stays a clean
+            // name/wallet column.
+            if (genuineBadge != null) genuineBadge,
             upgradeEligibility.when(
               upToDate: () => SizedBox.shrink(),
               canUpgrade: () => Icon(

--- a/frostsnapp/lib/device_list.dart
+++ b/frostsnapp/lib/device_list.dart
@@ -58,8 +58,10 @@ class _DeviceListPageState extends State<DeviceListPage> {
     final hasWallet = walletName != null;
     final hasKey = device.name != null;
 
+    final genuineWarning = colors.genuineWarning(context);
     return colors.buildGlowCard(
       margin: EdgeInsets.symmetric(vertical: 8),
+      errorColor: theme.colorScheme.error,
       child: ListTile(
         title: Text(
           device.name ?? 'Unnamed',
@@ -67,17 +69,22 @@ class _DeviceListPageState extends State<DeviceListPage> {
               ? monospaceTextStyle
               : monospaceTextStyle.copyWith(color: theme.disabledColor),
         ),
-        subtitle: Text(
-          device.name == null
-              ? '~'
-              : walletName == null
+        subtitle:
+            genuineWarning ??
+            Text(
+              device.name == null
+                  ? '~'
+                  : walletName == null
                   ? 'Wallet available for recovery'
                   : walletName,
-          style: TextStyle(
-            color: hasKey && hasWallet ? null : theme.disabledColor,
-          ),
+              style: TextStyle(
+                color: hasKey && hasWallet ? null : theme.disabledColor,
+              ),
+            ),
+        leading: Icon(
+          colors.genuineFailed ? Icons.gpp_bad_rounded : Icons.key,
+          color: colors.genuineFailed ? theme.colorScheme.error : colors.accent,
         ),
-        leading: Icon(Icons.key, color: colors.accent),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           spacing: 8,

--- a/frostsnapp/lib/genuine_badge.dart
+++ b/frostsnapp/lib/genuine_badge.dart
@@ -1,0 +1,181 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:frostsnap/global.dart';
+import 'package:frostsnap/id_ext.dart';
+import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/src/rust/api/device_list.dart';
+import 'package:frostsnap/theme.dart';
+
+/// Whether a genuine certificate key was compiled into this build. Read once: it is
+/// a compile-time constant on the Rust side, so calling across FFI on every badge
+/// build would be a round-trip per device per frame.
+final bool genuineCheckEnabled = coord.genuineCheckEnabled();
+
+/// How a device's genuine-check result is rendered.
+///
+/// Note what this file does *not* import: `device_colors.dart`. The case colour
+/// arrives in an unverified certificate, so a device chooses it — and a device must
+/// not get to influence how its own authenticity is drawn. Tinting a "Genuine" pill
+/// with the case colour gave a red device a red badge (red being the universal
+/// error colour) and made a black device's badge invisible against the dark theme.
+/// The palette below is fixed and derived only from the status.
+extension GenuineStatusExt on GenuineStatus {
+  IconData get icon => switch (this) {
+    GenuineStatus.genuine => Icons.verified_rounded,
+    GenuineStatus.failed => Icons.gpp_bad_rounded,
+    GenuineStatus.firmwareTooOld => Icons.system_update_rounded,
+    GenuineStatus.unknown => Icons.gpp_maybe_rounded,
+  };
+
+  /// Caution amber rather than error red for a failure: a single dishonest device
+  /// cannot by itself compromise a multi-device wallet, so this is a "stop and look"
+  /// signal, not a catastrophe. Everything else is neutral, because "not verified"
+  /// is the ordinary state for dev units, third-party hardware and older firmware,
+  /// and dressing it as a warning would train people to ignore the badge.
+  Color color(ColorScheme scheme) => switch (this) {
+    GenuineStatus.genuine => scheme.primary,
+    GenuineStatus.failed => cautionColor,
+    GenuineStatus.firmwareTooOld => scheme.onSurfaceVariant,
+    GenuineStatus.unknown => scheme.onSurfaceVariant,
+  };
+
+  String get label => switch (this) {
+    GenuineStatus.genuine => 'Genuine',
+    GenuineStatus.failed => 'Not genuine',
+    GenuineStatus.firmwareTooOld => 'Update to verify',
+    GenuineStatus.unknown => 'Unverified',
+  };
+
+  /// Title and body for the explainer dialog and the device-details row.
+  (String, String) get explanation => switch (this) {
+    GenuineStatus.genuine => (
+      'Genuine device',
+      'This device proved it is genuine Frostsnap hardware, using a key sealed '
+          'into its chip at the factory.\n\n'
+          'The proof is tied to this device and to this connection, so it cannot '
+          'be copied from another device or replayed.',
+    ),
+    GenuineStatus.failed => (
+      'Not genuine',
+      'This device answered the authenticity challenge, but its proof did not '
+          'verify. It may be counterfeit, tampered with, or relaying another '
+          "device's answer.\n\n"
+          'A single device cannot move funds on its own, so this is not an '
+          'emergency — but be careful about relying on it, and get in touch if '
+          'you did not expect it.',
+    ),
+    GenuineStatus.firmwareTooOld => (
+      'Update to verify',
+      'This device is running firmware from before authenticity checks existed, '
+          'so it cannot prove it is genuine — however sound the hardware is.\n\n'
+          'Update its firmware and it will be checked automatically the next '
+          'time you connect it.',
+    ),
+    GenuineStatus.unknown => (
+      'Not verified',
+      'This device has not proved that it was made by Frostsnap.\n\n'
+          'That is expected for a development unit, third-party or open-source '
+          'hardware, or a device with no factory certificate.\n\n'
+          'Otherwise, treat it with caution.',
+    ),
+  };
+}
+
+/// Explains what a genuine status means. Kept in-app rather than linking out, in
+/// keeping with the other explainers here.
+void showGenuineExplanation(BuildContext context, GenuineStatus status) {
+  final (title, body) = status.explanation;
+  showDialog<void>(
+    context: context,
+    builder: (context) {
+      final theme = Theme.of(context);
+      return BackdropFilter(
+        filter: blurFilter,
+        child: AlertDialog(
+          constraints: dialogConstraints,
+          icon: Icon(
+            status.icon,
+            color: status.color(theme.colorScheme),
+            size: 28,
+          ),
+          title: Text(title),
+          content: Text(
+            body,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Got it'),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+/// Compact status pill. Tapping it explains the status.
+///
+/// Renders nothing at all when this build has no genuine certificate key compiled
+/// in: with no check attempted, any badge — even a neutral one — would imply we
+/// looked.
+class GenuineBadge extends StatelessWidget {
+  const GenuineBadge({super.key, required this.status});
+
+  /// Tracks a device by id, repainting as its status resolves. Use this on screens
+  /// that only hold a [DeviceId]: the status arrives asynchronously, so a one-shot
+  /// read in `build` would freeze on whatever was true at first paint.
+  static Widget forDeviceId(DeviceId id) => StreamBuilder<DeviceListUpdate>(
+    stream: GlobalStreams.deviceListSubject,
+    builder: (context, snapshot) {
+      // `deviceIdEquals`, never `==`: the generated `DeviceId ==` compares the
+      // underlying byte list, which is a plain Dart List and so compares by
+      // reference — two ids decoded from separate FFI calls never match.
+      final device = snapshot.data?.state.devices.firstWhereOrNull(
+        (device) => deviceIdEquals(device.id, id),
+      );
+      if (device == null) return const SizedBox.shrink();
+      return GenuineBadge(status: device.genuine);
+    },
+  );
+
+  final GenuineStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!genuineCheckEnabled) return const SizedBox.shrink();
+    final scheme = Theme.of(context).colorScheme;
+    final color = status.color(scheme);
+
+    return InkWell(
+      onTap: () => showGenuineExplanation(context, status),
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: color.withValues(alpha: 0.4)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(status.icon, size: 14, color: color),
+            const SizedBox(width: 4),
+            Text(
+              status.label,
+              style: TextStyle(
+                color: color,
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frostsnapp/lib/restoration/wallet_recovery_page.dart
+++ b/frostsnapp/lib/restoration/wallet_recovery_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/maybe_fullscreen_dialog.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/restoration.dart';
 import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/snackbar.dart';
@@ -301,7 +302,7 @@ class WalletRecoveryPage extends StatelessWidget {
           margin: EdgeInsets.zero,
           child: ListTile(
             contentPadding: EdgeInsets.symmetric(horizontal: 16),
-            leading: Icon(Icons.key),
+            leading: Icon(Icons.key, color: caseAccentColor(share.deviceId)),
             trailing: deleteButton,
             subtitle: !showCompatibility
                 ? null

--- a/frostsnapp/lib/restoration/wallet_recovery_page.dart
+++ b/frostsnapp/lib/restoration/wallet_recovery_page.dart
@@ -5,6 +5,7 @@ import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/restoration.dart';
 import 'package:frostsnap/secure_key_provider.dart';
 import 'package:frostsnap/snackbar.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/recovery.dart';
 import 'package:frostsnap/theme.dart';
@@ -301,7 +302,7 @@ class WalletRecoveryPage extends StatelessWidget {
           margin: EdgeInsets.zero,
           child: ListTile(
             contentPadding: EdgeInsets.symmetric(horizontal: 16),
-            leading: Icon(Icons.key),
+            leading: Icon(Icons.key, color: DeviceColorScheme.fromDeviceId(context, share.deviceId).accent),
             trailing: deleteButton,
             subtitle: !showCompatibility
                 ? null

--- a/frostsnapp/lib/restoration/wallet_recovery_page.dart
+++ b/frostsnapp/lib/restoration/wallet_recovery_page.dart
@@ -302,7 +302,13 @@ class WalletRecoveryPage extends StatelessWidget {
           margin: EdgeInsets.zero,
           child: ListTile(
             contentPadding: EdgeInsets.symmetric(horizontal: 16),
-            leading: Icon(Icons.key, color: DeviceColorScheme.fromDeviceId(context, share.deviceId).accent),
+            leading: Icon(
+              Icons.key,
+              color: DeviceColorScheme.fromDeviceId(
+                context,
+                share.deviceId,
+              ).accent,
+            ),
             trailing: deleteButton,
             subtitle: !showCompatibility
                 ? null

--- a/frostsnapp/lib/sign_message.dart
+++ b/frostsnapp/lib/sign_message.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:frostsnap/animated_check.dart';
 import 'package:frostsnap/device_action.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/secure_key_provider.dart';
@@ -182,8 +183,10 @@ class _SigningDeviceSelectorState extends State<SigningDeviceSelector> {
         }
 
         final enoughNonces = coord.noncesAvailable(id: id) >= 1;
+        final deviceColors = DeviceColorScheme.fromDeviceId(context, id);
         return CheckboxListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          secondary: Icon(Icons.key, color: deviceColors.accent),
           title: Text(
             "${name ?? '<unknown>'}${enoughNonces ? '' : ' (not enough nonces)'}",
           ),

--- a/frostsnapp/lib/sign_message.dart
+++ b/frostsnapp/lib/sign_message.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:frostsnap/animated_check.dart';
 import 'package:frostsnap/device_action.dart';
+import 'package:frostsnap/device_colors.dart';
+import 'package:frostsnap/genuine_badge.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/wallet_key_mismatch.dart';
@@ -184,8 +186,18 @@ class _SigningDeviceSelectorState extends State<SigningDeviceSelector> {
         final enoughNonces = coord.noncesAvailable(id: id) >= 1;
         return CheckboxListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-          title: Text(
-            "${name ?? '<unknown>'}${enoughNonces ? '' : ' (not enough nonces)'}",
+          secondary: Icon(Icons.key, color: caseAccentColor(id)),
+          title: Row(
+            spacing: 8,
+            children: [
+              Flexible(
+                child: Text(
+                  "${name ?? '<unknown>'}${enoughNonces ? '' : ' (not enough nonces)'}",
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              GenuineBadge.forDeviceId(id),
+            ],
           ),
           value: selected.contains(id),
           onChanged: enoughNonces ? onChanged : null,

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/animated_gradient_card.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/device_action_upgrade.dart';
+import 'package:frostsnap/device_colors.dart';
+import 'package:frostsnap/genuine_badge.dart';
 import 'package:frostsnap/hex.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/secure_key_provider.dart';
@@ -642,6 +644,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
             if (device.name != null) {
               return _deviceRow(
                 context: context,
+                device: device,
                 title: Text(
                   device.name!,
                   style: monospaceTextStyle.copyWith(
@@ -662,6 +665,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
             return device.firmwareUpgradeEligibility().when(
               upToDate: () => _deviceRow(
                 context: context,
+                device: device,
                 title: _inlineNameField(context, device),
                 trailing: IconButton(
                   icon: Icon(
@@ -677,6 +681,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
               ),
               canUpgrade: () => _deviceRow(
                 context: context,
+                device: device,
                 title: const SizedBox.shrink(),
                 trailing: buildDeviceTrailingInfo(
                   context,
@@ -689,6 +694,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
               ),
               cannotUpgrade: (reason) => _deviceRow(
                 context: context,
+                device: device,
                 title: const SizedBox.shrink(),
                 trailing: buildDeviceTrailingInfo(
                   context,
@@ -769,24 +775,37 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
     required BuildContext context,
     required Widget title,
     required Widget trailing,
+    ConnectedDevice? device,
     VoidCallback? onTap,
     bool enabled = true,
   }) {
     final cs = Theme.of(context).colorScheme;
-    return Card.filled(
+    // Enrolment is the moment a device becomes part of a wallet, so it is worth
+    // showing what we know about it here — the colour to recognise it by, and
+    // whether it has proved it is genuine.
+    return DeviceGlowCard(
       margin: const EdgeInsets.symmetric(vertical: 4),
-      color: cs.surfaceContainerHigh,
-      clipBehavior: Clip.hardEdge,
+      caseColor: device?.caseColor,
       child: ListTile(
         onTap: onTap,
         enabled: enabled,
         leading: Icon(
           Icons.key,
-          color: enabled
-              ? cs.onSurfaceVariant
-              : cs.onSurfaceVariant.withValues(alpha: 0.5),
+          color:
+              device?.caseColor?.color ??
+              (enabled
+                  ? cs.onSurfaceVariant
+                  : cs.onSurfaceVariant.withValues(alpha: 0.5)),
         ),
-        title: title,
+        title: device == null
+            ? title
+            : Row(
+                spacing: 8,
+                children: [
+                  Flexible(child: title),
+                  GenuineBadge(status: device.genuine),
+                ],
+              ),
         trailing: trailing,
         contentPadding: const EdgeInsets.symmetric(horizontal: 16),
       ),

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/animated_gradient_card.dart';
 import 'package:frostsnap/device_action_fullscreen_dialog.dart';
 import 'package:frostsnap/device_action_upgrade.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/hex.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/secure_key_provider.dart';
@@ -641,6 +642,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
             if (device.name != null) {
               return _deviceRow(
                 context: context,
+                device: device,
                 title: Text(
                   device.name!,
                   style: monospaceTextStyle.copyWith(
@@ -661,6 +663,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
             return device.firmwareUpgradeEligibility().when(
               upToDate: () => _deviceRow(
                 context: context,
+                device: device,
                 title: _inlineNameField(context, device),
                 trailing: IconButton(
                   icon: Icon(
@@ -676,6 +679,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
               ),
               canUpgrade: () => _deviceRow(
                 context: context,
+                device: device,
                 title: const SizedBox.shrink(),
                 trailing: buildDeviceTrailingInfo(
                   context,
@@ -688,6 +692,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
               ),
               cannotUpgrade: (reason) => _deviceRow(
                 context: context,
+                device: device,
                 title: const SizedBox.shrink(),
                 trailing: buildDeviceTrailingInfo(
                   context,
@@ -768,23 +773,23 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
     required BuildContext context,
     required Widget title,
     required Widget trailing,
+    ConnectedDevice? device,
     VoidCallback? onTap,
     bool enabled = true,
   }) {
     final cs = Theme.of(context).colorScheme;
-    return Card.filled(
+    final colors = DeviceColorScheme.fromDevice(context, device);
+    final iconColor =
+        colors.accent ??
+        (enabled
+            ? cs.onSurfaceVariant
+            : cs.onSurfaceVariant.withValues(alpha: 0.5));
+    return colors.buildGlowCard(
       margin: const EdgeInsets.symmetric(vertical: 4),
-      color: cs.surfaceContainerHigh,
-      clipBehavior: Clip.hardEdge,
       child: ListTile(
         onTap: onTap,
         enabled: enabled,
-        leading: Icon(
-          Icons.key,
-          color: enabled
-              ? cs.onSurfaceVariant
-              : cs.onSurfaceVariant.withValues(alpha: 0.5),
-        ),
+        leading: Icon(Icons.key, color: iconColor),
         title: title,
         trailing: trailing,
         contentPadding: const EdgeInsets.symmetric(horizontal: 16),

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -784,6 +784,9 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
         (enabled
             ? cs.onSurfaceVariant
             : cs.onSurfaceVariant.withValues(alpha: 0.5));
+    // Genuine status matters here: you're about to trust these devices with a key
+    // share. Right-aligned to match the device list.
+    final genuineBadge = colors.genuineBadge(context);
     return colors.buildGlowCard(
       margin: const EdgeInsets.symmetric(vertical: 4),
       child: ListTile(
@@ -791,7 +794,13 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
         enabled: enabled,
         leading: Icon(Icons.key, color: iconColor),
         title: title,
-        trailing: trailing,
+        trailing: genuineBadge == null
+            ? trailing
+            : Row(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 8,
+                children: [genuineBadge, trailing],
+              ),
         contentPadding: const EdgeInsets.symmetric(horizontal: 16),
       ),
     );

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -12,6 +12,7 @@ import 'package:frostsnap/src/rust/api/super_wallet.dart';
 import 'package:frostsnap/src/rust/api/transaction.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:frostsnap/wallet.dart';
+import 'package:frostsnap/device_colors.dart';
 import 'package:frostsnap/wallet_send_controllers.dart';
 import 'package:frostsnap/wallet_send_feerate_picker.dart';
 import 'package:frostsnap/wallet_tx_details.dart';
@@ -453,6 +454,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
 
               if (nonces == 0) state.deselectSigner(dId: id);
 
+              final deviceColors = DeviceColorScheme.fromDeviceId(context, id);
               return CheckboxListTile(
                 value: isSelected,
                 onChanged: remaining > 0 || isSelected
@@ -460,7 +462,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
                           ? state.selectSigner(dId: id)
                           : state.deselectSigner(dId: id)
                     : null,
-                secondary: Icon(Icons.key),
+                secondary: Icon(Icons.key, color: deviceColors.accent),
                 title: Text(name ?? '<unknown>'),
                 subtitle: nonces == 0
                     ? Text(

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -11,6 +11,8 @@ import 'package:frostsnap/src/rust/api/signing.dart';
 import 'package:frostsnap/src/rust/api/super_wallet.dart';
 import 'package:frostsnap/src/rust/api/transaction.dart';
 import 'package:frostsnap/theme.dart';
+import 'package:frostsnap/device_colors.dart';
+import 'package:frostsnap/genuine_badge.dart';
 import 'package:frostsnap/wallet.dart';
 import 'package:frostsnap/wallet_send_controllers.dart';
 import 'package:frostsnap/wallet_send_feerate_picker.dart';
@@ -460,8 +462,19 @@ class _WalletSendPageState extends State<WalletSendPage> {
                           ? state.selectSigner(dId: id)
                           : state.deselectSigner(dId: id)
                     : null,
-                secondary: Icon(Icons.key),
-                title: Text(name ?? '<unknown>'),
+                secondary: Icon(Icons.key, color: caseAccentColor(id)),
+                title: Row(
+                  spacing: 8,
+                  children: [
+                    Flexible(
+                      child: Text(
+                        name ?? '<unknown>',
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    GenuineBadge.forDeviceId(id),
+                  ],
+                ),
                 subtitle: nonces == 0
                     ? Text(
                         'no nonces remaining or too many signing sessions',

--- a/frostsnapp/rust/src/api/coordinator.rs
+++ b/frostsnapp/rust/src/api/coordinator.rs
@@ -25,6 +25,7 @@ pub enum WalletKeyStatus {
     Ok,
 }
 
+use super::device_list::CaseColor;
 use crate::{coordinator::FfiCoordinator, frb_generated::StreamSink};
 
 pub use super::backup_run::{BackupDevice, BackupRun};
@@ -291,5 +292,23 @@ impl Coordinator {
     #[frb(sync)]
     pub fn get_device_name(&self, id: DeviceId) -> Option<String> {
         self.0.get_device_name(id)
+    }
+
+    /// The case colour we last recorded for a device, connected or not.
+    ///
+    /// Cosmetic identity only. Having a colour on file says nothing about whether
+    /// the device in front of you is genuine — read `genuine` on the
+    /// [`ConnectedDevice`](super::device_list::ConnectedDevice) for that.
+    #[frb(sync)]
+    pub fn get_device_case_color(&self, id: DeviceId) -> Option<CaseColor> {
+        self.0.get_device_case_color(id)
+    }
+
+    /// Whether this build can run the genuine check at all — false when no genuine
+    /// certificate key was compiled in, in which case every device stays `Unknown`
+    /// and the UI shouldn't imply a verdict it never attempted.
+    #[frb(sync)]
+    pub fn genuine_check_enabled(&self) -> bool {
+        self.0.genuine_check_enabled()
     }
 }

--- a/frostsnapp/rust/src/api/coordinator.rs
+++ b/frostsnapp/rust/src/api/coordinator.rs
@@ -262,4 +262,11 @@ impl Coordinator {
     pub fn get_device_case_color(&self, id: DeviceId) -> Option<CaseColor> {
         self.0.get_device_case_color(id)
     }
+
+    /// Whether this build runs the genuine check (a genuine cert key was baked in).
+    /// When false, every device stays `Unknown`.
+    #[frb(sync)]
+    pub fn genuine_check_enabled(&self) -> bool {
+        cfg!(genuine_cert_key)
+    }
 }

--- a/frostsnapp/rust/src/api/coordinator.rs
+++ b/frostsnapp/rust/src/api/coordinator.rs
@@ -15,6 +15,7 @@ use frostsnap_core::{
 use std::collections::BTreeMap;
 use tracing::{event, Level};
 
+use super::device_list::CaseColor;
 use crate::{coordinator::FfiCoordinator, frb_generated::StreamSink};
 
 pub use super::backup_run::{BackupDevice, BackupRun};
@@ -255,5 +256,10 @@ impl Coordinator {
     #[frb(sync)]
     pub fn get_device_name(&self, id: DeviceId) -> Option<String> {
         self.0.get_device_name(id)
+    }
+
+    #[frb(sync)]
+    pub fn get_device_case_color(&self, id: DeviceId) -> Option<CaseColor> {
+        self.0.get_device_case_color(id)
     }
 }

--- a/frostsnapp/rust/src/api/device_list.rs
+++ b/frostsnapp/rust/src/api/device_list.rs
@@ -41,6 +41,19 @@ impl CaseColor {
     }
 }
 
+/// Whether a connected device has passed the genuine (authenticity) check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenuineStatus {
+    /// Not yet checked, or can't be checked (e.g. no genuine key baked in, or
+    /// old firmware that can't produce a bound proof).
+    Unknown,
+    /// The device produced a valid bound genuine proof.
+    Genuine,
+    /// The device responded but the proof did not verify: counterfeit, or a relay
+    /// attempt.
+    Failed,
+}
+
 #[derive(Clone, Debug)]
 pub struct DeviceListChange {
     pub kind: DeviceListChangeKind,
@@ -68,6 +81,7 @@ pub struct ConnectedDevice {
     pub id: DeviceId,
     pub recovery_mode: bool,
     pub case_color: Option<CaseColor>,
+    pub genuine: GenuineStatus,
 }
 
 impl ConnectedDevice {

--- a/frostsnapp/rust/src/api/device_list.rs
+++ b/frostsnapp/rust/src/api/device_list.rs
@@ -12,6 +12,33 @@ pub enum DeviceListChangeKind {
     Removed,
     Named,
     RecoveryMode,
+    GenuineCheck,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum CaseColor {
+    Black,
+    Orange,
+    Silver,
+    Blue,
+    Red,
+}
+
+impl CaseColor {
+    #[frb(ignore)]
+    pub fn from_comms(
+        color: frostsnap_coordinator::frostsnap_comms::genuine_certificate::CaseColor,
+    ) -> Self {
+        use frostsnap_coordinator::frostsnap_comms::genuine_certificate::CaseColor as C;
+        match color {
+            C::Black => CaseColor::Black,
+            C::Orange => CaseColor::Orange,
+            C::Silver => CaseColor::Silver,
+            C::Blue => CaseColor::Blue,
+            C::Red => CaseColor::Red,
+            _ => CaseColor::Black,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -40,6 +67,7 @@ pub struct ConnectedDevice {
     pub latest_firmware: Option<FirmwareVersion>,
     pub id: DeviceId,
     pub recovery_mode: bool,
+    pub case_color: Option<CaseColor>,
 }
 
 impl ConnectedDevice {

--- a/frostsnapp/rust/src/api/device_list.rs
+++ b/frostsnapp/rust/src/api/device_list.rs
@@ -12,6 +12,67 @@ pub enum DeviceListChangeKind {
     Removed,
     Named,
     RecoveryMode,
+    /// The device's genuine status or case colour changed.
+    GenuineCheck,
+}
+
+/// The colour of a device's case, as claimed by its certificate.
+///
+/// Cosmetic identity — it is how someone tells their own devices apart — and
+/// deliberately not a trust signal: it is read from the certificate before, and
+/// regardless of, verification. Never render it in a way that implies a verdict.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CaseColor {
+    Black,
+    Orange,
+    Silver,
+    Blue,
+    Red,
+}
+
+impl CaseColor {
+    /// `None` for a colour this build has no name for, which is how a device from a
+    /// newer production run reads. Showing no colour is right there; picking a
+    /// wrong one would be worse than picking none, because colour is what the user
+    /// matches against the object in their hand.
+    #[frb(ignore)]
+    pub fn from_comms(
+        color: frostsnap_coordinator::frostsnap_comms::genuine_certificate::CaseColor,
+    ) -> Option<Self> {
+        use frostsnap_coordinator::frostsnap_comms::genuine_certificate::CaseColor as C;
+        Some(match color {
+            C::Black => CaseColor::Black,
+            C::Orange => CaseColor::Orange,
+            C::Silver => CaseColor::Silver,
+            C::Blue => CaseColor::Blue,
+            C::Red => CaseColor::Red,
+            _ => return None,
+        })
+    }
+}
+
+/// Whether a connected device has proved it is genuine Frostsnap hardware.
+///
+/// Always the result for *this* connection. A device that passed in the past is not
+/// carried over — a DeviceId is public and self-asserted, so a remembered verdict
+/// would be worth nothing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenuineStatus {
+    /// Not verified. Covers a build with no genuine key compiled in, a check still
+    /// in flight, and — the common case — a device that simply never answers: no
+    /// certificate provisioned, third-party hardware, or firmware predating the
+    /// challenge message. Benign in almost every case, and never something to act on.
+    Unknown,
+    /// Produced a valid proof bound to this connection's device id.
+    Genuine,
+    /// Answered, but the proof did not verify: counterfeit, tampered, or a relay
+    /// attempt.
+    Failed,
+    /// Answered with the retired unbound proof. Its firmware predates the identity
+    /// binding, so it cannot prove genuineness however sound the hardware is.
+    /// Distinct from [`Self::Failed`] because it is fixed by upgrading, not by
+    /// suspecting the device.
+    FirmwareTooOld,
 }
 
 #[derive(Clone, Debug)]
@@ -61,6 +122,10 @@ pub struct ConnectedDevice {
     pub latest_firmware: Option<FirmwareVersion>,
     pub id: DeviceId,
     pub recovery_mode: RecoveryMode,
+    /// `None` until we learn it, or when the device claims a colour this build
+    /// doesn't know.
+    pub case_color: Option<CaseColor>,
+    pub genuine: GenuineStatus,
 }
 
 impl ConnectedDevice {

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -196,6 +196,18 @@ impl FfiCoordinator {
                     for change in device_changes {
                         device_list.consume_manager_event(change.clone());
                         match change {
+                            DeviceChange::Connected { id, .. } => {
+                                // Pre-populate persisted case color so known
+                                // devices show their color immediately without
+                                // waiting for the genuine challenge round-trip.
+                                if let Some(color_str) =
+                                    device_names.lock().unwrap().get_case_color(id)
+                                {
+                                    if let Some(color) = parse_case_color_str(&color_str) {
+                                        device_list.set_case_color(id, color);
+                                    }
+                                }
+                            }
                             DeviceChange::Registered { id, .. } => {
                                 if coordinator.has_backups_that_need_to_be_consolidated(id) {
                                     device_list.set_recovery_mode(id, true);
@@ -261,6 +273,15 @@ impl FfiCoordinator {
                                     serial = certificate.serial_number(),
                                     "device passed genuine check"
                                 );
+                                // Set color in memory only — can't persist yet
+                                // because the DB row requires a name and the
+                                // genuine check fires before naming. The color
+                                // gets written to DB when the name is persisted.
+                                device_names
+                                    .lock()
+                                    .unwrap()
+                                    .MUTATE_NO_PERSIST()
+                                    .set_case_color(id, certificate.case_color().to_string());
                             }
                             _ => { /* ignore rest */ }
                         }
@@ -639,6 +660,14 @@ impl FfiCoordinator {
 
     pub fn get_device_name(&self, id: DeviceId) -> Option<String> {
         self.device_names.lock().unwrap().get(id)
+    }
+
+    pub fn get_device_case_color(
+        &self,
+        id: DeviceId,
+    ) -> Option<crate::api::device_list::CaseColor> {
+        let color_str = self.device_names.lock().unwrap().get_case_color(id)?;
+        parse_case_color_str(&color_str)
     }
 
     /// Persist a user-typed device name into the coord's local `device_names` store without
@@ -1372,6 +1401,13 @@ impl FfiCoordinator {
             .unwrap();
         Ok(())
     }
+}
+
+fn parse_case_color_str(color_str: &str) -> Option<crate::api::device_list::CaseColor> {
+    let comms_color =
+        frostsnap_coordinator::frostsnap_comms::genuine_certificate::CaseColor::from_str(color_str)
+            .ok()?;
+    Some(crate::api::device_list::CaseColor::from_comms(comms_color))
 }
 
 fn key_state(coordinator: &FrostCoordinator) -> api::coordinator::KeyState {

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -16,7 +16,7 @@ use frostsnap_coordinator::firmware_upgrade::{
 use frostsnap_coordinator::frostsnap_comms::{
     CoordinatorSendBody, CoordinatorSendMessage, Destination, Sha256Digest,
 };
-use frostsnap_coordinator::frostsnap_persist::DeviceNames;
+use frostsnap_coordinator::frostsnap_persist::{DeviceNames, GenuineDeviceInfo, GenuineRecord};
 use frostsnap_coordinator::nonce_replenish::NonceReplenishState;
 use frostsnap_coordinator::persist::Persisted;
 use frostsnap_coordinator::signing::SigningState;
@@ -63,6 +63,7 @@ pub struct FfiCoordinator {
     // // persisted things
     pub(crate) db: Arc<Mutex<rusqlite::Connection>>,
     device_names: Arc<Mutex<Persisted<DeviceNames>>>,
+    genuine_info: Arc<Mutex<Persisted<GenuineDeviceInfo>>>,
     pub(crate) coordinator: Arc<Mutex<Persisted<FrostCoordinator>>>,
     // backup management
     pub(crate) backup_state: Arc<Mutex<Persisted<BackupState>>>,
@@ -82,6 +83,8 @@ impl FfiCoordinator {
         let coordinator = Persisted::<FrostCoordinator>::new(&mut db_, ())?;
         event!(Level::DEBUG, "loading device names");
         let device_names = Persisted::<DeviceNames>::new(&mut db_, ())?;
+        event!(Level::DEBUG, "loading genuine device info");
+        let genuine_info = Persisted::<GenuineDeviceInfo>::new(&mut db_, ())?;
         event!(Level::DEBUG, "loading backup state");
         let backup_state = Persisted::<BackupState>::new(&mut db_, ())?;
 
@@ -105,6 +108,7 @@ impl FfiCoordinator {
             db,
             coordinator: Arc::new(Mutex::new(coordinator)),
             device_names: Arc::new(Mutex::new(device_names)),
+            genuine_info: Arc::new(Mutex::new(genuine_info)),
             backup_state: Arc::new(Mutex::new(backup_state)),
             backup_run_streams: Default::default(),
         })
@@ -130,6 +134,7 @@ impl FfiCoordinator {
         let ui_stack = self.ui_stack.clone();
         let db_loop = self.db.clone();
         let device_names = self.device_names.clone();
+        let genuine_info = self.genuine_info.clone();
         let usb_sender = self.usb_sender.clone();
         let firmware_upgrade_progress = self.firmware_upgrade_progress.clone();
         let device_list = self.device_list.clone();
@@ -200,8 +205,10 @@ impl FfiCoordinator {
                                 // Pre-populate persisted case color so known
                                 // devices show their color immediately without
                                 // waiting for the genuine challenge round-trip.
+                                // (This is only a visual hint; the live genuine
+                                // check re-establishes the trusted status.)
                                 if let Some(color_str) =
-                                    device_names.lock().unwrap().get_case_color(id)
+                                    genuine_info.lock().unwrap().get_case_color(id)
                                 {
                                     if let Some(color) = parse_case_color_str(&color_str) {
                                         device_list.set_case_color(id, color);
@@ -273,15 +280,26 @@ impl FfiCoordinator {
                                     serial = certificate.serial_number(),
                                     "device passed genuine check"
                                 );
-                                // Set color in memory only — can't persist yet
-                                // because the DB row requires a name and the
-                                // genuine check fires before naming. The color
-                                // gets written to DB when the name is persisted.
-                                device_names
-                                    .lock()
-                                    .unwrap()
-                                    .MUTATE_NO_PERSIST()
-                                    .set_case_color(id, certificate.case_color().to_string());
+                                // Persist the attested info immediately (see
+                                // `GenuineDeviceInfo` for why it's keyed by id, not name).
+                                let record = GenuineRecord {
+                                    case_color: certificate.case_color().to_string(),
+                                    serial: certificate.raw_serial(),
+                                    revision: certificate.revision().to_string(),
+                                };
+                                if let Err(e) =
+                                    genuine_info.lock().unwrap().staged_mutate(&mut *db, |g| {
+                                        g.set(id, record.clone());
+                                        Ok(())
+                                    })
+                                {
+                                    event!(
+                                        Level::ERROR,
+                                        device = id.to_string(),
+                                        error = e.to_string(),
+                                        "failed to persist genuine device info"
+                                    );
+                                }
                             }
                             _ => { /* ignore rest */ }
                         }
@@ -666,7 +684,7 @@ impl FfiCoordinator {
         &self,
         id: DeviceId,
     ) -> Option<crate::api::device_list::CaseColor> {
-        let color_str = self.device_names.lock().unwrap().get_case_color(id)?;
+        let color_str = self.genuine_info.lock().unwrap().get_case_color(id)?;
         parse_case_color_str(&color_str)
     }
 

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -75,7 +75,7 @@ type Signal = Box<dyn Sink<()>>;
 impl FfiCoordinator {
     pub fn new(
         db: Arc<Mutex<rusqlite::Connection>>,
-        usb_manager: UsbSerialManager,
+        mut usb_manager: UsbSerialManager,
     ) -> anyhow::Result<Self> {
         let mut db_ = db.lock().unwrap();
 
@@ -85,6 +85,9 @@ impl FfiCoordinator {
         let device_names = Persisted::<DeviceNames>::new(&mut db_, ())?;
         event!(Level::DEBUG, "loading genuine device info");
         let genuine_info = Persisted::<GenuineDeviceInfo>::new(&mut db_, ())?;
+        // Trust persisted genuine verdicts: don't re-challenge devices we've
+        // already verified.
+        usb_manager.set_known_genuine(genuine_info.device_ids());
         event!(Level::DEBUG, "loading backup state");
         let backup_state = Persisted::<BackupState>::new(&mut db_, ())?;
 
@@ -202,17 +205,19 @@ impl FfiCoordinator {
                         device_list.consume_manager_event(change.clone());
                         match change {
                             DeviceChange::Connected { id, .. } => {
-                                // Pre-populate persisted case color so known
-                                // devices show their color immediately without
-                                // waiting for the genuine challenge round-trip.
-                                // (This is only a visual hint; the live genuine
-                                // check re-establishes the trusted status.)
-                                if let Some(color_str) =
-                                    genuine_info.lock().unwrap().get_case_color(id)
+                                // Restore case colour and genuine status from the
+                                // persisted verdict. A device we've verified before
+                                // isn't re-challenged (see UsbSerialManager); only
+                                // Unknown/Failed devices are re-checked on connect.
+                                let genuine_info = genuine_info.lock().unwrap();
+                                if let Some(color) = genuine_info
+                                    .get_case_color(id)
+                                    .and_then(|s| parse_case_color_str(&s))
                                 {
-                                    if let Some(color) = parse_case_color_str(&color_str) {
-                                        device_list.set_case_color(id, color);
-                                    }
+                                    device_list.set_case_color(id, color);
+                                }
+                                if genuine_info.get(id).is_some() {
+                                    device_list.set_genuine_cached(id);
                                 }
                             }
                             DeviceChange::Registered { id, .. } => {

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -16,7 +16,7 @@ use frostsnap_coordinator::firmware_upgrade::{
 use frostsnap_coordinator::frostsnap_comms::{
     CoordinatorSendBody, CoordinatorSendMessage, Destination, Sha256Digest,
 };
-use frostsnap_coordinator::frostsnap_persist::DeviceNames;
+use frostsnap_coordinator::frostsnap_persist::{DeviceNames, GenuineDeviceInfo, GenuineRecord};
 use frostsnap_coordinator::nonce_replenish::NonceReplenishState;
 use frostsnap_coordinator::persist::Persisted;
 use frostsnap_coordinator::signing::SigningState;
@@ -25,8 +25,8 @@ use frostsnap_coordinator::wait_for_single_device::{
     WaitForSingleDevice, WaitForSingleDeviceState,
 };
 use frostsnap_coordinator::{
-    AppMessageBody, DeviceChange, DeviceMode, FirmwareVersion, Sink, UiProtocol, UiStack,
-    UsbSender, UsbSerialManager, ValidatedFirmwareBin, WaitForToUserMessage,
+    AppMessageBody, DeviceChange, DeviceMode, FirmwareVersion, GenuineOutcome, Sink, UiProtocol,
+    UiStack, UsbSender, UsbSerialManager, ValidatedFirmwareBin, WaitForToUserMessage,
 };
 use frostsnap_core::coordinator::restoration::{
     PhysicalBackupPhase, RecoverShare, RestorationState, ToUserRestoration,
@@ -63,6 +63,7 @@ pub struct FfiCoordinator {
     // // persisted things
     pub(crate) db: Arc<Mutex<rusqlite::Connection>>,
     device_names: Arc<Mutex<Persisted<DeviceNames>>>,
+    genuine_devices: Arc<Mutex<Persisted<GenuineDeviceInfo>>>,
     pub(crate) coordinator: Arc<Mutex<Persisted<FrostCoordinator>>>,
     // backup management
     pub(crate) backup_state: Arc<Mutex<Persisted<BackupState>>>,
@@ -70,6 +71,20 @@ pub struct FfiCoordinator {
 }
 
 type Signal = Box<dyn Sink<()>>;
+
+/// Case colour from a persisted record, translated into the app's own enum.
+///
+/// `None` when we've never verified the device, or when it claimed a colour this
+/// build has no name for — better to show none than to show the wrong one, since
+/// colour is what the user matches against the object in their hand.
+fn get_case_color(
+    genuine_devices: &Mutex<Persisted<GenuineDeviceInfo>>,
+    id: DeviceId,
+) -> Option<api::device_list::CaseColor> {
+    use frostsnap_coordinator::frostsnap_comms::genuine_certificate::CaseColor;
+    let stored = genuine_devices.lock().unwrap().get(id)?.case_color.clone();
+    api::device_list::CaseColor::from_comms(CaseColor::from_str(&stored).ok()?)
+}
 
 impl FfiCoordinator {
     pub fn new(
@@ -82,6 +97,8 @@ impl FfiCoordinator {
         let coordinator = Persisted::<FrostCoordinator>::new(&mut db_, ())?;
         event!(Level::DEBUG, "loading device names");
         let device_names = Persisted::<DeviceNames>::new(&mut db_, ())?;
+        event!(Level::DEBUG, "loading genuine device info");
+        let genuine_devices = Persisted::<GenuineDeviceInfo>::new(&mut db_, ())?;
         event!(Level::DEBUG, "loading backup state");
         let backup_state = Persisted::<BackupState>::new(&mut db_, ())?;
 
@@ -105,6 +122,7 @@ impl FfiCoordinator {
             db,
             coordinator: Arc::new(Mutex::new(coordinator)),
             device_names: Arc::new(Mutex::new(device_names)),
+            genuine_devices: Arc::new(Mutex::new(genuine_devices)),
             backup_state: Arc::new(Mutex::new(backup_state)),
             backup_run_streams: Default::default(),
         })
@@ -130,6 +148,7 @@ impl FfiCoordinator {
         let ui_stack = self.ui_stack.clone();
         let db_loop = self.db.clone();
         let device_names = self.device_names.clone();
+        let genuine_devices = self.genuine_devices.clone();
         let usb_sender = self.usb_sender.clone();
         let firmware_upgrade_progress = self.firmware_upgrade_progress.clone();
         let device_list = self.device_list.clone();
@@ -196,6 +215,16 @@ impl FfiCoordinator {
                     for change in device_changes {
                         device_list.consume_manager_event(change.clone());
                         match change {
+                            DeviceChange::Connected { id, .. } => {
+                                // Show a known device's colour straight away rather
+                                // than waiting on a challenge that may be queued
+                                // behind other devices — or that this device can't
+                                // answer at all. Colour only; the genuine status
+                                // stays Unknown until this connection proves itself.
+                                if let Some(color) = get_case_color(&genuine_devices, id) {
+                                    device_list.set_case_color(id, color);
+                                }
+                            }
                             DeviceChange::Registered { id, .. } => {
                                 let pending = coordinator.pending_physical_consolidations(id);
                                 if !pending.is_empty() {
@@ -258,13 +287,57 @@ impl FfiCoordinator {
                             DeviceChange::NeedsName { id } => {
                                 ui_stack.connected(id, DeviceMode::Blank);
                             }
-                            DeviceChange::GenuineDevice { id, certificate } => {
-                                event!(
-                                    Level::INFO,
-                                    device = id.to_string(),
-                                    serial = certificate.serial_number(),
-                                    "device passed genuine check"
-                                );
+                            DeviceChange::GenuineCheck { id, outcome } => {
+                                // Only a pass or an outright failure changes what we
+                                // store. Checking/NoAnswer/FirmwareTooOld all mean
+                                // "no new information about this hardware", and must
+                                // not erase what an earlier successful check learned
+                                // — otherwise a device would lose its colour the
+                                // moment it was downgraded or unplugged mid-check.
+                                let record = match outcome {
+                                    GenuineOutcome::Genuine(certificate) => {
+                                        event!(
+                                            Level::INFO,
+                                            device = id.to_string(),
+                                            serial = certificate.serial_number(),
+                                            "device passed the genuine check"
+                                        );
+                                        Some(GenuineRecord {
+                                            case_color: certificate.case_color().to_string(),
+                                            serial: certificate.raw_serial(),
+                                            revision: certificate.revision().to_string(),
+                                        })
+                                    }
+                                    GenuineOutcome::Failed => {
+                                        event!(
+                                            Level::WARN,
+                                            device = id.to_string(),
+                                            "device failed the genuine check"
+                                        );
+                                        None
+                                    }
+                                    _ => continue,
+                                };
+
+                                let mut genuine_devices = genuine_devices.lock().unwrap();
+                                let result =
+                                    genuine_devices.staged_mutate(&mut *db, |genuine| {
+                                        match record {
+                                            Some(record) => genuine.set(id, record),
+                                            // Stop vouching for hardware that just
+                                            // failed in front of us.
+                                            None => genuine.remove(id),
+                                        }
+                                        Ok(())
+                                    });
+                                if let Err(e) = result {
+                                    event!(
+                                        Level::ERROR,
+                                        id = id.to_string(),
+                                        error = e.to_string(),
+                                        "failed to persist genuine device record"
+                                    );
+                                }
                             }
                             _ => { /* ignore rest */ }
                         }
@@ -643,6 +716,18 @@ impl FfiCoordinator {
 
     pub fn get_device_name(&self, id: DeviceId) -> Option<String> {
         self.device_names.lock().unwrap().get(id)
+    }
+
+    /// Case colour from the persisted record, for a device that may not be
+    /// connected. `None` if we've never verified it, or if it claimed a colour this
+    /// build doesn't know.
+    pub fn get_device_case_color(&self, id: DeviceId) -> Option<api::device_list::CaseColor> {
+        get_case_color(&self.genuine_devices, id)
+    }
+
+    /// Whether a genuine certificate key was compiled into this build.
+    pub fn genuine_check_enabled(&self) -> bool {
+        cfg!(genuine_cert_key)
     }
 
     /// Persist a user-typed device name into the coord's local `device_names` store without

--- a/frostsnapp/rust/src/device_list.rs
+++ b/frostsnapp/rust/src/device_list.rs
@@ -97,6 +97,8 @@ impl DeviceList {
                         name: None,
                         id,
                         recovery_mode: api::RecoveryMode::Off,
+                        case_color: None,
+                        genuine: api::GenuineStatus::Unknown,
                     },
                 );
             }
@@ -156,12 +158,59 @@ impl DeviceList {
                 }
             }
             DeviceChange::AppMessage(_) => { /* not relevant */ }
-            DeviceChange::GenuineDevice { .. } => { /* not displayed in app yet */ }
+            // Cosmetic identity, learned from an unverified certificate. Set
+            // whenever we hear it, independently of the verdict below.
+            DeviceChange::CaseColor { id, color } => {
+                if let Some(case_color) = api::CaseColor::from_comms(color) {
+                    self.update_device(id, |device| device.case_color = Some(case_color));
+                }
+            }
+            DeviceChange::GenuineCheck { id, outcome } => {
+                use frostsnap_coordinator::GenuineOutcome;
+                let status = match outcome {
+                    GenuineOutcome::Genuine(_) => api::GenuineStatus::Genuine,
+                    GenuineOutcome::Failed => api::GenuineStatus::Failed,
+                    GenuineOutcome::FirmwareTooOld => api::GenuineStatus::FirmwareTooOld,
+                };
+                self.update_device(id, |device| device.genuine = status);
+            }
         }
     }
 
     pub fn get_device(&self, id: DeviceId) -> Option<api::ConnectedDevice> {
         self.connected.get(&id).cloned()
+    }
+
+    /// Apply `f` to a connected device and emit a `GenuineCheck` change for it.
+    ///
+    /// A device that has announced but isn't in `devices` yet (it hasn't been named,
+    /// so it has no index) still gets the update stored — it will be carried into
+    /// the list when it is appended.
+    fn update_device(&mut self, id: DeviceId, f: impl FnOnce(&mut api::ConnectedDevice)) {
+        let index = self.index_of(id);
+        let Some(connected) = self.connected.get_mut(&id) else {
+            return;
+        };
+        f(connected);
+        if let Some(index) = index {
+            self.outbox.push(api::DeviceListChange {
+                kind: api::DeviceListChangeKind::GenuineCheck,
+                index: index as u32,
+                device: connected.clone(),
+            });
+        }
+    }
+
+    /// Seed a device's case colour from a persisted record at connect time, without
+    /// overwriting a colour already learned live on this connection.
+    pub fn set_case_color(&mut self, id: DeviceId, color: api::CaseColor) {
+        let already_known = self
+            .connected
+            .get(&id)
+            .is_none_or(|device| device.case_color.is_some());
+        if !already_known {
+            self.update_device(id, |device| device.case_color = Some(color));
+        }
     }
     fn index_of(&self, id: DeviceId) -> Option<usize> {
         self.devices

--- a/frostsnapp/rust/src/device_list.rs
+++ b/frostsnapp/rust/src/device_list.rs
@@ -95,6 +95,7 @@ impl DeviceList {
                         id,
                         recovery_mode: false,
                         case_color: None,
+                        genuine: api::GenuineStatus::Unknown,
                     },
                 );
             }
@@ -157,7 +158,23 @@ impl DeviceList {
             DeviceChange::GenuineDevice { id, certificate } => {
                 let index = self.index_of(id);
                 if let Some(connected) = self.connected.get_mut(&id) {
-                    connected.case_color = Some(api::CaseColor::from_comms(certificate.case_color()));
+                    connected.case_color =
+                        Some(api::CaseColor::from_comms(certificate.case_color()));
+                    connected.genuine = api::GenuineStatus::Genuine;
+                    if let Some(index) = index {
+                        self.outbox.push(api::DeviceListChange {
+                            kind: api::DeviceListChangeKind::GenuineCheck,
+                            index: index as u32,
+                            device: connected.clone(),
+                        });
+                    }
+                }
+            }
+            DeviceChange::GenuineCheckFailed { id } => {
+                let index = self.index_of(id);
+                if let Some(connected) = self.connected.get_mut(&id) {
+                    connected.genuine = api::GenuineStatus::Failed;
+                    connected.case_color = None;
                     if let Some(index) = index {
                         self.outbox.push(api::DeviceListChange {
                             kind: api::DeviceListChangeKind::GenuineCheck,

--- a/frostsnapp/rust/src/device_list.rs
+++ b/frostsnapp/rust/src/device_list.rs
@@ -94,6 +94,7 @@ impl DeviceList {
                         name: None,
                         id,
                         recovery_mode: false,
+                        case_color: None,
                     },
                 );
             }
@@ -153,7 +154,19 @@ impl DeviceList {
                 }
             }
             DeviceChange::AppMessage(_) => { /* not relevant */ }
-            DeviceChange::GenuineDevice { .. } => { /* not displayed in app yet */ }
+            DeviceChange::GenuineDevice { id, certificate } => {
+                let index = self.index_of(id);
+                if let Some(connected) = self.connected.get_mut(&id) {
+                    connected.case_color = Some(api::CaseColor::from_comms(certificate.case_color()));
+                    if let Some(index) = index {
+                        self.outbox.push(api::DeviceListChange {
+                            kind: api::DeviceListChangeKind::GenuineCheck,
+                            index: index as u32,
+                            device: connected.clone(),
+                        });
+                    }
+                }
+            }
         }
     }
 
@@ -176,6 +189,16 @@ impl DeviceList {
                 index: (self.devices.len() - 1) as u32,
                 device: self.get_device(id).expect("invariant"),
             });
+        }
+    }
+
+    /// Pre-populate a device's case color (e.g. from persisted DB state at
+    /// connect time) without overwriting a color already learned this session.
+    pub fn set_case_color(&mut self, id: DeviceId, color: api::CaseColor) {
+        if let Some(connected) = self.connected.get_mut(&id) {
+            if connected.case_color.is_none() {
+                connected.case_color = Some(color);
+            }
         }
     }
 

--- a/frostsnapp/rust/src/device_list.rs
+++ b/frostsnapp/rust/src/device_list.rs
@@ -155,11 +155,24 @@ impl DeviceList {
                 }
             }
             DeviceChange::AppMessage(_) => { /* not relevant */ }
-            DeviceChange::GenuineDevice { id, certificate } => {
+            // Case colour is cosmetic identity, set whenever we learn it,
+            // independent of the genuine status (set separately below).
+            DeviceChange::CaseColor { id, color } => {
                 let index = self.index_of(id);
                 if let Some(connected) = self.connected.get_mut(&id) {
-                    connected.case_color =
-                        Some(api::CaseColor::from_comms(certificate.case_color()));
+                    connected.case_color = Some(api::CaseColor::from_comms(color));
+                    if let Some(index) = index {
+                        self.outbox.push(api::DeviceListChange {
+                            kind: api::DeviceListChangeKind::GenuineCheck,
+                            index: index as u32,
+                            device: connected.clone(),
+                        });
+                    }
+                }
+            }
+            DeviceChange::GenuineDevice { id, .. } => {
+                let index = self.index_of(id);
+                if let Some(connected) = self.connected.get_mut(&id) {
                     connected.genuine = api::GenuineStatus::Genuine;
                     if let Some(index) = index {
                         self.outbox.push(api::DeviceListChange {
@@ -171,10 +184,10 @@ impl DeviceList {
                 }
             }
             DeviceChange::GenuineCheckFailed { id } => {
+                // Status only; leave the case colour as-is.
                 let index = self.index_of(id);
                 if let Some(connected) = self.connected.get_mut(&id) {
                     connected.genuine = api::GenuineStatus::Failed;
-                    connected.case_color = None;
                     if let Some(index) = index {
                         self.outbox.push(api::DeviceListChange {
                             kind: api::DeviceListChangeKind::GenuineCheck,

--- a/frostsnapp/rust/src/device_list.rs
+++ b/frostsnapp/rust/src/device_list.rs
@@ -232,6 +232,17 @@ impl DeviceList {
         }
     }
 
+    /// Mark a device genuine from a persisted verdict, when the live challenge
+    /// was skipped. Only upgrades an Unknown status; never overrides a live
+    /// Genuine/Failed result from this session.
+    pub fn set_genuine_cached(&mut self, id: DeviceId) {
+        if let Some(connected) = self.connected.get_mut(&id) {
+            if connected.genuine == api::GenuineStatus::Unknown {
+                connected.genuine = api::GenuineStatus::Genuine;
+            }
+        }
+    }
+
     pub fn set_recovery_mode(&mut self, id: DeviceId, recovery_mode: bool) {
         if let Some(connected_device) = self.connected.get_mut(&id) {
             if connected_device.recovery_mode != recovery_mode {

--- a/frostsnapp/test/genuine_badge_test.dart
+++ b/frostsnapp/test/genuine_badge_test.dart
@@ -1,0 +1,107 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frostsnap/device_colors.dart';
+import 'package:frostsnap/genuine_badge.dart';
+import 'package:frostsnap/id_ext.dart';
+import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/src/rust/api/device_list.dart';
+import 'package:frostsnap/src/rust/lib.dart';
+
+DeviceId deviceId(int seed) {
+  final bytes = Uint8List(33);
+  bytes[0] = seed;
+  return DeviceId(field0: U8Array33(bytes));
+}
+
+void main() {
+  // The trap behind a bug where genuine status silently read "unverified" on every
+  // screen that looked a device up by id: the generated `DeviceId ==` forwards to
+  // `field0 ==`, and `field0` is a plain Dart list, which compares by reference.
+  // Two ids decoded from separate FFI calls are never the same object, so `==` is
+  // always false and `firstWhere` always throws.
+  group('DeviceId equality', () {
+    test('== does not compare by value, so never use it to match a device', () {
+      expect(deviceId(1) == deviceId(1), isFalse);
+    });
+
+    test('deviceIdEquals compares by value', () {
+      expect(deviceIdEquals(deviceId(1), deviceId(1)), isTrue);
+      expect(deviceIdEquals(deviceId(1), deviceId(2)), isFalse);
+    });
+  });
+
+  group('GenuineStatus presentation', () {
+    const scheme = ColorScheme.dark();
+
+    test('every status is distinguishable from every other', () {
+      // Two statuses that look and read alike are worse than no badge: the whole
+      // point is that "verified" and "we could not verify" are not confusable.
+      final labels = GenuineStatus.values.map((s) => s.label).toSet();
+      expect(labels, hasLength(GenuineStatus.values.length));
+
+      final byAppearance = GenuineStatus.values
+          .map((s) => '${s.icon.codePoint}/${s.color(scheme)}')
+          .toSet();
+      expect(
+        byAppearance.length,
+        greaterThan(1),
+        reason: 'statuses must not all render identically',
+      );
+    });
+
+    test('genuine and unknown never render the same', () {
+      expect(
+        GenuineStatus.genuine.label,
+        isNot(GenuineStatus.unknown.label),
+      );
+      expect(
+        GenuineStatus.genuine.color(scheme),
+        isNot(GenuineStatus.unknown.color(scheme)),
+      );
+      expect(GenuineStatus.genuine.icon, isNot(GenuineStatus.unknown.icon));
+    });
+
+    test('a failed check is not dressed up as merely unchecked', () {
+      expect(
+        GenuineStatus.failed.color(scheme),
+        isNot(GenuineStatus.unknown.color(scheme)),
+      );
+      expect(GenuineStatus.failed.icon, isNot(GenuineStatus.unknown.icon));
+    });
+
+    test('every status explains itself', () {
+      for (final status in GenuineStatus.values) {
+        final (title, body) = status.explanation;
+        expect(title, isNotEmpty, reason: '$status has no title');
+        expect(body, isNotEmpty, reason: '$status has no explanation');
+      }
+    });
+  });
+
+  group('CaseColor presentation', () {
+    test('no two case colours render alike', () {
+      // Colour exists so a device on screen can be matched to the one in your
+      // hand; two cases sharing a swatch would defeat that.
+      final colors = CaseColor.values.map((c) => c.color).toSet();
+      expect(colors, hasLength(CaseColor.values.length));
+
+      final labels = CaseColor.values.map((c) => c.label).toSet();
+      expect(labels, hasLength(CaseColor.values.length));
+    });
+
+    test('every case colour is visible against the dark surface', () {
+      // Black renders as a dark grey rather than true black precisely so it can
+      // be told apart from "no colour known" on this theme.
+      const surface = Color(0xFF141218);
+      for (final color in CaseColor.values) {
+        expect(
+          (color.color.computeLuminance() - surface.computeLuminance()).abs(),
+          greaterThan(0.01),
+          reason: '${color.label} is indistinguishable from the background',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
This makes the device genuine check trustworthy enough to turn on, and persists and shows each device's case colour throughout the app.

The device proves it's genuine Frostsnap hardware by signing a coordinator challenge with a provisioned key the factory has certified.

There is now a new _genuineness_ status pill (Genuine / Unknown / Not genuine) on the device list, the keygen screen, and the device-details screen (6e59c76e). Tapping it opens a short explanation dialog.

Core mechanism (b6a20e86): the device answers a genuine challenge with a certificate and **two signatures**:

- The **hardware key (RSA)** signs `SHA256(challenge || device_id)`: genuine hardware attestation for *this* device id.
- The **device-id key (schnorr)** signs the challenge: proof-of-possession of the secret for this device id.

The coordinator verifies **both against the connection's sender** (`message.from`). A relayed answer is bound to the genuine device's id, so relay attacks no longer work.

Three states:

- **Genuine** -- proof verified against a factory key.
- **Not genuine** -- the device answered but the signature is *bad* (wrong hardware key, forged cert, relay).
- **Unknown** -- old firmware (legacy proof), unresponsive device, cert signed by unknown factory key (a dev, open-source, or third-party device).

**Checked once, then remembered (cbfa12ef).** The check (certificate + RSA + a challenge round-trip) is costly, especially if connecting multiple devices at the same time. So when a device passes, its attested info (colour, serial) is stored in the DB keyed by device id; and upon later connects we read that back and skip re-challenging. This is safe because the `device_id` can't realistically be extracted (eFuse) and anything sensitive is encrypted to it, so a past pass stays trustworthy. Only passes are stored, so Unknown/Failed devices are re-checked every connect.


## Details

- Old `DeviceSendBody::SignedChallenge` is renamed to `_LegacyGenuineProof` (same wire slot, `_Legacy*` retirement convention) and the new `GenuineProof` is appended. Old firmware's unbound proof still decodes but is never trusted.

- **Colour persistence (307f129f).** Attested certificate is stored the instant the check passes and read from the DB on connect so that the device colour populates quickly and shows even while the device is disconnected (where appropriate).

- **`unverified_case_color()`** a deliberately separate, display-only accessor on the certificate that reads the colour without asserting the cert verified. Lets us show the colour in the Unknown/legacy case.

- **Genuine check is build-time gated (`cfg!(genuine_cert_key)`).** A factory public key is only baked in when the app is built with `FROSTSNAP_ENV` set. With no env, no key is baked in, so the coordinator never issues a challenge. Ran into this while testing.

- **Factory tool** updated to the new challenge so provisioning and `just genuine-check` recognise new firmware. These tools won't work against old firmware.


## Notes

- **Colours:** a production device on v0.3.0 firmware sends the legacy proof, and its case colour still shows.
- A full genuine "pass" needs a test with provisioned dev devices.
- A malicious device could spoof `from` and flip a real device's badge to "Not genuine". Doesn't gain them anything..