### PR TITLE
Name the testnet version in the UI

### DIFF
--- a/frostsnapp/lib/bitcoin_network_ext.dart
+++ b/frostsnapp/lib/bitcoin_network_ext.dart
@@ -1,0 +1,16 @@
+import 'package:frostsnap/src/rust/api/bitcoin.dart';
+
+extension BitcoinNetworkDisplayExt on BitcoinNetwork {
+  /// User-facing network name. Unlike [name], this says which testnet version
+  /// the wallet runs on ("testnet" is Testnet3, not Testnet4). [name] is the
+  /// identity string that round-trips through [BitcoinNetwork.fromString], so
+  /// it can't be changed for display purposes.
+  String get displayName => switch (name()) {
+    "bitcoin" => "Bitcoin",
+    "testnet" => "Testnet3",
+    "testnet4" => "Testnet4",
+    "signet" => "Signet",
+    "regtest" => "Regtest",
+    final other => other,
+  };
+}

--- a/frostsnapp/lib/electrum_server_settings.dart
+++ b/frostsnapp/lib/electrum_server_settings.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/settings.dart';
 import 'package:frostsnap/progress_indicator.dart';
 import 'package:frostsnap/dialog_content_with_actions.dart';
+import 'package:frostsnap/bitcoin_network_ext.dart';
 import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/settings.dart';
 import 'package:frostsnap/theme.dart';
@@ -102,7 +103,7 @@ class _NetworkServerCard extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
                 child: Text(
-                  network.name(),
+                  network.displayName,
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w600,
                   ),

--- a/frostsnapp/lib/settings.dart
+++ b/frostsnapp/lib/settings.dart
@@ -15,6 +15,7 @@ import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/logs.dart';
 import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/bitcoin_network_ext.dart';
 import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/settings.dart';
 import 'package:frostsnap/theme.dart';
@@ -1175,7 +1176,9 @@ class BitcoinNetworkChooser extends StatelessWidget {
             final name = network.name();
             return DropdownMenuItem<String>(
               value: name,
-              child: Text(name == "bitcoin" ? "Bitcoin (BTC)" : network.name()),
+              child: Text(
+                name == "bitcoin" ? "Bitcoin (BTC)" : network.displayName,
+              ),
             );
           }).toList(),
         ),

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -11,6 +11,7 @@ import 'package:frostsnap/nonce_replenish.dart';
 import 'package:frostsnap/restoration/wallet_recovery_page.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/backup_run.dart';
+import 'package:frostsnap/bitcoin_network_ext.dart';
 import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/coordinator.dart';
 import 'package:frostsnap/src/rust/api/settings.dart';
@@ -525,7 +526,7 @@ class WalletDrawer extends StatelessWidget {
                       color: theme.colorScheme.onSurfaceVariant,
                     ),
                   );
-                }(context, text: item.network?.name() ?? ''),
+                }(context, text: item.network?.displayName ?? ''),
             ],
           ),
         ),

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -12,6 +12,7 @@ import 'package:frostsnap/settings.dart';
 import 'package:frostsnap/snackbar.dart';
 import 'package:frostsnap/threshold_selector.dart';
 import 'package:frostsnap/src/rust/api.dart';
+import 'package:frostsnap/bitcoin_network_ext.dart';
 import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/device_list.dart';
 import 'package:frostsnap/src/rust/api/keygen.dart';
@@ -1263,7 +1264,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
     final network = _controller.form.network;
     final appBarTrailingText = network.isMainnet()
         ? ''
-        : ' (${network.name()})';
+        : ' (${network.displayName})';
 
     final header = TopBarSliver(
       title: Text('${_controller.title}$appBarTrailingText'),
@@ -1409,7 +1410,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
                     (network) => ButtonSegment(
                       value: network.name(),
                       label: Text(
-                        network.name(),
+                        network.displayName,
                         overflow: TextOverflow.fade,
                         softWrap: false,
                       ),
@@ -1450,7 +1451,7 @@ class _WalletCreatePageState extends State<WalletCreatePage> {
                   if (!_controller.form.network.isMainnet())
                     InputChip(
                       surfaceTintColor: theme.colorScheme.error,
-                      label: Text(_controller.form.network.name()),
+                      label: Text(_controller.form.network.displayName),
                       deleteIcon: Icon(Icons.clear_rounded),
                       onDeleted: () {
                         _isAdvancedOptionsHidden = true;


### PR DESCRIPTION
Stating "testnet" alone doesn't say whether the wallet is on Testnet3 or Testnet4, show "Testnet3" wherever the network is displayed.