### PR TITLE
Block firmware downgrades on the device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,6 +1753,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "frostsnap_core",
+ "frostsnap_macros",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rsa",

--- a/device/src/esp32_run.rs
+++ b/device/src/esp32_run.rs
@@ -403,7 +403,7 @@ impl<'a> DeviceLoop<'a> {
                                                 if let Some(mut upgrade) = self.upgrade.take() {
                                                     let upstream_io =
                                                         self.upstream_serial.inner_mut();
-                                                    upgrade.enter_upgrade_mode(
+                                                    let outcome = upgrade.enter_upgrade_mode(
                                                         upstream_io,
                                                         if self.downstream_connection_state
                                                             == DownstreamConnectionState::Established
@@ -419,7 +419,21 @@ impl<'a> DeviceLoop<'a> {
                                                         self.timer,
                                                         self.rsa,
                                                     );
-                                                    reset(self.upstream_serial);
+                                                    match outcome {
+                                                        ota::UpgradeOutcome::Committed => {
+                                                            reset(self.upstream_serial)
+                                                        }
+                                                        // Any refusal parks here until power
+                                                        // cycle. The active slot is unchanged
+                                                        // and the screen says why and how to
+                                                        // recover; resuming the loop instead
+                                                        // would leave the coordinator and the
+                                                        // chain in a half-finished upgrade
+                                                        // conversation.
+                                                        ota::UpgradeOutcome::Rejected => loop {
+                                                            self.ui.poll();
+                                                        },
+                                                    }
                                                 } else {
                                                     panic!("upgrade cannot start because we were not warned about it")
                                                 }

--- a/device/src/frosty_ui.rs
+++ b/device/src/frosty_ui.rs
@@ -245,6 +245,9 @@ impl<'a> UserInteraction for FrostyUi<'a> {
                         FirmwareUpgradeProgress::downloading(progress)
                     }
                     FirmwareUpgradeStatus::Passive => FirmwareUpgradeProgress::passive(),
+                    FirmwareUpgradeStatus::Rejected { reason } => {
+                        FirmwareUpgradeProgress::rejected(&reason.to_string())
+                    }
                 });
 
                 WidgetTree::FirmwareUpgradeProgress { widget, status }

--- a/device/src/frosty_ui.rs
+++ b/device/src/frosty_ui.rs
@@ -19,6 +19,16 @@ use crate::{
     UpstreamConnectionState,
 };
 
+fn refuse_reason_text(reason: crate::ota::RefuseReason) -> &'static str {
+    use crate::ota::RefuseReason;
+    match reason {
+        RefuseReason::UnparseableFirmware => "Firmware invalid",
+        RefuseReason::DigestMismatch => "Download corrupted",
+        RefuseReason::SecureBootInvalid => "Signature invalid",
+        RefuseReason::DowngradeBlocked => "Downgrade blocked",
+    }
+}
+
 // Type alias for the display to match factory
 type DeviceDisplay<'a> = mipidsi::Display<
     display_interface_spi::SPIInterface<
@@ -357,6 +367,9 @@ impl<'a> UserInteraction for FrostyUi<'a> {
                         FirmwareUpgradeProgress::downloading(progress)
                     }
                     FirmwareUpgradeStatus::Passive => FirmwareUpgradeProgress::passive(),
+                    FirmwareUpgradeStatus::Rejected { reason } => {
+                        FirmwareUpgradeProgress::rejected(refuse_reason_text(reason))
+                    }
                 });
 
                 WidgetTree::FirmwareUpgradeProgress { widget, status }

--- a/device/src/ota.rs
+++ b/device/src/ota.rs
@@ -12,10 +12,78 @@ use esp_hal::time::Duration;
 use esp_hal::timer;
 use esp_hal::Blocking;
 use frostsnap_comms::{
-    CommsMisc, DeviceSendBody, Sha256Digest, BAUDRATE, FIRMWARE_NEXT_CHUNK_READY_SIGNAL,
-    FIRMWARE_UPGRADE_CHUNK_LEN,
+    firmware_version, CommsMisc, DeviceSendBody, Sha256Digest, BAUDRATE,
+    FIRMWARE_NEXT_CHUNK_READY_SIGNAL, FIRMWARE_UPGRADE_CHUNK_LEN,
 };
 use nb::block;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpgradeVerdict {
+    Commit,
+    Refuse(RefuseReason),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefuseReason {
+    UnparseableFirmware,
+    DigestMismatch,
+    SecureBootInvalid,
+    DowngradeBlocked,
+}
+
+impl core::fmt::Display for RefuseReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            RefuseReason::UnparseableFirmware => "Firmware invalid",
+            RefuseReason::DigestMismatch => "Download corrupted",
+            RefuseReason::SecureBootInvalid => "Signature invalid",
+            RefuseReason::DowngradeBlocked => "Downgrade blocked",
+        })
+    }
+}
+
+/// Decide whether to commit the downloaded upgrade sitting in `partition`,
+/// against the digest the coordinator announced. Everything examined here is
+/// attacker-controlled, so every failure is a verdict, never a panic. When
+/// more than one thing is wrong the reason follows the check order below,
+/// most fundamental first; that only picks the reason shown, never whether it
+/// commits.
+fn decide_upgrade(
+    partition: &EspFlashPartition<'_>,
+    announced_digest: &Sha256Digest,
+    sha: &mut Sha<'_>,
+    rsa: &mut Rsa<Blocking>,
+) -> UpgradeVerdict {
+    let Ok((firmware_size, _)) = partition.firmware_size() else {
+        return UpgradeVerdict::Refuse(RefuseReason::UnparseableFirmware);
+    };
+
+    // Only the body digest is accepted. v0.0.1-era coordinators announce the
+    // full-image digest instead, but anything they'd push is superseded
+    // firmware this device refuses anyway — mismatching them early just picks
+    // a different refusal reason.
+    let body_digest = partition.sha256_digest(sha, Some(firmware_size));
+    if body_digest != *announced_digest {
+        return UpgradeVerdict::Refuse(RefuseReason::DigestMismatch);
+    }
+
+    if secure_boot::is_secure_boot_enabled()
+        && secure_boot::verify_secure_boot(partition, rsa, sha).is_err()
+    {
+        return UpgradeVerdict::Refuse(RefuseReason::SecureBootInvalid);
+    }
+
+    // Only body digests are compared: the shared list's v0.0.1 full-image
+    // digest can never equal any image's body digest.
+    let downgrade_blocked = firmware_version::EARLIEST_ACCEPTABLE
+        .versions_before()
+        .any(|(digest, _)| *digest == body_digest);
+    if downgrade_blocked {
+        return UpgradeVerdict::Refuse(RefuseReason::DowngradeBlocked);
+    }
+
+    UpgradeVerdict::Commit
+}
 
 #[derive(Clone, Debug)]
 pub struct OtaPartitions<'a> {
@@ -205,6 +273,16 @@ pub enum State {
     WaitingToEnterUpgradeMode,
 }
 
+/// Outcome of driving an upgrade to its decision point. `Rejected` means the
+/// written image was refused (any [`RefuseReason`]) with the
+/// active slot unchanged; the caller must not reboot into it and is expected to
+/// park on the refusal screen until the user power-cycles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpgradeOutcome {
+    Committed,
+    Rejected,
+}
+
 impl FirmwareUpgradeMode<'_> {
     pub fn poll(&mut self, ui: &mut impl crate::ui::UserInteraction) -> Option<DeviceSendBody> {
         match self {
@@ -298,7 +376,7 @@ impl FirmwareUpgradeMode<'_> {
         sha: &mut Sha<'_>,
         timer: &T,
         rsa: &mut Rsa<Blocking>,
-    ) {
+    ) -> UpgradeOutcome {
         match self {
             FirmwareUpgradeMode::Upgrading { state, .. } => {
                 if !matches!(state, State::WaitingToEnterUpgradeMode) {
@@ -414,44 +492,24 @@ impl FirmwareUpgradeMode<'_> {
         } = &self
         {
             let partition = &ota.ota_partitions()[*ota_slot];
-            let (firmware_size, firmware_and_signature_block_size) =
-                partition.firmware_size().unwrap();
 
-            // Verify firmware digest - we accept BOTH digest types:
-            //
-            // 1. Deterministic firmware digest (PrepareUpgrade2): Hash of firmware only,
-            //    excluding padding and signature block. Displayed on device screen so users
-            //    can verify it matches their locally-built reproducible firmware.
-            //
-            // 2. Legacy full digest (PrepareUpgrade): Hash of entire signed firmware including
-            //    padding and signature block. Used by v0.0.1 and earlier coordinators.
-            //
-            // Why accept both?
-            // - SHA256 collision resistance (~2^-256) makes accidental matches impossible
-            // - Simplifies code - no need to track which message variant was received
-            // - Provides backwards compatibility with older coordinators
-            // - Allows graceful fallback if coordinator sends wrong digest type
-            //
-            // See frostsnap_comms::CoordinatorUpgradeMessage for protocol documentation.
-
-            let digest_without_signature = partition.sha256_digest(sha, Some(firmware_size));
-            if digest_without_signature != *expected_digest {
-                let digest_with_signature =
-                    partition.sha256_digest(sha, Some(firmware_and_signature_block_size));
-                if digest_with_signature != *expected_digest {
-                    panic!(
-                    "upgrade downloaded did not match intended digest.\n\nGot:\n{}\n\nExpected:\n{}\n\n(Legacy:\n{})",
-                    digest_without_signature, expected_digest, digest_with_signature
-                );
+            // The coordinator driving this is untrusted, so acceptance is enforced
+            // here, against the bytes actually written. Any refusal leaves the active
+            // slot unchanged and returns Rejected; the running firmware survives and
+            // boots again on the power cycle the refusal screen asks for.
+            match decide_upgrade(partition, expected_digest, sha, rsa) {
+                UpgradeVerdict::Commit => ota.switch_partition(*ota_slot, OtaMetadata {}),
+                UpgradeVerdict::Refuse(reason) => {
+                    ui.set_workflow(ui::Workflow::FirmwareUpgrade(
+                        ui::FirmwareUpgradeStatus::Rejected { reason },
+                    ));
+                    ui.poll();
+                    return UpgradeOutcome::Rejected;
                 }
             }
-
-            if secure_boot::is_secure_boot_enabled() {
-                secure_boot::verify_secure_boot(partition, rsa, sha).unwrap();
-            }
-
-            ota.switch_partition(*ota_slot, OtaMetadata {});
         }
+
+        UpgradeOutcome::Committed
     }
 }
 

--- a/device/src/ota.rs
+++ b/device/src/ota.rs
@@ -12,10 +12,68 @@ use esp_hal::time::Duration;
 use esp_hal::timer;
 use esp_hal::Blocking;
 use frostsnap_comms::{
-    CommsMisc, DeviceSendBody, Sha256Digest, BAUDRATE, FIRMWARE_NEXT_CHUNK_READY_SIGNAL,
-    FIRMWARE_UPGRADE_CHUNK_LEN,
+    firmware_version, CommsMisc, DeviceSendBody, Sha256Digest, BAUDRATE,
+    FIRMWARE_NEXT_CHUNK_READY_SIGNAL, FIRMWARE_UPGRADE_CHUNK_LEN,
 };
 use nb::block;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpgradeVerdict {
+    Commit,
+    Refuse(RefuseReason),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefuseReason {
+    UnparseableFirmware,
+    DigestMismatch,
+    SecureBootInvalid,
+    DowngradeBlocked,
+}
+
+/// Decide whether to commit the downloaded upgrade sitting in `partition`,
+/// against the digest the coordinator announced. Everything examined here is
+/// attacker-controlled, so every failure is a verdict, never a panic. When
+/// more than one thing is wrong the reason follows the check order below,
+/// most fundamental first; that only picks the reason shown, never whether it
+/// commits.
+fn decide_upgrade(
+    partition: &EspFlashPartition<'_>,
+    announced_digest: &Sha256Digest,
+    sha: &mut Sha<'_>,
+    rsa: &mut Rsa<Blocking>,
+) -> UpgradeVerdict {
+    let Ok((firmware_size, firmware_and_signature_block_size)) = partition.firmware_size() else {
+        return UpgradeVerdict::Refuse(RefuseReason::UnparseableFirmware);
+    };
+
+    let body_digest = partition.sha256_digest(sha, Some(firmware_size));
+    let full_digest = partition.sha256_digest(sha, Some(firmware_and_signature_block_size));
+
+    // A match on either digest convention identifies the intended image (the
+    // full digest is what v0.0.1-era coordinators announce); SHA256 makes an
+    // accidental match impossible.
+    if body_digest != *announced_digest && full_digest != *announced_digest {
+        return UpgradeVerdict::Refuse(RefuseReason::DigestMismatch);
+    }
+
+    if secure_boot::is_secure_boot_enabled()
+        && secure_boot::verify_secure_boot(partition, rsa, sha).is_err()
+    {
+        return UpgradeVerdict::Refuse(RefuseReason::SecureBootInvalid);
+    }
+
+    // Only body digests are compared: the shared list's v0.0.1 full-image
+    // digest can never equal any image's body digest.
+    let downgrade_blocked =
+        firmware_version::versions_before(firmware_version::EARLIEST_ACCEPTABLE)
+            .any(|(digest, _)| *digest == body_digest);
+    if downgrade_blocked {
+        return UpgradeVerdict::Refuse(RefuseReason::DowngradeBlocked);
+    }
+
+    UpgradeVerdict::Commit
+}
 
 #[derive(Clone, Debug)]
 pub struct OtaPartitions<'a> {
@@ -205,6 +263,16 @@ pub enum State {
     WaitingToEnterUpgradeMode,
 }
 
+/// Outcome of driving an upgrade to its decision point. `Rejected` means the
+/// written image was refused (any [`RefuseReason`]) with the
+/// active slot unchanged; the caller must not reboot into it and is expected to
+/// park on the refusal screen until the user power-cycles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpgradeOutcome {
+    Committed,
+    Rejected,
+}
+
 impl FirmwareUpgradeMode<'_> {
     pub fn poll(&mut self, ui: &mut impl crate::ui::UserInteraction) -> Option<DeviceSendBody> {
         match self {
@@ -298,7 +366,7 @@ impl FirmwareUpgradeMode<'_> {
         sha: &mut Sha<'_>,
         timer: &T,
         rsa: &mut Rsa<Blocking>,
-    ) {
+    ) -> UpgradeOutcome {
         match self {
             FirmwareUpgradeMode::Upgrading { state, .. } => {
                 if !matches!(state, State::WaitingToEnterUpgradeMode) {
@@ -414,44 +482,24 @@ impl FirmwareUpgradeMode<'_> {
         } = &self
         {
             let partition = &ota.ota_partitions()[*ota_slot];
-            let (firmware_size, firmware_and_signature_block_size) =
-                partition.firmware_size().unwrap();
 
-            // Verify firmware digest - we accept BOTH digest types:
-            //
-            // 1. Deterministic firmware digest (PrepareUpgrade2): Hash of firmware only,
-            //    excluding padding and signature block. Displayed on device screen so users
-            //    can verify it matches their locally-built reproducible firmware.
-            //
-            // 2. Legacy full digest (PrepareUpgrade): Hash of entire signed firmware including
-            //    padding and signature block. Used by v0.0.1 and earlier coordinators.
-            //
-            // Why accept both?
-            // - SHA256 collision resistance (~2^-256) makes accidental matches impossible
-            // - Simplifies code - no need to track which message variant was received
-            // - Provides backwards compatibility with older coordinators
-            // - Allows graceful fallback if coordinator sends wrong digest type
-            //
-            // See frostsnap_comms::CoordinatorUpgradeMessage for protocol documentation.
-
-            let digest_without_signature = partition.sha256_digest(sha, Some(firmware_size));
-            if digest_without_signature != *expected_digest {
-                let digest_with_signature =
-                    partition.sha256_digest(sha, Some(firmware_and_signature_block_size));
-                if digest_with_signature != *expected_digest {
-                    panic!(
-                    "upgrade downloaded did not match intended digest.\n\nGot:\n{}\n\nExpected:\n{}\n\n(Legacy:\n{})",
-                    digest_without_signature, expected_digest, digest_with_signature
-                );
+            // The coordinator driving this is untrusted, so acceptance is enforced
+            // here, against the bytes actually written. Any refusal leaves the active
+            // slot unchanged and returns Rejected; the running firmware survives and
+            // boots again on the power cycle the refusal screen asks for.
+            match decide_upgrade(partition, expected_digest, sha, rsa) {
+                UpgradeVerdict::Commit => ota.switch_partition(*ota_slot, OtaMetadata {}),
+                UpgradeVerdict::Refuse(reason) => {
+                    ui.set_workflow(ui::Workflow::FirmwareUpgrade(
+                        ui::FirmwareUpgradeStatus::Rejected { reason },
+                    ));
+                    ui.poll();
+                    return UpgradeOutcome::Rejected;
                 }
             }
-
-            if secure_boot::is_secure_boot_enabled() {
-                secure_boot::verify_secure_boot(partition, rsa, sha).unwrap();
-            }
-
-            ota.switch_partition(*ota_slot, OtaMetadata {});
         }
+
+        UpgradeOutcome::Committed
     }
 }
 

--- a/device/src/ota.rs
+++ b/device/src/ota.rs
@@ -311,11 +311,11 @@ impl FirmwareUpgradeMode<'_> {
                         for _ in 0..ERASE_CHUNK_SIZE {
                             partition.erase_sector(*seq).expect("must erase sector");
 
-                            *seq += 1;
                             if *seq == last_sector_index {
                                 finished = true;
                                 break;
                             }
+                            *seq += 1;
                         }
                         ui.set_workflow(ui::Workflow::FirmwareUpgrade(
                             ui::FirmwareUpgradeStatus::Erase {

--- a/device/src/ui.rs
+++ b/device/src/ui.rs
@@ -135,6 +135,7 @@ pub enum FirmwareUpgradeStatus {
     Erase { progress: f32 },
     Download { progress: f32 },
     Passive,
+    Rejected { reason: crate::ota::RefuseReason },
 }
 
 #[derive(Clone, Debug)]

--- a/frostsnap_comms/Cargo.toml
+++ b/frostsnap_comms/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 frostsnap_core = { workspace = true  }
+frostsnap_macros = { workspace = true }
 serde = { workspace = true }
 bincode =  { workspace = true }
 rand_core = { workspace = true }

--- a/frostsnap_comms/src/firmware_version.rs
+++ b/frostsnap_comms/src/firmware_version.rs
@@ -1,0 +1,163 @@
+//! The shared record of released firmware versions. Data only — what the
+//! device and coordinator do with it lives in their own crates — and the
+//! digest tables stay private because the two digest conventions are easy to
+//! confuse: go through the accessors, which say which one they mean.
+//!
+//! A release's digest is appended to the list when it should become active
+//! (after its artifact is built and signed — an image can never contain its
+//! own digest, and it doesn't need to).
+
+use crate::Sha256Digest;
+use frostsnap_macros::hex;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VersionNumber {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+}
+
+impl core::fmt::Display for VersionNumber {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl VersionNumber {
+    pub const fn new(major: u8, minor: u8, patch: u8) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// The release `digest` identifies, under either digest convention a
+    /// device may announce (body digest, or v0.0.1's full-image digest).
+    pub fn from_digest(digest: &Sha256Digest) -> Option<Self> {
+        if *digest == V0_0_1_FULL_IMAGE_DIGEST {
+            return Some(VersionNumber::new(0, 0, 1));
+        }
+        KNOWN_FIRMWARE_VERSIONS
+            .iter()
+            .find(|(d, _)| d == digest)
+            .map(|(_, v)| *v)
+    }
+
+    /// Releases strictly older than `self`, as (body digest, version) — the
+    /// superseded set when `self` is [`EARLIEST_ACCEPTABLE`].
+    pub fn versions_before(self) -> impl Iterator<Item = &'static (Sha256Digest, VersionNumber)> {
+        KNOWN_FIRMWARE_VERSIONS
+            .iter()
+            .filter(move |(_, v)| *v < self)
+    }
+
+    pub fn features(&self) -> FirmwareFeatures {
+        const V0_0_1: VersionNumber = VersionNumber::new(0, 0, 1);
+        const V0_3_0: VersionNumber = VersionNumber::new(0, 3, 0);
+
+        FirmwareFeatures {
+            upgrade_digest_no_sig: *self > V0_0_1,
+            check_backup: *self >= V0_3_0,
+        }
+    }
+}
+
+#[derive(bincode::Encode, bincode::Decode, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FirmwareFeatures {
+    /// Device supports firmware digest verification without signature block
+    pub upgrade_digest_no_sig: bool,
+    /// Device supports the check backup quiz workflow
+    pub check_backup: bool,
+}
+
+impl FirmwareFeatures {
+    pub const fn all() -> Self {
+        Self {
+            upgrade_digest_no_sig: true,
+            check_backup: true,
+        }
+    }
+}
+
+/// Devices built from this tree refuse to install any release older than
+/// this — currently the upcoming release, i.e. every previous firmware is
+/// rejected. Bumped when a release is cut, together with appending the
+/// previous release to the list below.
+pub const EARLIEST_ACCEPTABLE: VersionNumber = VersionNumber::new(0, 4, 0);
+
+/// Body (firmware-only, sans signature block) digest of each shipped release —
+/// the digest a device computes over a written image, and the
+/// deterministic-build digest.
+const KNOWN_FIRMWARE_VERSIONS: &[(Sha256Digest, VersionNumber)] = &[
+    (
+        Sha256Digest(hex!(
+            "6273dc08ca7c805fa70ac8feeb98c62f7b6fcb337fb1cd8412f24f0d6dda51f7"
+        )),
+        VersionNumber::new(0, 3, 0),
+    ),
+    (
+        Sha256Digest(hex!(
+            "e432d313c7698b1e8843b10ba95efa8c28e66a5723b966c56c156687d09d16e0"
+        )),
+        VersionNumber::new(0, 2, 0),
+    ),
+    (
+        Sha256Digest(hex!(
+            "5ff7bd280b96d645b2c739a6b91bfc6c27197e213302770f1a7180678ca4f720"
+        )),
+        VersionNumber::new(0, 1, 0),
+    ),
+    (
+        Sha256Digest(hex!(
+            "8f45ae6b72c241a20798acbd3c6d3e54071cae73e335df1785f2d485a915da4c"
+        )),
+        VersionNumber::new(0, 0, 1),
+    ),
+];
+
+/// v0.0.1-era devices announced the digest over the FULL image (body plus
+/// signature block), so that one release is also identified by this digest.
+const V0_0_1_FULL_IMAGE_DIGEST: Sha256Digest = Sha256Digest(hex!(
+    "57161f80b41413b1053e272f9c3da8d16ecfce44793345be69f7fe03d93f4eb0"
+));
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn every_known_version_is_below_earliest_acceptable() {
+        assert_eq!(
+            EARLIEST_ACCEPTABLE.versions_before().count(),
+            KNOWN_FIRMWARE_VERSIONS.len()
+        );
+    }
+
+    #[test]
+    fn versions_at_or_after_the_bound_are_excluded() {
+        assert_eq!(VersionNumber::new(0, 0, 1).versions_before().count(), 0);
+        assert!(VersionNumber::new(0, 2, 0)
+            .versions_before()
+            .all(|(_, v)| *v < VersionNumber::new(0, 2, 0)));
+    }
+
+    #[test]
+    fn v0_0_1_resolves_under_both_digest_conventions() {
+        let v0_0_1 = VersionNumber::new(0, 0, 1);
+        assert_eq!(
+            VersionNumber::from_digest(&V0_0_1_FULL_IMAGE_DIGEST),
+            Some(v0_0_1)
+        );
+        let (body, _) = KNOWN_FIRMWARE_VERSIONS
+            .iter()
+            .find(|(_, v)| *v == v0_0_1)
+            .unwrap();
+        assert_eq!(VersionNumber::from_digest(body), Some(v0_0_1));
+        // The full-image digest names the release but is not a body digest, so
+        // it must never appear in the superseded (blockable) set.
+        assert!(EARLIEST_ACCEPTABLE
+            .versions_before()
+            .all(|(d, _)| *d != V0_0_1_FULL_IMAGE_DIGEST));
+    }
+}

--- a/frostsnap_comms/src/firmware_version.rs
+++ b/frostsnap_comms/src/firmware_version.rs
@@ -1,0 +1,162 @@
+//! The shared record of released firmware versions. Data only — what the
+//! device and coordinator do with it lives in their own crates — and the
+//! digest tables stay private because the two digest conventions are easy to
+//! confuse: go through the accessors, which say which one they mean.
+//!
+//! A release's digest is appended to the list when it should become active
+//! (after its artifact is built and signed — an image can never contain its
+//! own digest, and it doesn't need to).
+
+use crate::Sha256Digest;
+use frostsnap_macros::hex;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VersionNumber {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+}
+
+impl core::fmt::Display for VersionNumber {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl VersionNumber {
+    pub const fn new(major: u8, minor: u8, patch: u8) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// The release `digest` identifies, under either digest convention a
+    /// device may announce (body digest, or v0.0.1's full-image digest).
+    pub fn from_digest(digest: &Sha256Digest) -> Option<Self> {
+        if *digest == V0_0_1_FULL_IMAGE_DIGEST {
+            return Some(VersionNumber::new(0, 0, 1));
+        }
+        KNOWN_FIRMWARE_VERSIONS
+            .iter()
+            .find(|(d, _)| d == digest)
+            .map(|(_, v)| *v)
+    }
+
+    pub fn features(&self) -> FirmwareFeatures {
+        const V0_0_1: VersionNumber = VersionNumber::new(0, 0, 1);
+        const V0_3_0: VersionNumber = VersionNumber::new(0, 3, 0);
+
+        FirmwareFeatures {
+            upgrade_digest_no_sig: *self > V0_0_1,
+            check_backup: *self >= V0_3_0,
+        }
+    }
+}
+
+#[derive(bincode::Encode, bincode::Decode, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FirmwareFeatures {
+    /// Device supports firmware digest verification without signature block
+    pub upgrade_digest_no_sig: bool,
+    /// Device supports the check backup quiz workflow
+    pub check_backup: bool,
+}
+
+impl FirmwareFeatures {
+    pub const fn all() -> Self {
+        Self {
+            upgrade_digest_no_sig: true,
+            check_backup: true,
+        }
+    }
+}
+
+/// Devices built from this tree refuse to install any release older than
+/// this — currently the upcoming release, i.e. every previous firmware is
+/// rejected. Bumped when a release is cut, together with appending the
+/// previous release to the list below.
+pub const EARLIEST_ACCEPTABLE: VersionNumber = VersionNumber::new(0, 4, 0);
+
+/// Body (firmware-only, sans signature block) digest of each shipped release —
+/// the digest a device computes over a written image, and the
+/// deterministic-build digest.
+const KNOWN_FIRMWARE_VERSIONS: &[(Sha256Digest, VersionNumber)] = &[
+    (
+        Sha256Digest(hex!(
+            "6273dc08ca7c805fa70ac8feeb98c62f7b6fcb337fb1cd8412f24f0d6dda51f7"
+        )),
+        VersionNumber::new(0, 3, 0),
+    ),
+    (
+        Sha256Digest(hex!(
+            "e432d313c7698b1e8843b10ba95efa8c28e66a5723b966c56c156687d09d16e0"
+        )),
+        VersionNumber::new(0, 2, 0),
+    ),
+    (
+        Sha256Digest(hex!(
+            "5ff7bd280b96d645b2c739a6b91bfc6c27197e213302770f1a7180678ca4f720"
+        )),
+        VersionNumber::new(0, 1, 0),
+    ),
+    (
+        Sha256Digest(hex!(
+            "8f45ae6b72c241a20798acbd3c6d3e54071cae73e335df1785f2d485a915da4c"
+        )),
+        VersionNumber::new(0, 0, 1),
+    ),
+];
+
+/// v0.0.1-era devices announced the digest over the FULL image (body plus
+/// signature block), so that one release is also identified by this digest.
+const V0_0_1_FULL_IMAGE_DIGEST: Sha256Digest = Sha256Digest(hex!(
+    "57161f80b41413b1053e272f9c3da8d16ecfce44793345be69f7fe03d93f4eb0"
+));
+
+/// Releases strictly older than `version`, as (body digest, version) — the
+/// superseded set when `version` is [`EARLIEST_ACCEPTABLE`].
+pub fn versions_before(
+    version: VersionNumber,
+) -> impl Iterator<Item = &'static (Sha256Digest, VersionNumber)> {
+    KNOWN_FIRMWARE_VERSIONS
+        .iter()
+        .filter(move |(_, v)| *v < version)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn every_known_version_is_below_earliest_acceptable() {
+        assert_eq!(
+            versions_before(EARLIEST_ACCEPTABLE).count(),
+            KNOWN_FIRMWARE_VERSIONS.len()
+        );
+    }
+
+    #[test]
+    fn versions_at_or_after_the_bound_are_excluded() {
+        assert_eq!(versions_before(VersionNumber::new(0, 0, 1)).count(), 0);
+        assert!(versions_before(VersionNumber::new(0, 2, 0))
+            .all(|(_, v)| *v < VersionNumber::new(0, 2, 0)));
+    }
+
+    #[test]
+    fn v0_0_1_resolves_under_both_digest_conventions() {
+        let v0_0_1 = VersionNumber::new(0, 0, 1);
+        assert_eq!(
+            VersionNumber::from_digest(&V0_0_1_FULL_IMAGE_DIGEST),
+            Some(v0_0_1)
+        );
+        let (body, _) = KNOWN_FIRMWARE_VERSIONS
+            .iter()
+            .find(|(_, v)| *v == v0_0_1)
+            .unwrap();
+        assert_eq!(VersionNumber::from_digest(body), Some(v0_0_1));
+        // The full-image digest names the release but is not a body digest, so
+        // it must never appear in the superseded (blockable) set.
+        assert!(versions_before(EARLIEST_ACCEPTABLE).all(|(d, _)| *d != V0_0_1_FULL_IMAGE_DIGEST));
+    }
+}

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -7,6 +7,7 @@ extern crate std;
 extern crate alloc;
 pub mod factory;
 pub mod firmware_reader;
+pub mod firmware_version;
 pub mod fixed_string;
 pub mod genuine_certificate;
 use alloc::boxed::Box;

--- a/frostsnap_comms/src/lib.rs
+++ b/frostsnap_comms/src/lib.rs
@@ -7,6 +7,7 @@ extern crate std;
 extern crate alloc;
 pub mod factory;
 pub mod firmware_reader;
+pub mod firmware_version;
 pub mod fixed_string;
 pub mod genuine_certificate;
 use alloc::boxed::Box;
@@ -266,15 +267,12 @@ impl From<CoordinatorSendMessage> for CoordinatorSendMessage<WireCoordinatorSend
 ///
 /// ## Device Verification Strategy
 ///
-/// Devices accept **both** digest types during verification for backwards compatibility.
-/// This is cryptographically sound because:
+/// Devices accept only the deterministic firmware-only digest. A legacy
+/// coordinator announcing the full-image digest gets a digest-mismatch
+/// refusal — anything it could push is superseded firmware the device now
+/// refuses as a downgrade anyway, so the legacy convention buys nothing.
 ///
-/// 1. SHA256 collision resistance (~2^-256 probability) makes accidental matches impossible
-/// 2. The two digests cover different byte ranges, requiring collision at specific boundaries
-/// 3. Simplifies device code - no need to track which variant was received
-/// 4. Provides graceful fallback if coordinator sends wrong digest type
-///
-/// See `device/src/ota.rs::enter_upgrade_mode()` for verification implementation.
+/// See `decide_upgrade` in `device/src/ota.rs` for the verification.
 #[derive(Encode, Decode, Debug, Clone)]
 pub enum CoordinatorUpgradeMessage {
     /// Legacy upgrade preparation - sends digest of entire signed firmware.

--- a/frostsnap_coordinator/src/firmware.rs
+++ b/frostsnap_coordinator/src/firmware.rs
@@ -1,22 +1,6 @@
-use bincode::{Decode, Encode};
 use frostsnap_comms::{Sha256Digest, FIRMWARE_UPGRADE_CHUNK_LEN};
 
-#[derive(Encode, Decode, Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct FirmwareFeatures {
-    /// Device supports firmware digest verification without signature block
-    pub upgrade_digest_no_sig: bool,
-    /// Device supports the check backup quiz workflow
-    pub check_backup: bool,
-}
-
-impl FirmwareFeatures {
-    pub const fn all() -> Self {
-        Self {
-            upgrade_digest_no_sig: true,
-            check_backup: true,
-        }
-    }
-}
+pub use frostsnap_comms::firmware_version::{FirmwareFeatures, VersionNumber, EARLIEST_ACCEPTABLE};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FirmwareVersion {
@@ -185,7 +169,7 @@ impl std::fmt::Display for FirmwareValidationError {
             FirmwareValidationError::UnknownSignedFirmware { digest } => {
                 write!(
                     f,
-                    "Unknown signed firmware with digest: {}. Signed firmware must be in KNOWN_FIRMWARE_VERSIONS",
+                    "Unknown signed firmware with digest: {}. Signed firmware must be a registered release",
                     digest
                 )
             }
@@ -288,85 +272,3 @@ impl ValidatedFirmwareBin {
         self.firmware_version.version
     }
 }
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct VersionNumber {
-    pub major: u8,
-    pub minor: u8,
-    pub patch: u8,
-}
-
-impl std::fmt::Display for VersionNumber {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
-    }
-}
-
-impl VersionNumber {
-    pub const fn new(major: u8, minor: u8, patch: u8) -> Self {
-        Self {
-            major,
-            minor,
-            patch,
-        }
-    }
-
-    pub fn from_digest(digest: &Sha256Digest) -> Option<Self> {
-        KNOWN_FIRMWARE_VERSIONS
-            .iter()
-            .find(|(d, _)| d == digest)
-            .map(|(_, v)| *v)
-    }
-
-    pub fn features(&self) -> FirmwareFeatures {
-        const V0_0_1: VersionNumber = VersionNumber::new(0, 0, 1);
-        const V0_3_0: VersionNumber = VersionNumber::new(0, 3, 0);
-
-        FirmwareFeatures {
-            upgrade_digest_no_sig: *self > V0_0_1,
-            check_backup: *self >= V0_3_0,
-        }
-    }
-}
-
-// Known firmware versions indexed by their digest
-//
-// NOTE: v0.0.1 has both signed and unsigned entries because we didn't have a proper
-// digest-to-version system yet. Devices announced their full digest (including signature),
-// so signed and unsigned builds had different digests. Starting with future versions, we
-// should only track the firmware-only (deterministic) digest.
-use frostsnap_macros::hex;
-pub const KNOWN_FIRMWARE_VERSIONS: &[(Sha256Digest, VersionNumber)] = &[
-    (
-        Sha256Digest(hex!(
-            "6273dc08ca7c805fa70ac8feeb98c62f7b6fcb337fb1cd8412f24f0d6dda51f7"
-        )),
-        VersionNumber::new(0, 3, 0),
-    ),
-    (
-        Sha256Digest(hex!(
-            "e432d313c7698b1e8843b10ba95efa8c28e66a5723b966c56c156687d09d16e0"
-        )),
-        VersionNumber::new(0, 2, 0),
-    ),
-    (
-        Sha256Digest(hex!(
-            "5ff7bd280b96d645b2c739a6b91bfc6c27197e213302770f1a7180678ca4f720"
-        )),
-        VersionNumber::new(0, 1, 0),
-    ),
-    /*signed*/
-    (
-        Sha256Digest(hex!(
-            "57161f80b41413b1053e272f9c3da8d16ecfce44793345be69f7fe03d93f4eb0"
-        )),
-        VersionNumber::new(0, 0, 1),
-    ),
-    /*unsigned*/
-    (
-        Sha256Digest(hex!(
-            "8f45ae6b72c241a20798acbd3c6d3e54071cae73e335df1785f2d485a915da4c"
-        )),
-        VersionNumber::new(0, 0, 1),
-    ),
-];

--- a/frostsnap_factory/src/cli.rs
+++ b/frostsnap_factory/src/cli.rs
@@ -61,7 +61,7 @@ pub enum Commands {
         /// Path to signed binary
         #[arg(short, long)]
         input: PathBuf,
-        /// Require the firmware digest to be in KNOWN_FIRMWARE_VERSIONS. Use in release CI
+        /// Require the firmware digest to be a registered release. Use in release CI
         /// to block shipping a release whose firmware version hasn't been registered.
         #[arg(long)]
         require_known_version: bool,

--- a/frostsnap_factory/src/main.rs
+++ b/frostsnap_factory/src/main.rs
@@ -387,7 +387,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 };
                 return Err(format!(
                     "firmware is not a known release ({what}); \
-                     add an entry to frostsnap_coordinator/src/firmware.rs before releasing"
+                     add it to frostsnap_comms/src/firmware_version.rs \
+                     before releasing"
                 )
                 .into());
             }

--- a/frostsnap_widgets/src/demo_widget.rs
+++ b/frostsnap_widgets/src/demo_widget.rs
@@ -583,6 +583,74 @@ macro_rules! demo_widget {
                 let widget = FirmwareUpgradeProgress::passive();
                 $run_macro!(widget);
             }
+            "firmware_upgrade_rejected" => {
+                use $crate::firmware_upgrade::FirmwareUpgradeProgress;
+                use embedded_graphics::prelude::*;
+
+                // Cycles through the refusal reasons the device can show
+                // (mirrors refuse_reason_text in device/src/frosty_ui.rs).
+                const REASONS: [&str; 4] = [
+                    "Downgrade blocked",
+                    "Firmware invalid",
+                    "Download corrupted",
+                    "Signature invalid",
+                ];
+
+                struct RejectedDemo {
+                    widget: FirmwareUpgradeProgress,
+                    size: Size,
+                    last_switch_time: Option<Instant>,
+                    reason_index: usize,
+                }
+
+                impl $crate::DynWidget for RejectedDemo {
+                    fn set_constraints(&mut self, max_size: Size) {
+                        self.size = max_size;
+                        self.widget.set_constraints(max_size);
+                    }
+                    fn sizing(&self) -> $crate::Sizing {
+                        self.widget.sizing()
+                    }
+                    fn force_full_redraw(&mut self) {
+                        self.widget.force_full_redraw();
+                    }
+                }
+
+                impl $crate::Widget for RejectedDemo {
+                    type Color = Rgb565;
+                    fn draw<D>(
+                        &mut self,
+                        target: &mut SuperDrawTarget<D, Self::Color>,
+                        current_time: Instant,
+                    ) -> Result<(), D::Error>
+                    where
+                        D: DrawTarget<Color = Self::Color>,
+                    {
+                        if self.last_switch_time.is_none() {
+                            self.last_switch_time = Some(current_time);
+                        }
+                        let elapsed = current_time
+                            .saturating_duration_since(self.last_switch_time.unwrap());
+                        if elapsed >= 2000 {
+                            self.reason_index = (self.reason_index + 1) % REASONS.len();
+                            self.widget =
+                                FirmwareUpgradeProgress::rejected(REASONS[self.reason_index]);
+                            self.widget.set_constraints(self.size);
+                            target.clear(PALETTE.background)?;
+                            self.last_switch_time = Some(current_time);
+                        }
+                        self.widget.draw(target, current_time)
+                    }
+                }
+
+                let widget = RejectedDemo {
+                    widget: FirmwareUpgradeProgress::rejected(REASONS[0]),
+                    size: Size::zero(),
+                    last_switch_time: None,
+                    reason_index: 0,
+                };
+                $run_macro!(widget);
+            }
             "progress" => {
                 use $crate::{ProgressIndicator, Widget, Instant};
                 use embedded_graphics::prelude::*;

--- a/frostsnap_widgets/src/firmware_upgrade.rs
+++ b/frostsnap_widgets/src/firmware_upgrade.rs
@@ -1,11 +1,15 @@
 use crate::HOLD_TO_CONFIRM_TIME_SHORT_MS;
 use crate::{
-    gray4_style::Gray4TextStyle, palette::PALETTE, prelude::*, HoldToConfirm, Padding,
-    ProgressIndicator,
+    gray4_style::Gray4TextStyle, palette::PALETTE, prelude::*, GrayToAlpha, HoldToConfirm, Image,
+    Padding, ProgressIndicator,
 };
 use alloc::{boxed::Box, format, string::String, string::ToString};
 use embedded_graphics::geometry::Size;
+use embedded_graphics::pixelcolor::{Gray8, Rgb565};
 use frostsnap_fonts::{NOTO_SANS_17_REGULAR, NOTO_SANS_18_MEDIUM, NOTO_SANS_MONO_17_REGULAR};
+use tinybmp::Bmp;
+
+const WARNING_ICON_DATA: &[u8] = include_bytes!("../assets/warning-icon-24x24.bmp");
 
 #[derive(frostsnap_macros::Widget)]
 pub struct FirmwareUpgradeConfirm {
@@ -132,6 +136,21 @@ pub enum FirmwareUpgradeProgress {
     Passive {
         widget: Box<Center<Padding<Column<(Text<Gray4TextStyle>, Text<Gray4TextStyle>)>>>>,
     },
+    /// Upgrade was refused - warning icon, title, reason, recovery instruction
+    Rejected {
+        widget: Box<
+            Center<
+                Padding<
+                    Column<(
+                        Image<GrayToAlpha<Bmp<'static, Gray8>, Rgb565>>,
+                        Text<Gray4TextStyle>,
+                        Text<Gray4TextStyle>,
+                        Text<Gray4TextStyle>,
+                    )>,
+                >,
+            >,
+        >,
+    },
 }
 
 impl FirmwareUpgradeProgress {
@@ -188,6 +207,48 @@ impl FirmwareUpgradeProgress {
         let widget = Center::new(padded);
 
         Self::Passive {
+            widget: Box::new(widget),
+        }
+    }
+
+    /// A refusal must read as a failure, not a neutral status: warning icon and
+    /// red title, with the reason in primary text so it carries the information.
+    /// The device parks on this screen, so it also says how to recover.
+    pub fn rejected(status: &str) -> Self {
+        let warning_bmp =
+            Bmp::<Gray8>::from_slice(WARNING_ICON_DATA).expect("Failed to load warning icon BMP");
+        let icon = Image::new(GrayToAlpha::new(warning_bmp, PALETTE.error));
+
+        let title = Text::new(
+            "Upgrade failed".to_string(),
+            Gray4TextStyle::new(&NOTO_SANS_18_MEDIUM, PALETTE.error),
+        );
+
+        let status = Text::new(
+            status.to_string(),
+            Gray4TextStyle::new(&NOTO_SANS_17_REGULAR, PALETTE.on_background),
+        );
+
+        let instruction = Text::new(
+            "Unplug to try again".to_string(),
+            Gray4TextStyle::new(&NOTO_SANS_17_REGULAR, PALETTE.text_secondary),
+        );
+
+        let column = Column::builder()
+            .push(icon)
+            .gap(12)
+            .push(title)
+            .gap(6)
+            .push(status)
+            .gap(16)
+            .push(instruction)
+            .with_main_axis_alignment(MainAxisAlignment::Center)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+        let padded = Padding::symmetric(20, 20, column);
+        let widget = Center::new(padded);
+
+        Self::Rejected {
             widget: Box::new(widget),
         }
     }

--- a/frostsnap_widgets/src/firmware_upgrade.rs
+++ b/frostsnap_widgets/src/firmware_upgrade.rs
@@ -1,11 +1,15 @@
 use crate::HOLD_TO_CONFIRM_TIME_SHORT_MS;
 use crate::{
-    gray4_style::Gray4TextStyle, palette::PALETTE, prelude::*, HoldToConfirm, Padding,
-    ProgressIndicator,
+    gray4_style::Gray4TextStyle, palette::PALETTE, prelude::*, GrayToAlpha, HoldToConfirm, Image,
+    Padding, ProgressIndicator,
 };
 use alloc::{boxed::Box, format, string::String, string::ToString};
 use embedded_graphics::geometry::Size;
+use embedded_graphics::pixelcolor::{Gray8, Rgb565};
 use frostsnap_fonts::{NOTO_SANS_17_REGULAR, NOTO_SANS_18_MEDIUM, NOTO_SANS_MONO_17_REGULAR};
+use tinybmp::Bmp;
+
+const WARNING_ICON_DATA: &[u8] = include_bytes!("../assets/warning-icon-24x24.bmp");
 
 #[derive(frostsnap_macros::Widget)]
 pub struct FirmwareUpgradeConfirm {
@@ -132,6 +136,21 @@ pub enum FirmwareUpgradeProgress {
     Passive {
         widget: Box<Center<Padding<Column<(Text<Gray4TextStyle>, Text<Gray4TextStyle>)>>>>,
     },
+    /// Upgrade was refused - warning icon, title, reason, recovery instruction
+    Rejected {
+        widget: Box<
+            Center<
+                Padding<
+                    Column<(
+                        Image<GrayToAlpha<Bmp<'static, Gray8>, Rgb565>>,
+                        Text<Gray4TextStyle>,
+                        Text<Gray4TextStyle>,
+                        Text<Gray4TextStyle>,
+                    )>,
+                >,
+            >,
+        >,
+    },
 }
 
 impl FirmwareUpgradeProgress {
@@ -188,6 +207,44 @@ impl FirmwareUpgradeProgress {
         let widget = Center::new(padded);
 
         Self::Passive {
+            widget: Box::new(widget),
+        }
+    }
+
+    /// A refusal must read as a failure, not a neutral status: warning icon and
+    /// red title, with the reason in primary text so it carries the information.
+    /// The device parks on this screen, so it also says how to recover.
+    pub fn rejected(status: &str) -> Self {
+        let warning_bmp =
+            Bmp::<Gray8>::from_slice(WARNING_ICON_DATA).expect("Failed to load warning icon BMP");
+        let icon = Image::new(GrayToAlpha::new(warning_bmp, PALETTE.error));
+
+        let title = Text::new(
+            "Upgrade failed".to_string(),
+            Gray4TextStyle::new(&NOTO_SANS_18_MEDIUM, PALETTE.error),
+        );
+
+        let status = Text::new(
+            status.to_string(),
+            Gray4TextStyle::new(&NOTO_SANS_17_REGULAR, PALETTE.on_background),
+        );
+
+        let instruction = Text::new(
+            "Unplug to try again".to_string(),
+            Gray4TextStyle::new(&NOTO_SANS_17_REGULAR, PALETTE.text_secondary),
+        );
+
+        let mut column = Column::new((icon, title, status, instruction))
+            .with_main_axis_alignment(MainAxisAlignment::Center)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center);
+        column.set_gap(0, 12);
+        column.set_gap(1, 6);
+        column.set_gap(2, 16);
+
+        let padded = Padding::symmetric(20, 20, column);
+        let widget = Center::new(padded);
+
+        Self::Rejected {
             widget: Box::new(widget),
         }
     }


### PR DESCRIPTION
A malicious or modified coordinator can skip the app's `check_upgrade_eligibility`, so downgrade protection is enforced where the image is actually accepted: **on the device**, just before `switch_partition` commits the newly written slot.

## Device enforcement

All four image-driven post-download checks — the image parses, the written digest matches the announced one, the Secure Boot v2 signature verifies (when enabled), and the firmware-only digest is not a superseded release — fold into one decision (`decide_upgrade` in `device/src/ota.rs`) returning `Commit` or `Refuse(reason)` with fixed precedence. Every refusal takes the same path: active slot unchanged, and the device parks on the error screen (warning icon + "Upgrade failed" + reason + "Unplug to try again") until power cycle — the running firmware boots again on replug. Resuming the normal loop instead would leave the coordinator and chain mid-way through an upgrade conversation that never concludes. This replaced three prior `panic!` paths (parse unwrap, digest mismatch, secure boot), whose handler loops forever. `decide_upgrade` drives the flash/SHA/RSA peripherals directly, so it has no host tests — it is compile-verified for both boards; the version data under it is unit-tested in `frostsnap_comms` (superseded-set bounds, v0.0.1's dual digest conventions) and anchored against the real v0.0.1 release binary in the coordinator's existing test.

## Release table

`frostsnap_comms::firmware_version` is the one shared module: `VersionNumber`, `EARLIEST_ACCEPTABLE` (0.4.0 — devices built from this tree refuse anything older, i.e. all previous firmware), and two private digest tables (body digests per release, plus v0.0.1's one-off full-image digest — that era announced it) reached only through accessors that name the convention they mean: `versions_before(v)` (superseded set, body digests) and the `VersionNumber::from_digest` constructor (either convention). Business logic stays in the consuming crates: the device's downgrade gate is a one-line filter over `versions_before` in `ota.rs`; the coordinator keeps using `VersionNumber::from_digest` as before, now backed by the shared list.

A release's digest is appended to the shared list when it should become active — after its artifact is built and signed, since an image can never contain its own digest and doesn't need to. Release CI keeps `--require-known-version` as the check that registration happened.

## Blocked digests

Firmware-only digests, reproduced from the verified PROD-signed release artifacts and pinned by tests against the real v0.0.1 binary:

| version | body digest |
|---|---|
| v0.0.1 | `8f45ae6b72c241a20798acbd3c6d3e54071cae73e335df1785f2d485a915da4c` |
| v0.1.0 | `5ff7bd280b96d645b2c739a6b91bfc6c27197e213302770f1a7180678ca4f720` |
| v0.2.0 | `e432d313c7698b1e8843b10ba95efa8c28e66a5723b966c56c156687d09d16e0` |
| v0.3.0 | `6273dc08ca7c805fa70ac8feeb98c62f7b6fcb337fb1cd8412f24f0d6dda51f7` |

v0.0.1's known full-image digest (`57161f80…`) resolves to its version for lookups but can never appear in the blockable set — by construction and by test.

## Release ritual

Cutting vN: bump `EARLIEST_ACCEPTABLE`, build + sign the artifact, then append its digest to the shared list when it should become active. Interim by design until versions are embedded in firmware binaries.

## Measurements

- Net flash cost of the whole device-side feature on `frontier`: **+2254 bytes** (the removed panic strings largely pay for the decision logic + per-reason refusal screen).
