### PR TITLE
[app] Prompt to upgrade a connected device's firmware

### DIFF
--- a/frostsnapp/lib/firmware_upgrade_bubble.dart
+++ b/frostsnapp/lib/firmware_upgrade_bubble.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:frostsnap/device_action_upgrade.dart';
+
+/// Session-scoped: dismissing silences it until the app restarts. A notifier
+/// rather than a bare bool so the scope matches the storage — every mounted
+/// prompt reacts, not only the one whose button was pressed.
+final _dismissed = ValueNotifier(false);
+
+/// Belongs in the page's own widget tree rather than on the root navigator or
+/// an overlay — every fullscreen device dialog is a root-navigator route, so
+/// living below them is what keeps this from ever covering a device prompt.
+/// Ordering it explicitly would be a rule to get wrong; this cannot be.
+class FirmwareUpgradeBubble extends StatefulWidget {
+  const FirmwareUpgradeBubble({super.key});
+
+  @override
+  State<FirmwareUpgradeBubble> createState() => _FirmwareUpgradeBubbleState();
+}
+
+class _FirmwareUpgradeBubbleState extends State<FirmwareUpgradeBubble> {
+  static const _maxWidth = 460.0;
+
+  final _upgrades = DeviceActionUpgradeController();
+  bool _upgrading = false;
+
+  @override
+  void dispose() {
+    _upgrades.dispose();
+    super.dispose();
+  }
+
+  Future<void> _upgrade() async {
+    setState(() => _upgrading = true);
+    try {
+      await _upgrades.run(context);
+    } finally {
+      if (mounted) setState(() => _upgrading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Positioned(
+      top: 0,
+      left: 0,
+      right: 0,
+      // Deliberately over the page's own `SliverAppBar`, drawer button
+      // included: LLFourn's call, on the grounds that having to dismiss it to
+      // reach the tray is acceptable pressure to deal with the upgrade. Note
+      // it is the drawer button it lands on, so dismissing is the only way
+      // back to the tray while it is up.
+      child: SafeArea(
+        bottom: false,
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: _maxWidth),
+            child: ListenableBuilder(
+              listenable: Listenable.merge([_upgrades, _dismissed]),
+              builder: (context, _) {
+                final count = _upgrades.count;
+                final visible = count > 0 && !_dismissed.value && !_upgrading;
+                final label = count == 1
+                    ? 'A device can be upgraded'
+                    : '$count devices can be upgraded';
+
+                return IgnorePointer(
+                  ignoring: !visible,
+                  child: AnimatedSlide(
+                    offset: visible ? Offset.zero : const Offset(0, -1.4),
+                    duration: Durations.medium4,
+                    curve: Curves.easeInOutCubicEmphasized,
+                    child: AnimatedOpacity(
+                      opacity: visible ? 1 : 0,
+                      duration: Durations.short4,
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(12, 10, 12, 0),
+                        child: Material(
+                          // Raised a tier above the page and given a real
+                          // shadow: this is the only thing on screen that is
+                          // floating rather than laid out, and it should read
+                          // that way.
+                          color: theme.colorScheme.surfaceContainerHigh,
+                          elevation: 6,
+                          borderRadius: BorderRadius.circular(28),
+                          child: Padding(
+                            padding: const EdgeInsets.fromLTRB(18, 6, 6, 6),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.system_update_rounded,
+                                  size: 20,
+                                  color: theme.colorScheme.primary,
+                                ),
+                                const SizedBox(width: 14),
+                                Expanded(
+                                  child: Text(
+                                    label,
+                                    style: theme.textTheme.bodyMedium,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                TextButton(
+                                  onPressed: _upgrade,
+                                  child: const Text('Upgrade'),
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.close_rounded),
+                                  iconSize: 18,
+                                  visualDensity: VisualDensity.compact,
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                  tooltip: 'Dismiss',
+                                  onPressed: () => _dismissed.value = true,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frostsnapp/lib/firmware_upgrade_bubble.dart
+++ b/frostsnapp/lib/firmware_upgrade_bubble.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:frostsnap/device_action_upgrade.dart';
+import 'package:frostsnap/global.dart';
+import 'package:frostsnap/src/rust/api/device_list.dart';
 
-/// Session-scoped: dismissing silences it until the app restarts. A notifier
-/// rather than a bare bool so the scope matches the storage — every mounted
-/// prompt reacts, not only the one whose button was pressed.
+/// Cleared whenever a device is plugged in, so the dismissal means "not now"
+/// rather than "not this run". A notifier rather than a bare field because it
+/// is library-level: every mounted prompt should react, not only the one whose
+/// button was pressed.
 final _dismissed = ValueNotifier(false);
 
 /// Belongs in the page's own widget tree rather than on the root navigator or
@@ -21,10 +26,26 @@ class _FirmwareUpgradeBubbleState extends State<FirmwareUpgradeBubble> {
   static const _maxWidth = 460.0;
 
   final _upgrades = DeviceActionUpgradeController();
+  StreamSubscription<DeviceListUpdate>? _connects;
   bool _upgrading = false;
 
   @override
+  void initState() {
+    super.initState();
+    // The upgrade controller answers "how many can be upgraded", not "did
+    // something just arrive", so this is a separate question rather than a
+    // second copy of the same one.
+    _connects = GlobalStreams.deviceListSubject.listen((update) {
+      final plugged = update.changes.any(
+        (change) => change.kind == DeviceListChangeKind.added,
+      );
+      if (plugged) _dismissed.value = false;
+    });
+  }
+
+  @override
   void dispose() {
+    _connects?.cancel();
     _upgrades.dispose();
     super.dispose();
   }

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:frostsnap/backup_workflow.dart';
 import 'package:frostsnap/contexts.dart';
 import 'package:frostsnap/device_list.dart';
+import 'package:frostsnap/firmware_upgrade_bubble.dart';
 import 'package:frostsnap/global.dart';
 import 'package:frostsnap/id_ext.dart';
 import 'package:frostsnap/keygen.dart';
@@ -186,24 +187,29 @@ class WalletHome extends StatelessWidget {
           appBar: walletListController.selected == null
               ? AppBar(forceMaterialTransparency: true)
               : null,
-          body: AnimatedSwitcher(
-            duration: Durations.long1,
-            reverseDuration: Duration.zero,
-            switchInCurve: Curves.easeInOutCubicEmphasized,
-            transitionBuilder: (child, animation) => SlideTransition(
-              position: Tween<Offset>(
-                begin: Offset(1, 0),
-                end: Offset(0, 0),
-              ).animate(animation),
-              child: FadeTransition(
-                opacity: CurvedAnimation(
-                  parent: animation,
-                  curve: Curves.linear,
+          body: Stack(
+            children: [
+              AnimatedSwitcher(
+                duration: Durations.long1,
+                reverseDuration: Duration.zero,
+                switchInCurve: Curves.easeInOutCubicEmphasized,
+                transitionBuilder: (child, animation) => SlideTransition(
+                  position: Tween<Offset>(
+                    begin: Offset(1, 0),
+                    end: Offset(0, 0),
+                  ).animate(animation),
+                  child: FadeTransition(
+                    opacity: CurvedAnimation(
+                      parent: animation,
+                      curve: Curves.linear,
+                    ),
+                    child: child,
+                  ),
                 ),
-                child: child,
+                child: body,
               ),
-            ),
-            child: body,
+              const FirmwareUpgradeBubble(),
+            ],
           ),
           bottomNavigationBar: bottomBar,
         );
@@ -650,7 +656,10 @@ class WalletDrawer extends StatelessWidget {
           ),
         ]);
 
-        final drawerColor = theme.colorScheme.surface;
+        // A tier above the page so the tray reads as a panel laid over the
+        // content rather than continuous with it. M3 puts the drawer container
+        // on surfaceContainerLow; `surface` is what the page body already uses.
+        final drawerColor = theme.colorScheme.surfaceContainerLow;
 
         final drawer = NavigationDrawer(
           backgroundColor: drawerColor,

--- a/frostsnapp/rust/src/api/device_list.rs
+++ b/frostsnapp/rust/src/api/device_list.rs
@@ -66,12 +66,28 @@ pub struct ConnectedDevice {
 impl ConnectedDevice {
     #[frb(sync)]
     pub fn ready(&self) -> bool {
-        self.name.is_some() && !self.needs_firmware_upgrade()
+        self.name.is_some() && self.firmware_is_up_to_date()
     }
 
+    /// Whether an upgrade is available *and* possible.
+    ///
+    /// False both when the device is current and when nothing can be done —
+    /// no firmware bundled in the app, or a device newer than the app knows
+    /// about. Those are not the same as "up to date", but offering the user an
+    /// upgrade that would be refused is worse than saying nothing, so they are
+    /// the same answer here. Callers that mean "is this device current" want
+    /// [`firmware_is_up_to_date`] instead.
     #[frb(sync)]
     pub fn needs_firmware_upgrade(&self) -> bool {
-        !matches!(
+        matches!(
+            self.firmware_upgrade_eligibility(),
+            FirmwareUpgradeEligibility::CanUpgrade
+        )
+    }
+
+    #[frb(ignore)]
+    pub(crate) fn firmware_is_up_to_date(&self) -> bool {
+        matches!(
             self.firmware_upgrade_eligibility(),
             FirmwareUpgradeEligibility::UpToDate
         )

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -215,7 +215,7 @@ impl FfiCoordinator {
 
                                 if let Some(connected_device) = device_list.get_device(id) {
                                     // we only send some messages out if the device has up to date firmware
-                                    if !connected_device.needs_firmware_upgrade() {
+                                    if connected_device.firmware_is_up_to_date() {
                                         // coordinator_outbox.extend(
                                         //     coordinator.maybe_request_nonce_replenishment(
                                         //         &BTreeSet::from([id]),


### PR DESCRIPTION
A device could sit on stale firmware indefinitely. The only way to discover an upgrade was the device list's "Upgrade N devices" button, which you had to go looking for.

This floats a prompt over the wallet page when a connected device reports it can be upgraded, offering the existing upgrade flow or a dismissal that lasts the session.

## Placement is the design

The prompt lives in the **wallet page's own widget tree**, not on the root navigator and not in an overlay.

Every fullscreen device dialog is a root-navigator route, so page content sits beneath all of them by construction. The prompt *cannot* cover a device prompt, rather than being ordered not to — there is no z-order rule for a later change to get wrong. An `OverlayEntry` would have done the opposite.

It reads its count from `DeviceActionUpgradeController`, the `ChangeNotifier` whose job that already is, rather than watching the device list a second time. That also means it observes connections continuously, so a device plugged in halfway through signing is noticed like any other.

## An approach that was tried and abandoned

The first attempt gated each action on the firmware question — asking before check-backup, display-backup, verify-address and signing. Worth recording why it didn't survive:

- The coordinator dispatches protocol messages the moment a call is made (`tell_device_to_check_backup` calls `start_protocol` inside its own body), so the question had to be asked *before* every call site sent anything. That makes it a line each site must remember.
- It sampled the device list **once**, at action start. Signing and address verification are exactly the flows where devices arrive one at a time *afterwards*, so the two that most needed it were structurally uncovered.
- Covering them properly needs the app, not the coordinator, to decide when per-device messages go out. Signing already works that way (`connected_but_need_request` is state the app acts on), but `VerifyAddressProtocol::connected` queues its own send, so verify would need a coordinator change to participate at all.

A prompt that watches the device list interposes on nothing and needs none of that.

## Two deliberate choices

**It sits over the page's own `SliverAppBar`, drawer button included.** Dismissing to reach the tray is accepted as reasonable pressure to deal with the upgrade. The spec-correct M3 alternative is a banner, which is *inline* rather than floating — that is what would stop it covering anything — but the app bar it must sit below is a sliver inside each page's `CustomScrollView`, so it costs an insertion per page instead of the single one this needs. A pinned-sliver variant was built and compared before settling here.

**The drawer background changes too**, because it is the same defect a level up: `NavigationDrawer` was passed `colorScheme.surface`, the token the page body already uses, so the tray and the content it slid over were the same colour. That was an override away from Flutter's own M3 default of `surfaceContainerLow`.

## Testing

No new tests. Nothing here can be asserted without the device stack, and mocked device tests would only assert the mock.

`flutter analyze`, `just dart-format-check-app` and the existing 144-test suite are clean. Behaviour was driven by hand against two devices on stale firmware — prompt appears on connect, Upgrade runs the existing flow, it clears itself once the devices report the new digest, dismissal lasts the session, and it is completely hidden behind a fullscreen device dialog.
