### PR TITLE
Add security check explainer text and Learn More dialog

### DIFF
--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -284,6 +284,7 @@ class WalletCreateController extends ChangeNotifier {
         return BackdropFilter(
           filter: blurFilter,
           child: AlertDialog(
+            scrollable: true,
             title: const Text('Security check'),
             content: DefaultTextStyle(
               style: theme.textTheme.bodyMedium!.copyWith(

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -201,11 +201,17 @@ class WalletCreateController extends ChangeNotifier {
                 ),
               ),
               Text(
-                'The security check code confirms that all devices have behaved honestly during key generation.',
+                'This check guarantees every device (including this phone) '
+                'has contributed randomness and acted honestly during key '
+                'generation.',
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
+              ),
+              TextButton(
+                onPressed: () => _showSecurityCheckInfo(context),
+                child: const Text('Learn more'),
               ),
             ],
           );
@@ -264,6 +270,45 @@ class WalletCreateController extends ChangeNotifier {
 
   void _onCancel() async {
     await coord.cancelProtocol();
+  }
+
+  /// Shows an in-app explainer for the security check. Deliberately an
+  /// in-app dialog rather than an external link (url_launcher): this screen is
+  /// shown while the user is actively comparing a code across devices, and
+  /// navigating away mid-comparison is a bad UX and a security risk.
+  void _showSecurityCheckInfo(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        final theme = Theme.of(dialogContext);
+        return BackdropFilter(
+          filter: blurFilter,
+          child: AlertDialog(
+            title: const Text('Security check'),
+            content: DefaultTextStyle(
+              style: theme.textTheme.bodyMedium!.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              child: const Text(
+                'Every device contributing to this wallet generates its own '
+                'random data during key generation. The security check '
+                'displays a short code derived from that combined randomness.\n\n'
+                'If the code is identical on every device, it confirms every '
+                'device (including this phone) contributed randomness and no '
+                'device behaved dishonestly or was swapped during setup.\n\n'
+                'If the codes differ, cancel and try again.',
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(),
+                child: const Text('Got it'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   Future<void> resetDeviceNames(Iterable<ConnectedDevice> devices) async {

--- a/frostsnapp/lib/wallet_create.dart
+++ b/frostsnapp/lib/wallet_create.dart
@@ -200,11 +200,17 @@ class WalletCreateController extends ChangeNotifier {
                 ),
               ),
               Text(
-                'The security check code confirms that all devices have behaved honestly during key generation.',
+                'This check guarantees every device (including this phone) '
+                'has contributed randomness and acted honestly during key '
+                'generation.',
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
+              ),
+              TextButton(
+                onPressed: () => _showSecurityCheckInfo(context),
+                child: const Text('Learn more'),
               ),
             ],
           );
@@ -263,6 +269,45 @@ class WalletCreateController extends ChangeNotifier {
 
   void _onCancel() async {
     await coord.cancelProtocol();
+  }
+
+  /// Shows an in-app explainer for the security check. Deliberately an
+  /// in-app dialog rather than an external link (url_launcher): this screen is
+  /// shown while the user is actively comparing a code across devices, and
+  /// navigating away mid-comparison is a bad UX and a security risk.
+  void _showSecurityCheckInfo(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        final theme = Theme.of(dialogContext);
+        return BackdropFilter(
+          filter: blurFilter,
+          child: AlertDialog(
+            title: const Text('Security check'),
+            content: DefaultTextStyle(
+              style: theme.textTheme.bodyMedium!.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              child: const Text(
+                'Every device contributing to this wallet generates its own '
+                'random data during key generation. The security check '
+                'displays a short code derived from that combined randomness.\n\n'
+                'If the code is identical on every device, it confirms every '
+                'device (including this phone) contributed randomness and no '
+                'device behaved dishonestly or was swapped during setup.\n\n'
+                'If the codes differ, cancel and try again.',
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(),
+                child: const Text('Got it'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   Future<void> resetDeviceNames(Iterable<ConnectedDevice> devices) async {


### PR DESCRIPTION
fixes #352

updates the existing explainer text on the security check step to match the wording proposed in the issue... and adds a "learn more" button that opens a small in-app dialog with more detail.

deliberately kept in-app rather than linking out (url_launcher)... per @LLFourn's feedback on the issue, this screen is shown while the user is actively comparing a security code across devices, and navigating away mid-comparison is a ux risk. the new dialog reuses the same backdropfilter + alertdialog pattern already used elsewhere in this file (the 1-of-n wallet warning i believe)... for visual consistency.

i wasn't able to visually test the rendered dialog... reaching this screen requires the full keygen flow with connected physical devices..happy to do a follow-up visual check if that's useful before merging, or if either of you can eyeball it against a real device that'd be very much appreciated.