### PR TITLE
Draw the progress bar with our AA rounded rect so it can erase itself

### DIFF
--- a/frostsnap_widgets/src/progress.rs
+++ b/frostsnap_widgets/src/progress.rs
@@ -1,3 +1,4 @@
+use crate::aa::rounded_rect::AARoundedRectangle;
 use crate::super_draw_target::SuperDrawTarget;
 use crate::DefaultTextStyle;
 use crate::{palette::PALETTE, Column, Frac, Switcher, Text as TextWidget, Widget, FONT_SMALL};
@@ -6,7 +7,7 @@ use embedded_graphics::{
     draw_target::DrawTarget,
     geometry::{Point, Size},
     pixelcolor::Rgb565,
-    primitives::{Primitive, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle, RoundedRectangle},
+    primitives::Rectangle,
     text::Alignment,
     Drawable,
 };
@@ -21,10 +22,6 @@ pub struct ProgressBar {
     corner_radius: u32,
     /// Padding from edges
     bar_rect: Option<Rectangle>,
-    /// Last drawn filled width to track changes
-    last_filled_width: Option<u32>,
-    /// Whether background has been drawn
-    background_drawn: bool,
 }
 
 impl ProgressBar {
@@ -35,8 +32,6 @@ impl ProgressBar {
             bar_height: 20,
             corner_radius: 10,
             bar_rect: None,
-            last_filled_width: None,
-            background_drawn: false,
         }
     }
 
@@ -47,8 +42,6 @@ impl ProgressBar {
             bar_height,
             corner_radius,
             bar_rect: None,
-            last_filled_width: None,
-            background_drawn: false,
         }
     }
 
@@ -82,15 +75,6 @@ impl crate::DynWidget for ProgressBar {
             Point::new(0, 0),
             Size::new(max_size.width, self.bar_height),
         ));
-
-        // Reset drawing state when constraints change
-        self.background_drawn = false;
-        self.last_filled_width = None;
-    }
-
-    fn force_full_redraw(&mut self) {
-        self.background_drawn = false;
-        self.last_filled_width = None;
     }
 }
 
@@ -106,61 +90,30 @@ impl Widget for ProgressBar {
             .bar_rect
             .expect("ProgressBar::draw called before set_constraints");
 
-        // Draw the background/border only if not already drawn
-        if !self.background_drawn {
-            let background_rect = RoundedRectangle::with_equal_corners(
-                bar_rect,
-                Size::new(self.corner_radius, self.corner_radius),
-            );
+        // Our AA rounded rect writes every pixel of its bounding rect (corners
+        // are blended against the backdrop), so redrawing it covers everything
+        // it previously lit — unlike embedded-graphics' RoundedRectangle, whose
+        // silently confined radius at small widths orphans corner pixels.
+        let background_color = target.background_color();
 
-            let background_style = PrimitiveStyleBuilder::new()
-                .stroke_color(PALETTE.outline)
-                .stroke_width(2)
-                .build();
-
-            background_rect.into_styled(background_style).draw(target)?;
-        }
+        AARoundedRectangle::new(bar_rect, background_color)
+            .with_corner_radius(self.corner_radius)
+            .with_border(PALETTE.outline, 2)
+            .draw(target)?;
 
         // Calculate the filled width based on progress
         let filled_width = (self.progress * bar_rect.size.width).round().max(1);
 
-        // Only redraw if the filled width has changed
-        if self.last_filled_width != Some(filled_width) {
-            // Clear the inside of the bar first (in case progress decreased)
-            if let Some(last_width) = self.last_filled_width {
-                if filled_width < last_width {
-                    // Clear the area that was previously filled
-                    let clear_rect = Rectangle::new(
-                        Point::new(
-                            bar_rect.top_left.x + 2 + filled_width as i32,
-                            bar_rect.top_left.y + 2,
-                        ),
-                        Size::new(last_width - filled_width, self.bar_height - 4),
-                    );
-                    let clear_style = PrimitiveStyle::with_fill(PALETTE.background);
-                    clear_rect.into_styled(clear_style).draw(target)?;
-                }
-            }
+        if self.progress > Frac::ZERO && filled_width > 4 {
+            let fill_rect = Rectangle::new(
+                Point::new(bar_rect.top_left.x + 2, bar_rect.top_left.y + 2),
+                Size::new(filled_width.saturating_sub(4), self.bar_height - 4),
+            );
 
-            // Draw the filled progress rectangle (if there's any progress)
-            if self.progress > Frac::ZERO && filled_width > 2 {
-                // Account for the border width
-                let fill_rect = RoundedRectangle::with_equal_corners(
-                    Rectangle::new(
-                        Point::new(bar_rect.top_left.x + 2, bar_rect.top_left.y + 2),
-                        Size::new(filled_width.saturating_sub(4), self.bar_height - 4),
-                    ),
-                    Size::new(
-                        self.corner_radius.saturating_sub(2),
-                        self.corner_radius.saturating_sub(2),
-                    ),
-                );
-
-                let fill_style = PrimitiveStyle::with_fill(PALETTE.primary);
-                fill_rect.into_styled(fill_style).draw(target)?;
-            }
-
-            self.last_filled_width = Some(filled_width);
+            AARoundedRectangle::new(fill_rect, background_color)
+                .with_corner_radius(self.corner_radius.saturating_sub(2))
+                .with_fill(PALETTE.primary)
+                .draw(target)?;
         }
 
         Ok(())


### PR DESCRIPTION
The progress bar could leave pixels on screen that **nothing was ever able to repaint**, so they survived a fade-out and persisted after switching to another screen. Visible as a small crescent at the bar's left end.

## Cause

The fill was an embedded-graphics `RoundedRectangle` whose **width was the progress**. That library confines corner radii to the rectangle size at draw time (`RoundedRectangle::get_confined_corner_quadrant` → `corners.confine(size)`). So:

- at low progress the cap is rasterised nearly **square** and lights the corner pixels;
- once the bar is wide enough for the full radius, the cap is properly **round**, and those corner pixels are no longer part of the bar's appearance at all.

Growing the input stopped growing the coverage — `rounded_rect(w=6, r=8)` is not a subset of `rounded_rect(w=200, r=8)`. Those pixels are outside the widget's current appearance, so a faithful redraw correctly doesn't paint them and *cannot* erase them. `force_full_redraw` can't help: you can't repaint a shape that no longer exists.

## Fix

Use our own `AARoundedRectangle`. It blends its curve against the backdrop, so it writes **every pixel of its bounding rect** — coverage is the plain rectangle, not the curve. The fill's bounding rect grows monotonically with progress, so every earlier state is a strict subset of every later one and a redraw always covers everything previously lit. Radius confinement still happens; it just no longer matters.

## Notes

- **Colours unchanged**: `PALETTE.outline` border, `PALETTE.primary` fill. Edges are now anti-aliased (`target.background_color()` is only the backdrop the AA edges blend against).
- Removed the change-tracking state. `background_drawn` was **never set to `true`**, so the "draw the border once" gate it implied never actually existed; `last_filled_width` gated the fill. The widget now just redraws, which is what makes it self-erasing.
- **Tradeoff**: that's a bar-sized repaint per frame instead of a delta. If it shows up on hardware, the right follow-up is a genuine full-redraw-vs-incremental split, not resurrecting the broken flags.
- The removed decrease-in-progress clear branch is no longer needed for the OTA path (monotonic), and a shrink now simply redraws the smaller bar.

## Verification

Reproduced and confirmed fixed both in the widget simulator (switching a download screen out to an empty box, so nothing paints over the residue) and flashed to an esp32c3. Bar renders correctly through a full 0→100% ramp; the leftover crescent is gone.
