### PR TITLE
Bound the derivation paths a sign task may present as ours

### DIFF
--- a/device/src/widget_tree.rs
+++ b/device/src/widget_tree.rs
@@ -212,7 +212,7 @@ impl WidgetTree {
         rand_seed: u32,
     ) -> Self {
         let address_display =
-            AddressWithIndex::new_with_seed(address, bip32_path.index as usize, rand_seed);
+            AddressWithIndex::new_with_seed(address, bip32_path.index.to_u32() as usize, rand_seed);
         Self::AddressDisplay(Box::new(Center::new(address_display)))
     }
 }

--- a/frost_backup/tests/descriptor_match.rs
+++ b/frost_backup/tests/descriptor_match.rs
@@ -4,7 +4,7 @@ use bitcoin::{Address, Network};
 use frost_backup::{generate_descriptor, generate_xpriv};
 use frostsnap_coordinator::bitcoin::{descriptor_for_account_keychain, wallet::KeychainId};
 use frostsnap_core::{
-    tweak::{AccountKind, BitcoinAccount, BitcoinAccountKeychain, Keychain},
+    tweak::{AccountKind, BitcoinAccount, BitcoinAccountKeychain, Keychain, NormalIndex},
     MasterAppkey,
 };
 use schnorr_fun::fun::prelude::*;
@@ -37,7 +37,7 @@ fn test_addresses_match() {
     // Create a bitcoin account (0 hardened)
     let account = BitcoinAccount {
         kind: AccountKind::Segwitv1,
-        index: 0,
+        index: NormalIndex::ZERO,
     };
 
     // Create keychain id for external chain (0)

--- a/frostsnap_coordinator/src/bitcoin.rs
+++ b/frostsnap_coordinator/src/bitcoin.rs
@@ -78,7 +78,7 @@ fn peek_spk(approot: MasterAppkey, path: BitcoinBip32Path) -> ScriptBuf {
         bitcoin::NetworkKind::Main,
     );
     descriptor
-        .at_derivation_index(path.index)
+        .at_derivation_index(path.index.to_u32())
         .expect("infallible")
         .script_pubkey()
 }
@@ -87,7 +87,9 @@ fn peek_spk(approot: MasterAppkey, path: BitcoinBip32Path) -> ScriptBuf {
 mod test {
     use bitcoin::Network;
     use core::str::FromStr;
-    use frostsnap_core::tweak::{AccountKind, AppTweak, BitcoinAccountKeychain, BitcoinBip32Path};
+    use frostsnap_core::tweak::{
+        AccountKind, AppTweak, BitcoinAccountKeychain, BitcoinBip32Path, NormalIndex,
+    };
 
     use super::*;
 
@@ -96,7 +98,7 @@ mod test {
         let master_appkey = MasterAppkey::from_str("0325b0d1cda060241998916f45d02e227db436bdd708a55cf1dc67f3f534e332186fd6543fbfc5dd07094e93543fa05120f12d3a80876aa011a4897b7a0770d1fb").unwrap();
         let account = BitcoinAccount {
             kind: AccountKind::Segwitv1,
-            index: 0,
+            index: NormalIndex::ZERO,
         };
 
         let internal_tweak = AppTweak::Bitcoin(BitcoinBip32Path {
@@ -104,14 +106,14 @@ mod test {
                 account,
                 keychain: Keychain::Internal,
             },
-            index: 84,
+            index: NormalIndex::new(84).unwrap(),
         });
         let external_tweak = AppTweak::Bitcoin(BitcoinBip32Path {
             account_keychain: BitcoinAccountKeychain {
                 account,
                 keychain: Keychain::External,
             },
-            index: 42,
+            index: NormalIndex::new(42).unwrap(),
         });
 
         let multi_x_descriptor =

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -4,7 +4,7 @@
 //! re-plan) as often as it likes — a fee display bound to a plan cannot move the wallet's
 //! keychain indices.
 
-use super::wallet::{CoordSuperWallet, KeychainId};
+use super::wallet::{revealed_index, CoordSuperWallet, KeychainId};
 use anyhow::{anyhow, Result};
 use bdk_chain::{
     bitcoin::{self, Amount, OutPoint, TxOut},
@@ -213,7 +213,7 @@ impl CoordSuperWallet {
                 (
                     BitcoinBip32Path {
                         account_keychain,
-                        index,
+                        index: revealed_index(index),
                     },
                     utxos[position].outpoint,
                 )
@@ -356,7 +356,7 @@ impl CoordSuperWallet {
                     master_appkey: plan.master_appkey,
                     bip32_path: BitcoinBip32Path {
                         account_keychain: BitcoinAccountKeychain::internal(),
-                        index,
+                        index: revealed_index(index),
                     },
                 },
             );
@@ -381,6 +381,7 @@ mod test {
         BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate,
     };
     use frostsnap_core::schnorr_fun::fun::Point;
+    use frostsnap_core::tweak::NormalIndex;
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
 
@@ -456,7 +457,7 @@ mod test {
                 self.master_appkey,
                 BitcoinBip32Path {
                     account_keychain,
-                    index,
+                    index: NormalIndex::new(index).expect("fixture index is a literal below 2^31"),
                 },
             );
             let tx = bitcoin::Transaction {
@@ -597,7 +598,7 @@ mod test {
         let template = f.wallet.commit_send(&plan, [0]).unwrap();
         let change_index = template
             .iter_locally_owned_outputs()
-            .map(|(_, _, spk)| spk.bip32_path.index)
+            .map(|(_, _, spk)| spk.bip32_path.index.to_u32())
             .next()
             .expect("send has a change output");
         assert_eq!(change_index, 1);

--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -11,7 +11,7 @@ use bdk_chain::{
 };
 use frostsnap_core::{
     bitcoin_transaction::{self, LocalSpk},
-    tweak::{AppTweakKind, BitcoinAccountKeychain, BitcoinBip32Path},
+    tweak::{AppTweakKind, BitcoinAccountKeychain, BitcoinBip32Path, NormalIndex},
     MasterAppkey,
 };
 use frostsnap_core::{
@@ -205,7 +205,7 @@ impl CoordSuperWallet {
                     master_appkey,
                     BitcoinBip32Path {
                         account_keychain: keychain,
-                        index: i,
+                        index: revealed_index(i),
                     },
                 )
             })
@@ -219,18 +219,19 @@ impl CoordSuperWallet {
             master_appkey,
             BitcoinBip32Path {
                 account_keychain: keychain,
-                index,
+                index: NormalIndex::new(index)?,
             },
         ))
     }
 
     fn address_info(&self, master_appkey: MasterAppkey, path: BitcoinBip32Path) -> AddressInfo {
         let keychain = (master_appkey, path.account_keychain);
-        let used = self.tx_graph.index.is_used(keychain, path.index);
-        let revealed = self.tx_graph.index.last_revealed_index(keychain) <= Some(path.index);
+        let used = self.tx_graph.index.is_used(keychain, path.index.to_u32());
+        let revealed =
+            self.tx_graph.index.last_revealed_index(keychain) <= Some(path.index.to_u32());
         let spk = super::peek_spk(master_appkey, path);
         AddressInfo {
-            index: path.index,
+            index: path.index.to_u32(),
             address: bitcoin::Address::from_script(&spk, self.network).expect("has address form"),
             external: true,
             used,
@@ -252,7 +253,7 @@ impl CoordSuperWallet {
             master_appkey,
             BitcoinBip32Path {
                 account_keychain: keychain,
-                index,
+                index: revealed_index(index),
             },
         )
     }
@@ -312,7 +313,7 @@ impl CoordSuperWallet {
                             master_appkey,
                             BitcoinBip32Path {
                                 account_keychain: keychain,
-                                index: i,
+                                index: NormalIndex::new(i)?,
                             },
                         ))
                     } else {
@@ -625,7 +626,7 @@ impl CoordSuperWallet {
                         master_appkey,
                         bip32_path: BitcoinBip32Path {
                             account_keychain,
-                            index,
+                            index: revealed_index(index),
                         },
                     },
                 ),
@@ -709,6 +710,11 @@ impl std::fmt::Display for PsbtValidationError {
 }
 impl std::error::Error for PsbtValidationError {}
 
+/// bdk stops revealing at `BIP32_MAX_INDEX`, so any index it hands back is a normal child.
+pub(super) fn revealed_index(index: u32) -> NormalIndex {
+    NormalIndex::new(index).expect("bdk never reveals past BIP32_MAX_INDEX")
+}
+
 #[derive(Clone, Debug)]
 pub struct AddressInfo {
     pub index: u32,
@@ -754,7 +760,7 @@ mod test {
         let (account_keychain, external_descriptor) = &descriptors[0];
         let xonly = AppTweak::Bitcoin(BitcoinBip32Path {
             account_keychain: *account_keychain,
-            index: 42,
+            index: NormalIndex::new(42).unwrap(),
         })
         .derive_xonly_key(&master_appkey.to_xpub());
 

--- a/frostsnap_coordinator/src/verify_address.rs
+++ b/frostsnap_coordinator/src/verify_address.rs
@@ -5,7 +5,8 @@ use std::{
 
 use frostsnap_comms::{CoordinatorSendBody, CoordinatorSendMessage, Destination};
 use frostsnap_core::{
-    coordinator::VerifyAddress, message::CoordinatorToDeviceMessage, DeviceId, MasterAppkey,
+    coordinator::VerifyAddress, message::CoordinatorToDeviceMessage, tweak::NormalIndex, DeviceId,
+    MasterAppkey,
 };
 
 use crate::{Completion, DeviceMode, Sink, UiProtocol};
@@ -19,7 +20,7 @@ pub struct VerifyAddressProtocolState {
 pub struct VerifyAddressProtocol {
     state: VerifyAddressProtocolState,
     master_appkey: MasterAppkey,
-    derivation_index: u32,
+    derivation_index: NormalIndex,
     is_complete: Option<Completion>,
     need_to_send_to: BTreeSet<DeviceId>,
     sink: Box<dyn Sink<VerifyAddressProtocolState>>,

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -1269,7 +1269,7 @@ impl FrostCoordinator {
     pub fn verify_address(
         &self,
         key_id: KeyId,
-        derivation_index: u32,
+        derivation_index: crate::tweak::NormalIndex,
     ) -> Result<VerifyAddress, ActionError> {
         let frost_key = self
             .get_frost_key(key_id)
@@ -2012,7 +2012,7 @@ impl IntoIterator for NonceReplenishRequest {
 #[derive(Debug, Clone)]
 pub struct VerifyAddress {
     pub master_appkey: MasterAppkey,
-    pub derivation_index: u32,
+    pub derivation_index: crate::tweak::NormalIndex,
     pub target_devices: BTreeSet<DeviceId>,
 }
 

--- a/frostsnap_core/src/device.rs
+++ b/frostsnap_core/src/device.rs
@@ -397,10 +397,7 @@ impl<S: NonceStreamSlot + core::fmt::Debug> FrostSigner<S> {
                     })?
                     .clone();
 
-                let bip32_path = tweak::BitcoinBip32Path {
-                    account_keychain: tweak::BitcoinAccountKeychain::external(),
-                    index: derivation_index,
-                };
+                let bip32_path = tweak::BitcoinBip32Path::external(derivation_index);
                 let spk = bitcoin_transaction::LocalSpk {
                     master_appkey,
                     bip32_path,

--- a/frostsnap_core/src/message/screen_verify.rs
+++ b/frostsnap_core/src/message/screen_verify.rs
@@ -1,4 +1,4 @@
-use crate::{Kind, MasterAppkey};
+use crate::{tweak::NormalIndex, Kind, MasterAppkey};
 use frostsnap_macros::Kind as KindDerive;
 
 /// Screen verification messages (for verifying addresses on device screens)
@@ -6,6 +6,6 @@ use frostsnap_macros::Kind as KindDerive;
 pub enum ScreenVerify {
     VerifyAddress {
         master_appkey: MasterAppkey,
-        derivation_index: u32,
+        derivation_index: NormalIndex,
     },
 }

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -1,12 +1,18 @@
 use crate::{
     bitcoin_transaction,
     device::KeyPurpose,
-    tweak::{AppTweak, BitcoinAccount, BitcoinAccountKeychain, Keychain},
+    tweak::{AppTweak, BitcoinAccount, BitcoinAccountKeychain, Keychain, NormalIndex},
     MasterAppkey,
 };
 use alloc::{boxed::Box, string::String, vec::Vec};
 use bitcoin::hashes::Hash;
 use schnorr_fun::{Message, Schnorr, Signature};
+
+/// TEMPORARY ceiling on the index of an output a sign task may claim as ours, bounding the space
+/// a coordinator can hide one in. A chosen number, not a property of the wallet: chain activity
+/// moves the revealed range too, so "past what ordinary use reaches" is not something this side
+/// can assert.
+const OUTPUT_INDEX_LIMIT: u32 = 200_000;
 
 #[derive(Debug, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Hash)]
 pub enum WireSignTask {
@@ -113,6 +119,37 @@ impl WireSignTask {
                     }
                 }
 
+                // TEMPORARY. A blunt narrowing of the paths a coordinator may present as ours,
+                // while the wallet's account and address-issuance model is still implicit. Not a
+                // considered final model.
+                //
+                // Outputs only. An input path is self-certifying: `Input::txout` builds the
+                // prevout from the claimed path's own spk, so the sighash commits to it and a
+                // forged path signs against a prevout that is not on chain. Policing inputs would
+                // buy nothing and would strand coins a PSBT legitimately imports.
+                //
+                // The known cost is that only this side is bounded: an honest coordinator that
+                // allocated change or revealed an address past the ceiling would have its own task
+                // refused here. Reaching that is implausible today, and closing it properly means
+                // one shared issuance boundary in the wallet, which is the cleanup.
+                for owner in tx_template
+                    .outputs()
+                    .iter()
+                    .filter_map(|output| output.owner().local_owner())
+                {
+                    let path = owner.bip32_path;
+
+                    if path.account_keychain.account != BitcoinAccount::default() {
+                        return Err(SignTaskError::UnwatchedAccount {
+                            account: path.account_keychain.account,
+                        });
+                    }
+
+                    if path.index.to_u32() >= OUTPUT_INDEX_LIMIT {
+                        return Err(SignTaskError::OutputIndexOutOfRange { index: path.index });
+                    }
+                }
+
                 if !tx_template.has_any_inputs_to_sign() {
                     return Err(SignTaskError::NothingToSign);
                 }
@@ -210,6 +247,12 @@ pub enum SignTaskError {
         expected: Box<MasterAppkey>,
         kind: &'static str,
     },
+    UnwatchedAccount {
+        account: BitcoinAccount,
+    },
+    OutputIndexOutOfRange {
+        index: NormalIndex,
+    },
     WrongPurpose,
     InvalidBitcoinTransaction,
     NothingToSign,
@@ -225,6 +268,14 @@ impl core::fmt::Display for SignTaskError {
             } => write!(
                 f,
                 "sign task was for key {expected} but got an {kind} for key {got}",
+            ),
+            SignTaskError::UnwatchedAccount { account } => write!(
+                f,
+                "sign task has an output in an account this wallet doesn't use: {account:?}",
+            ),
+            SignTaskError::OutputIndexOutOfRange { index } => write!(
+                f,
+                "sign task has an output at index {index}, past the limit of {OUTPUT_INDEX_LIMIT}",
             ),
             SignTaskError::InvalidBitcoinTransaction => {
                 write!(f, "Bitcoin transaction input value was less than outputs")
@@ -357,5 +408,67 @@ mod test {
             .check(signing, KeyPurpose::Bitcoin(Network::Bitcoin))
             .expect("a send to an external recipient must be accepted");
         assert_eq!(checked.master_appkey, signing);
+    }
+
+    /// One test for the whole temporary policy: it is three lines of check and will be replaced,
+    /// so it gets its boundaries pinned once rather than a case each.
+    #[test]
+    fn temporary_path_policy() {
+        let signing = signing_key();
+        let other_account = crate::tweak::BitcoinAccountKeychain {
+            account: BitcoinAccount {
+                index: NormalIndex::new(1).unwrap(),
+                ..Default::default()
+            },
+            keychain: crate::tweak::Keychain::External,
+        };
+        let limit = NormalIndex::new(OUTPUT_INDEX_LIMIT).unwrap();
+        let below_limit = NormalIndex::new(OUTPUT_INDEX_LIMIT - 1).unwrap();
+
+        let spend_to_self = |input: BitcoinBip32Path, output: BitcoinBip32Path| {
+            let mut tx = TransactionTemplate::new();
+            tx.push_imaginary_owned_input(
+                LocalSpk {
+                    master_appkey: signing,
+                    bip32_path: input,
+                },
+                Amount::from_sat(100_000),
+            );
+            tx.push_owned_output(
+                Amount::from_sat(90_000),
+                LocalSpk {
+                    master_appkey: signing,
+                    bip32_path: output,
+                },
+            );
+            WireSignTask::BitcoinTransaction(tx)
+                .check(signing, KeyPurpose::Bitcoin(Network::Bitcoin))
+        };
+        let external = BitcoinBip32Path::external;
+
+        assert!(
+            spend_to_self(external(NormalIndex::ZERO), external(below_limit)).is_ok(),
+            "the highest in-range output index must still be accepted"
+        );
+
+        assert!(matches!(
+            spend_to_self(external(NormalIndex::ZERO), external(limit)),
+            Err(SignTaskError::OutputIndexOutOfRange { index }) if index == limit
+        ));
+
+        let in_other_account = BitcoinBip32Path {
+            account_keychain: other_account,
+            index: NormalIndex::ZERO,
+        };
+
+        assert!(matches!(
+            spend_to_self(external(NormalIndex::ZERO), in_other_account),
+            Err(SignTaskError::UnwatchedAccount { .. })
+        ));
+
+        assert!(
+            spend_to_self(in_other_account, external(NormalIndex::ZERO)).is_ok(),
+            "an input is a coin we control whatever its path, so it must stay spendable"
+        );
     }
 }

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -66,7 +66,7 @@ impl WireSignTask {
                 .filter_map(move |(_, _, spk)| {
                     (spk.master_appkey == master_appkey
                         && spk.bip32_path.account_keychain == internal)
-                        .then_some(spk.bip32_path.index)
+                        .then_some(spk.bip32_path.index.to_u32())
                 })
         })
     }
@@ -249,7 +249,7 @@ impl std::error::Error for SignTaskError {}
 mod test {
     use super::*;
     use crate::bitcoin_transaction::{LocalSpk, TransactionTemplate};
-    use crate::tweak::BitcoinBip32Path;
+    use crate::tweak::{BitcoinBip32Path, NormalIndex};
     use bitcoin::{Amount, Network, ScriptBuf, TxOut};
     use schnorr_fun::fun::prelude::*;
 
@@ -273,7 +273,7 @@ mod test {
         tx_template.push_imaginary_owned_input(
             LocalSpk {
                 master_appkey: signing,
-                bip32_path: BitcoinBip32Path::external(0),
+                bip32_path: BitcoinBip32Path::external(NormalIndex::ZERO),
             },
             Amount::from_sat(100_000),
         );
@@ -281,7 +281,7 @@ mod test {
             Amount::from_sat(90_000),
             LocalSpk {
                 master_appkey: other,
-                bip32_path: BitcoinBip32Path::internal(0),
+                bip32_path: BitcoinBip32Path::internal(NormalIndex::ZERO),
             },
         );
 
@@ -312,7 +312,7 @@ mod test {
         tx_template.push_imaginary_owned_input(
             LocalSpk {
                 master_appkey: other,
-                bip32_path: BitcoinBip32Path::external(0),
+                bip32_path: BitcoinBip32Path::external(NormalIndex::ZERO),
             },
             Amount::from_sat(100_000),
         );
@@ -344,7 +344,7 @@ mod test {
         tx_template.push_imaginary_owned_input(
             LocalSpk {
                 master_appkey: signing,
-                bip32_path: BitcoinBip32Path::external(0),
+                bip32_path: BitcoinBip32Path::external(NormalIndex::ZERO),
             },
             Amount::from_sat(100_000),
         );

--- a/frostsnap_core/src/tweak.rs
+++ b/frostsnap_core/src/tweak.rs
@@ -160,18 +160,6 @@ impl BitcoinBip32Path {
     }
 }
 
-impl From<BitcoinBip32Path> for DerivationPath {
-    fn from(bip32_path: BitcoinBip32Path) -> Self {
-        DerivationPath::from_normal_path_segments(
-            bip32_path
-                .account_keychain
-                .account
-                .path_segments_from_bitcoin_appkey()
-                .chain(core::iter::once(bip32_path.index.to_u32())),
-        )
-    }
-}
-
 #[derive(
     Clone, Copy, Debug, PartialEq, bincode::Encode, bincode::Decode, Eq, Hash, PartialOrd, Ord,
 )]

--- a/frostsnap_core/src/tweak.rs
+++ b/frostsnap_core/src/tweak.rs
@@ -8,6 +8,106 @@ use schnorr_fun::{
     fun::{g, marker::*, Point, Scalar, G},
 };
 
+/// A BIP32 normal (non-hardened) child index.
+///
+/// Our own derivation hmacs any `u32` it is handed, but the descriptors the wallet builds spks
+/// from can only express normal children — so a hardened index names a path we can derive and
+/// never watch. Decoding enforces the range as well as construction, which keeps the guarantee
+/// with the type instead of with whoever remembers to check.
+///
+/// rust-bitcoin has no equivalent: `ChildNumber` is an enum spanning both halves, and its
+/// `From<u32>` maps the hardened half to `Hardened` rather than failing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+pub struct NormalIndex(u32);
+
+impl NormalIndex {
+    pub const ZERO: Self = NormalIndex(0);
+
+    pub fn new(index: u32) -> Option<Self> {
+        ChildNumber::from_normal_idx(index).ok()?;
+        Some(NormalIndex(index))
+    }
+
+    pub fn to_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<NormalIndex> for ChildNumber {
+    fn from(index: NormalIndex) -> Self {
+        ChildNumber::Normal { index: index.0 }
+    }
+}
+
+impl From<NormalIndex> for u32 {
+    fn from(index: NormalIndex) -> Self {
+        index.0
+    }
+}
+
+impl TryFrom<u32> for NormalIndex {
+    type Error = HardenedIndexError;
+
+    fn try_from(index: u32) -> Result<Self, Self::Error> {
+        NormalIndex::new(index).ok_or(HardenedIndexError { index })
+    }
+}
+
+impl core::fmt::Display for NormalIndex {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HardenedIndexError {
+    pub index: u32,
+}
+
+impl core::fmt::Display for HardenedIndexError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "bip32 index {} is hardened; only normal children can be derived here",
+            self.index
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for HardenedIndexError {}
+
+impl bincode::Encode for NormalIndex {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        self.0.encode(encoder)
+    }
+}
+
+impl<Context> bincode::Decode<Context> for NormalIndex {
+    fn decode<D: bincode::de::Decoder>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let index = u32::decode(decoder)?;
+        NormalIndex::new(index).ok_or(bincode::error::DecodeError::Other(
+            "bip32 index is hardened",
+        ))
+    }
+}
+
+impl<'de, Context> bincode::BorrowDecode<'de, Context> for NormalIndex {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let index = u32::borrow_decode(decoder)?;
+        NormalIndex::new(index).ok_or(bincode::error::DecodeError::Other(
+            "bip32 index is hardened",
+        ))
+    }
+}
+
 #[derive(
     Clone, Copy, Debug, PartialEq, bincode::Encode, bincode::Decode, Eq, Hash, PartialOrd, Ord,
 )]
@@ -41,18 +141,18 @@ pub enum AppTweak {
 )]
 pub struct BitcoinBip32Path {
     pub account_keychain: BitcoinAccountKeychain,
-    pub index: u32,
+    pub index: NormalIndex,
 }
 
 impl BitcoinBip32Path {
-    pub fn external(index: u32) -> Self {
+    pub fn external(index: NormalIndex) -> Self {
         Self {
             account_keychain: BitcoinAccountKeychain::external(),
             index,
         }
     }
 
-    pub fn internal(index: u32) -> Self {
+    pub fn internal(index: NormalIndex) -> Self {
         Self {
             account_keychain: BitcoinAccountKeychain::internal(),
             index,
@@ -67,7 +167,7 @@ impl From<BitcoinBip32Path> for DerivationPath {
                 .account_keychain
                 .account
                 .path_segments_from_bitcoin_appkey()
-                .chain(core::iter::once(bip32_path.index)),
+                .chain(core::iter::once(bip32_path.index.to_u32())),
         )
     }
 }
@@ -77,14 +177,14 @@ impl From<BitcoinBip32Path> for DerivationPath {
 )]
 pub struct BitcoinAccount {
     pub kind: AccountKind,
-    pub index: u32,
+    pub index: NormalIndex,
 }
 
 impl BitcoinAccount {
     pub fn path_segments_from_bitcoin_appkey(&self) -> impl Iterator<Item = u32> {
         self.kind
             .path_segments_from_bitcoin_appkey()
-            .chain(core::iter::once(self.index))
+            .chain(core::iter::once(self.index.to_u32()))
     }
 }
 
@@ -92,7 +192,7 @@ impl Default for BitcoinAccount {
     fn default() -> Self {
         Self {
             kind: AccountKind::Segwitv1,
-            index: 0,
+            index: NormalIndex::ZERO,
         }
     }
 }
@@ -131,7 +231,7 @@ impl BitcoinBip32Path {
     pub fn path_segments_from_bitcoin_appkey(&self) -> impl Iterator<Item = u32> {
         self.account_keychain
             .path_segments_from_bitcoin_appkey()
-            .chain(core::iter::once(self.index))
+            .chain(core::iter::once(self.index.to_u32()))
     }
 
     pub fn from_u32_slice(path: &[u32]) -> Option<Self> {
@@ -144,24 +244,22 @@ impl BitcoinBip32Path {
             _ => return None,
         };
 
-        let account_index = path[1];
-        let account = BitcoinAccount {
-            kind: account_kind,
-            index: account_index,
-        };
-
         let keychain = match path[2] {
             0 => Keychain::External,
             1 => Keychain::Internal,
             _ => return None,
         };
 
-        let _check_it = ChildNumber::from_normal_idx(path[2]).ok()?;
-        let index = path[3];
+        // The kind and keychain segments are pinned to one value each above; these two carry the
+        // whole `u32`, so they are where the range can actually be violated.
+        let account = BitcoinAccount {
+            kind: account_kind,
+            index: NormalIndex::new(path[1])?,
+        };
 
         Some(BitcoinBip32Path {
             account_keychain: BitcoinAccountKeychain { account, keychain },
-            index,
+            index: NormalIndex::new(path[3])?,
         })
     }
 }
@@ -421,6 +519,181 @@ mod test {
     use alloc::vec::Vec;
     use bitcoin::secp256k1::Secp256k1;
     use schnorr_fun::frost::chilldkg::certpedpop;
+
+    const MAX_NORMAL: u32 = (1 << 31) - 1;
+
+    /// Mirrors the encoding of [`BitcoinBip32Path`] with the indices left as bare `u32`s, so a
+    /// test can produce the bytes a pre-`NormalIndex` encoder would have written.
+    #[derive(bincode::Encode)]
+    struct RawPath {
+        account_kind: u32,
+        account_index: u32,
+        keychain: u32,
+        index: u32,
+    }
+
+    fn encode(value: &impl bincode::Encode) -> Vec<u8> {
+        bincode::encode_to_vec(value, bincode::config::standard()).unwrap()
+    }
+
+    #[test]
+    fn normal_index_range() {
+        assert!(NormalIndex::new(0).is_some());
+        assert!(NormalIndex::new(MAX_NORMAL).is_some());
+        assert!(NormalIndex::new(MAX_NORMAL + 1).is_none());
+        assert!(NormalIndex::new(u32::MAX).is_none());
+    }
+
+    /// The type may not change what goes on the wire, only what is accepted off it.
+    #[test]
+    fn encoding_is_unchanged_by_the_newtype() {
+        let path = BitcoinBip32Path {
+            account_keychain: BitcoinAccountKeychain {
+                account: BitcoinAccount {
+                    kind: AccountKind::Segwitv1,
+                    index: NormalIndex::new(7).unwrap(),
+                },
+                keychain: Keychain::Internal,
+            },
+            index: NormalIndex::new(MAX_NORMAL).unwrap(),
+        };
+        let raw = RawPath {
+            account_kind: 0,
+            account_index: 7,
+            keychain: 1,
+            index: MAX_NORMAL,
+        };
+
+        assert_eq!(encode(&path), encode(&raw));
+    }
+
+    /// A hardened index has to be refused wherever it can arrive, not only at the leaf type, so
+    /// this drives it through each wire type that carries a path.
+    #[test]
+    fn hardened_index_is_refused_by_path_tweak_and_sign_item() {
+        let cfg = bincode::config::standard();
+        let raw = |account_index, index| RawPath {
+            account_kind: 0,
+            account_index,
+            keychain: 0,
+            index,
+        };
+        // `AppTweak::Bitcoin` is variant 1; a `SignItem` is an empty message then an `AppTweak`.
+        let wrap = |bytes: &[u8], prefix: &[u8]| {
+            let mut out = prefix.to_vec();
+            out.extend_from_slice(bytes);
+            out
+        };
+
+        // Both segments carrying a full `u32`, in range and just past it.
+        let cases = [
+            (MAX_NORMAL, MAX_NORMAL, false),
+            (MAX_NORMAL + 1, 0, true),
+            (0, MAX_NORMAL + 1, true),
+        ];
+
+        for (account_index, index, out_of_range) in cases {
+            let path = encode(&raw(account_index, index));
+            let tweak = wrap(&path, &[1]);
+            let sign_item = wrap(&tweak, &[0]);
+
+            // The in-range case decoding cleanly is what proves the rejections below are about
+            // the index and not about bytes that were malformed to begin with.
+            assert_eq!(
+                bincode::decode_from_slice::<BitcoinBip32Path, _>(&path, cfg).is_err(),
+                out_of_range,
+                "BitcoinBip32Path at {account_index}/{index}"
+            );
+            assert_eq!(
+                bincode::decode_from_slice::<AppTweak, _>(&tweak, cfg).is_err(),
+                out_of_range,
+                "AppTweak at {account_index}/{index}"
+            );
+            assert_eq!(
+                bincode::decode_from_slice::<crate::SignItem, _>(&sign_item, cfg).is_err(),
+                out_of_range,
+                "SignItem at {account_index}/{index}"
+            );
+        }
+    }
+
+    /// The untrusted signing boundary is the one that matters most. Splices a hardened value into
+    /// the encoding of a real task, giving the bytes an encoder predating `NormalIndex` would have
+    /// produced, and covers both segments that carry a full `u32`.
+    #[test]
+    fn hardened_index_is_refused_inside_a_transaction_sign_task() {
+        let master_appkey = crate::MasterAppkey::derive_from_rootkey(g!(2 * G).normalize());
+        let cfg = bincode::config::standard();
+
+        let needle = encode(&MAX_NORMAL);
+        let hardened = encode(&(MAX_NORMAL + 1));
+        assert_eq!(
+            needle.len(),
+            hardened.len(),
+            "the splice must preserve length"
+        );
+
+        let sentinel = NormalIndex::new(MAX_NORMAL).unwrap();
+        let at_address_index = BitcoinBip32Path {
+            account_keychain: BitcoinAccountKeychain::external(),
+            index: sentinel,
+        };
+        let at_account_index = BitcoinBip32Path {
+            account_keychain: BitcoinAccountKeychain {
+                account: BitcoinAccount {
+                    kind: AccountKind::Segwitv1,
+                    index: sentinel,
+                },
+                keychain: Keychain::External,
+            },
+            index: NormalIndex::ZERO,
+        };
+
+        for bip32_path in [at_address_index, at_account_index] {
+            let mut tx_template = crate::bitcoin_transaction::TransactionTemplate::new();
+            tx_template.push_imaginary_owned_input(
+                crate::bitcoin_transaction::LocalSpk {
+                    master_appkey,
+                    bip32_path,
+                },
+                bitcoin::Amount::from_sat(100_000),
+            );
+            let bytes = encode(&crate::WireSignTask::BitcoinTransaction(tx_template));
+
+            // Without this the splice below would prove nothing: a decode failure could just mean
+            // the bytes were never valid.
+            assert!(
+                bincode::decode_from_slice::<crate::WireSignTask, _>(&bytes, cfg).is_ok(),
+                "the in-range task must decode"
+            );
+
+            let occurrences = bytes.windows(needle.len()).filter(|w| *w == needle).count();
+            assert_eq!(
+                occurrences, 1,
+                "exactly one segment should carry the sentinel"
+            );
+            let at = bytes
+                .windows(needle.len())
+                .position(|w| w == needle)
+                .expect("sentinel is present");
+
+            let mut patched = bytes.clone();
+            patched[at..at + hardened.len()].copy_from_slice(&hardened);
+
+            assert!(
+                bincode::decode_from_slice::<crate::WireSignTask, _>(&patched, cfg).is_err(),
+                "a hardened index must not survive decoding inside a sign task"
+            );
+        }
+    }
+
+    #[test]
+    fn from_u32_slice_bounds_both_unpinned_segments() {
+        assert!(BitcoinBip32Path::from_u32_slice(&[0, MAX_NORMAL, 1, MAX_NORMAL]).is_some());
+        assert!(BitcoinBip32Path::from_u32_slice(&[0, MAX_NORMAL + 1, 0, 0]).is_none());
+        assert!(BitcoinBip32Path::from_u32_slice(&[0, 0, 0, MAX_NORMAL + 1]).is_none());
+        assert!(BitcoinBip32Path::from_u32_slice(&[0, 0, 1, u32::MAX]).is_none());
+    }
 
     #[test]
     pub fn bip32_derivation_matches_rust_bitcoin() {

--- a/frostsnap_core/tests/endtoend.rs
+++ b/frostsnap_core/tests/endtoend.rs
@@ -1,7 +1,7 @@
 use common::TEST_ENCRYPTION_KEY;
 use frostsnap_core::bitcoin_transaction::{LocalSpk, TransactionTemplate};
 use frostsnap_core::device::KeyPurpose;
-use frostsnap_core::tweak::BitcoinBip32Path;
+use frostsnap_core::tweak::{BitcoinBip32Path, NormalIndex};
 use frostsnap_core::EnterPhysicalId;
 use frostsnap_core::{MasterAppkey, WireSignTask};
 use rand::seq::IteratorRandom;
@@ -231,7 +231,10 @@ fn test_verify_address() {
 
     let key_data = run.coordinator.iter_keys().next().unwrap().clone();
 
-    let verify_request = run.coordinator.verify_address(key_data.key_id, 0).unwrap();
+    let verify_request = run
+        .coordinator
+        .verify_address(key_data.key_id, NormalIndex::ZERO)
+        .unwrap();
     run.extend(verify_request);
     run.run_until_finished(&mut env, &mut test_rng).unwrap();
 
@@ -333,7 +336,7 @@ fn signing_a_bitcoin_transaction_produces_valid_signatures() {
     tx_template.push_imaginary_owned_input(
         LocalSpk {
             master_appkey,
-            bip32_path: BitcoinBip32Path::external(7),
+            bip32_path: BitcoinBip32Path::external(NormalIndex::new(7).unwrap()),
         },
         bitcoin::Amount::from_sat(42_000),
     );
@@ -341,7 +344,7 @@ fn signing_a_bitcoin_transaction_produces_valid_signatures() {
     tx_template.push_imaginary_owned_input(
         LocalSpk {
             master_appkey,
-            bip32_path: BitcoinBip32Path::internal(42),
+            bip32_path: BitcoinBip32Path::internal(NormalIndex::new(42).unwrap()),
         },
         bitcoin::Amount::from_sat(1_337_000),
     );

--- a/frostsnap_core/tests/feerate_calculation.rs
+++ b/frostsnap_core/tests/feerate_calculation.rs
@@ -1,6 +1,6 @@
 use bitcoin::{Amount, ScriptBuf, TxOut};
 use frostsnap_core::bitcoin_transaction::{LocalSpk, TransactionTemplate};
-use frostsnap_core::tweak::BitcoinBip32Path;
+use frostsnap_core::tweak::{BitcoinBip32Path, NormalIndex};
 use frostsnap_core::MasterAppkey;
 use schnorr_fun::fun::G;
 
@@ -24,7 +24,7 @@ fn test_feerate_estimation_accuracy() {
     // Create dummy local SPK for the inputs
     let local_spk = LocalSpk {
         master_appkey,
-        bip32_path: BitcoinBip32Path::external(0),
+        bip32_path: BitcoinBip32Path::external(NormalIndex::ZERO),
     };
 
     // Add 2 owned inputs matching the real transaction amounts

--- a/frostsnap_core/tests/proptest.rs
+++ b/frostsnap_core/tests/proptest.rs
@@ -16,7 +16,7 @@ use frostsnap_core::{
     },
     device::{DeviceToUserMessage, KeyGenPhase3, KeyPurpose, SignPhase1},
     message::{self, DeviceSend, DeviceToCoordinatorMessage},
-    tweak::BitcoinBip32Path,
+    tweak::{BitcoinBip32Path, NormalIndex},
     AccessStructureRef, DeviceId, KeygenId, SignSessionId, WireSignTask,
 };
 use proptest_state_machine::{
@@ -796,7 +796,9 @@ impl StateMachineTest for HappyPathTest {
                     tx_template.push_imaginary_owned_input(
                         LocalSpk {
                             master_appkey,
-                            bip32_path: BitcoinBip32Path::external(i as u32),
+                            bip32_path: BitcoinBip32Path::external(
+                                NormalIndex::new(i as u32).unwrap(),
+                            ),
                         },
                         bitcoin::Amount::from_sat(amount),
                     );
@@ -810,7 +812,7 @@ impl StateMachineTest for HappyPathTest {
                         bitcoin::Amount::from_sat(change),
                         LocalSpk {
                             master_appkey,
-                            bip32_path: BitcoinBip32Path::internal(0),
+                            bip32_path: BitcoinBip32Path::internal(NormalIndex::ZERO),
                         },
                     );
                 }

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -193,11 +193,11 @@ impl Transaction {
         let txid = tx_temp.txid();
         let is_mine = tx_temp
             .iter_locally_owned_inputs()
-            .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index))
+            .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index.to_u32()))
             .chain(
                 tx_temp
                     .iter_locally_owned_outputs()
-                    .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index)),
+                    .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index.to_u32())),
             )
             .collect::<HashMap<_, _>>();
         let prevouts = tx_temp

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -114,11 +114,11 @@ impl ActiveSignSessionExt for ActiveSignSession {
                 let txid = raw_tx.compute_txid();
                 let is_mine = tx_temp
                     .iter_locally_owned_inputs()
-                    .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index))
+                    .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index.to_u32()))
                     .chain(
                         tx_temp
                             .iter_locally_owned_outputs()
-                            .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index)),
+                            .map(|(_, _, spk)| (spk.spk(), spk.bip32_path.index.to_u32())),
                     )
                     .collect::<HashMap<_, _>>();
                 let prevouts = tx_temp

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -763,6 +763,9 @@ impl FfiCoordinator {
     ) -> anyhow::Result<()> {
         let coordinator = self.coordinator.lock().unwrap();
 
+        let address_index = frostsnap_core::tweak::NormalIndex::new(address_index)
+            .ok_or_else(|| anyhow!("address index {address_index} is not a normal bip32 child"))?;
+
         let verify_address_messages = coordinator.verify_address(key_id, address_index)?;
 
         let ui_protocol = VerifyAddressProtocol::new(verify_address_messages.clone(), stream);


### PR DESCRIPTION
`WireSignTask::check` decides what a transaction *means* to the user before the device shows it. It asked whether a locally-owned output derived from our `master_appkey`, but nothing about **where under that key** it sat — and the wallet only ever watches one place.

Two commits, smallest first. Only one of them is meant to survive.

## 1. Make a bip32 index prove its range on decode

`BitcoinBip32Path::index` and `BitcoinAccount::index` were bare `u32`s. BIP32 splits child numbers at 2^31; `derive_bip32_in_place` hmacs whatever it is handed, while miniscript descriptors — how the wallet builds spks — can only express normal children. So a wire type could carry an index the device derives happily and the wallet can never watch.

`NormalIndex` holds only a normal child and enforces it in `Decode`/`BorrowDecode` as well as its constructors, so the guarantee travels with the type instead of with whoever remembers to check. `Encode` delegates to the inner `u32`, so the wire bytes are unchanged.

Worth recording as a near-miss: rust-bitcoin's `ChildNumber` spans both halves and its `From<u32>` maps the hardened half to `Hardened` rather than failing, with `Deserialize` built on that — so decoding `0x80000000` through it succeeds silently. Only `from_normal_idx` errors.

`ScreenVerify::VerifyAddress` carried the same unvalidated `u32` to the device, which turns it straight into an address on screen, so it takes the type too; the conversion happens once at the Dart boundary, where it can fail.

Two latent problems fell out. `peek_spk` did `at_derivation_index(..).expect("infallible")`, which a hardened index would have panicked; it is honest now. And `from_u32_slice` validated the keychain segment its own `match` had already pinned to 0 or 1, while the account and address indices — the two segments carrying a full `u32` — went unchecked.

## 2. Temporary: narrow what a sign task may present as ours

For every locally-owned **output**, `check` now also requires:

- the account to be `BitcoinAccount::default()` — the wallet's only account
- `index < OUTPUT_INDEX_LIMIT` (200,000)

with a distinct `SignTaskError` per rule. Marked `TEMPORARY` at both the constant and the check.

**The ceiling applies to both keychains, internal and external.** It is not defended as sitting above what ordinary use reaches — that would be a claim about reachability, and `check` cannot judge reachability, since only the coordinator knows its revealed range. It is defended as *bounding the space*: everything the device has ever called ours lands inside a range an exhaustive sweep could cover. That is a property of the rule rather than a guess about the counterparty.

**The known cost — only this side is bounded.** `OUTPUT_INDEX_LIMIT` lives in `sign_task.rs` and nothing on the coordinator side reads it, so an honest coordinator that allocated change or revealed an address past the ceiling would have its own task refused here. Reaching it is implausible for change (`next_unused_spk` needs nearly every index below it used) and cheaper for external, where `apply_update` feeds chain-reported `last_active_indices` into `reveal_to_target_multi`, so a third party can walk `last_revealed` forward at roughly one dust output per 25 (bdk's `DEFAULT_LOOKAHEAD`). The consequence there is a refused self-send — not lost or unspendable funds.

That names the real problem underneath: **two authorities on which paths are legitimate — `check` and the wallet's issuance — and only one of them bounded.** Closing it means one shared issuance boundary that every path routes through (`next_address`, `get_address_info`, `addresses_state`, `search_for_address`, the device `verify_address` flow, and change allocation), with `next_address` becoming fallible. Deferred by decision, and named at the check so it is not rediscovered from scratch.

Inputs are deliberately not bounded: `Input::txout` derives the prevout script from the claimed path, so the sighash commits to it and a forged input path can only sign against a prevout that is not on chain — while bounding inputs would strand a coin a PSBT legitimately imports, `push_owned_input` having already matched its script against the path it claims. A test pins that exclusion, so it is not helpfully undone later.

## Tests

Six new. Five in `tweak.rs` for the type:

- `normal_index_range` — the constructor boundary: 0 and `MAX_NORMAL` accepted, `MAX_NORMAL + 1` and `u32::MAX` refused
- `encoding_is_unchanged_by_the_newtype` — the wire bytes stay the inner `u32`'s
- `from_u32_slice_bounds_both_unpinned_segments` — the account and address segments are checked, not just the keychain the surrounding `match` had already pinned
- `hardened_index_is_refused_by_path_tweak_and_sign_item` — raw `RawPath` bytes wrapped with the prefixes that make them an `AppTweak::Bitcoin` and a `SignItem`, with each full-`u32` segment at `MAX_NORMAL` and one past it
- `hardened_index_is_refused_inside_a_transaction_sign_task` — a **length-preserving splice** (asserted as such) of a hardened value into the encoded bytes of a real `WireSignTask::BitcoinTransaction`, at the address index and at the account index

and one in `sign_task.rs`:

- `temporary_path_policy` — the highest in-range output index still signs, the index at the limit is `OutputIndexOutOfRange`, an output in another account is `UnwatchedAccount`, and an **input** in another account still signs

The last two of the five are the enclosing-type cases, and they matter more than the newtype's own tests. bincode's derive composes, so the invariant is only worth anything if it survives `BitcoinBip32Path` → `AppTweak` → `SignItem` → `TransactionTemplate`; these decode hostile bytes at those boundaries rather than arguing that composition makes it true by construction.
