### PR TITLE
[coordinator] Log nUSB read errors instead of discarding them

### DIFF
--- a/frostsnap_coordinator/src/cdc_acm_usb.rs
+++ b/frostsnap_coordinator/src/cdc_acm_usb.rs
@@ -186,6 +186,7 @@ impl io::Read for CdcAcmSerial {
 mod _impl {
 
     use crate::serialport::*;
+    use tracing::{event, Level};
 
     #[allow(unused)]
     impl SerialPort for super::CdcAcmSerial {
@@ -210,7 +211,11 @@ mod _impl {
 
             match pin_reader.poll_fill_buf(&mut cx) {
                 Poll::Ready(Ok(buf)) => Ok(buf.len() as u32),
-                Poll::Ready(Err(_)) => Ok(0),
+                // Still Ok(0): returning Err would make any benign error here a disconnect.
+                Poll::Ready(Err(e)) => {
+                    event!(Level::ERROR, error = ?e, "nUSB read failed");
+                    Ok(0)
+                }
                 Poll::Pending => Ok(0), // No data available yet, don't block
             }
         }


### PR DESCRIPTION
`CdcAcmSerial::bytes_to_read` maps a read error to "no data available":

```rust
Poll::Ready(Err(_)) => Ok(0),
```

The error is destructured with `_` and dropped, and `mod _impl` contains no logging at all, so the
failure is not merely unhandled — it is unobservable.

## Why it matters

The layer above expects the opposite. `SerialPort::anything_to_read` returns `true` on `Err`
specifically so the caller reads and surfaces it:

```rust
// just say there's something there to get the caller to read and get the error rather than
// returning it here
Err(_) => true,
```

From there `try_read_message` returns `Err` and `poll_ports` disconnects the port. **Because
`CdcAcmSerial` never returns `Err`, that entire path is unreachable on mobile** — and
`try_read_message` short-circuits at `!anything_to_read() && buffer.is_empty()`, so `read()` is never
called and the error cannot surface anywhere else either.

`DesktopSerial` uses the `serialport` crate's `bytes_to_read`, which does propagate `Err`. So the same
interface behaves differently on the two platforms: desktop disconnects correctly, mobile cannot.

## Why only a log

Returning `Err` here would turn any benign or recoverable error on this path into a device disconnect
— which may well be why it was written this way. This change is therefore observation only, with no
behavioural change and no regression risk. What the field data says should decide whether the error is
then propagated.

Filed while looking at #537, where a phone sat on the backup screen indefinitely while the device was
untouched and still displaying. That is what this code path would look like if the endpoint failed —
but that is a hypothesis, and it is currently unfalsifiable precisely because nothing is logged. This
makes it testable either way.

## Verification

`cargo fmt -p frostsnap_coordinator -- --check` and `cargo clippy -p frostsnap_coordinator --release
--locked --all-features -- -Dwarnings`, both clean on the stable toolchain CI uses.
