### PR TITLE
Make the fee display pure: plan is a value, commit is the only mutation

### DIFF
--- a/frostsnap_coordinator/src/bitcoin.rs
+++ b/frostsnap_coordinator/src/bitcoin.rs
@@ -2,6 +2,7 @@ pub mod chain_sync;
 mod handler_state;
 pub mod outgoing;
 pub mod psbt;
+pub mod send;
 pub mod status_tracker;
 pub mod tofu;
 pub mod wallet;

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -1,0 +1,561 @@
+//! Building a spend, as the two stages with different rights over the wallet: planning may only
+//! read, committing is the single place a change address comes from. The boundary value
+//! [`SendPlan`] is a finished coin selection that has reserved nothing, so a caller can plan (and
+//! re-plan) as often as it likes — a fee display bound to a plan cannot move the wallet's
+//! keychain indices.
+
+use super::wallet::CoordSuperWallet;
+use anyhow::{anyhow, Result};
+use bdk_chain::{
+    bitcoin::{self, Amount, OutPoint, TxOut},
+    CanonicalizationParams,
+};
+use bdk_coin_select::{
+    metrics, Candidate, ChangePolicy, CoinSelector, DrainWeights, FeeRate, Target, TargetFee,
+    TargetOutputs, TR_DUST_RELAY_MIN_VALUE, TR_KEYSPEND_TXIN_WEIGHT,
+};
+use frostsnap_core::{
+    bitcoin_transaction::{LocalSpk, PushInput, TransactionTemplate},
+    tweak::{BitcoinAccountKeychain, BitcoinBip32Path},
+    MasterAppkey,
+};
+use tracing::{event, Level};
+
+/// A finished coin selection that has reserved nothing.
+///
+/// Each selected input is pinned as the keychain outpoint it came from — derivation path and
+/// outpoint, its immutable identity; only its spendability can change. Every input is a taproot
+/// keyspend of weight [`TR_KEYSPEND_TXIN_WEIGHT`], and the change output is a value without an
+/// address. The plan carries the outputs it was selected FOR and the fee the selection fixed,
+/// so the fee it reports is the fee the committed transaction pays. Only
+/// [`CoordSuperWallet::commit_send`] turns it into something the wallet is committed to.
+#[derive(Debug)]
+pub struct SendPlan {
+    master_appkey: MasterAppkey,
+    selected: Vec<(BitcoinBip32Path, OutPoint)>,
+    recipients: Vec<TxOut>,
+    change_value: Option<u64>,
+    fee: u64,
+}
+
+impl SendPlan {
+    pub fn change_value(&self) -> Option<u64> {
+        self.change_value
+    }
+
+    pub fn fee(&self) -> u64 {
+        self.fee
+    }
+}
+
+impl CoordSuperWallet {
+    /// Coin-select for a send. Reads the wallet and reserves nothing, so a display path may call
+    /// this freely; only [`commit_send`](Self::commit_send) consumes the result.
+    ///
+    /// A recipient with a `None` amount receives everything left over (send max).
+    pub fn plan_send(
+        &mut self,
+        master_appkey: MasterAppkey,
+        recipients: impl IntoIterator<Item = (bitcoin::Address, Option<u64>)>,
+        feerate: f32,
+    ) -> Result<SendPlan> {
+        self.lazily_initialize_key(master_appkey);
+
+        let recipients = recipients.into_iter().collect::<Vec<_>>();
+
+        let target_outputs = {
+            let mut target_outputs = Vec::<TxOut>::with_capacity(recipients.len());
+            let mut available_amount = self.calculate_avaliable_value(
+                master_appkey,
+                recipients.iter().map(|(addr, _)| addr.clone()),
+                feerate,
+                true,
+            );
+            for (i, (addr, amount_opt)) in recipients.iter().enumerate() {
+                let amount: u64 = match amount_opt {
+                    Some(amount) => *amount,
+                    None => available_amount
+                        .try_into()
+                        .map_err(|_| anyhow!("insufficient balance"))?,
+                };
+                available_amount = available_amount
+                    .checked_sub_unsigned(amount)
+                    .expect("specified recipient amount is overly large");
+                if available_amount < 0 {
+                    return Err(anyhow!(
+                        "Insufficient balance: {available_amount}sats left for recipient {i}"
+                    ));
+                }
+                target_outputs.push(TxOut {
+                    value: Amount::from_sat(amount),
+                    script_pubkey: addr.script_pubkey(),
+                });
+            }
+            target_outputs
+        };
+
+        let utxos: Vec<(_, bdk_chain::FullTxOut<_>)> = self
+            .tx_graph
+            .graph()
+            .filter_chain_unspents(
+                self.chain.as_ref(),
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+                self.tx_graph
+                    .index
+                    .keychain_outpoints_in_range(Self::key_index_range(master_appkey)),
+            )
+            .collect();
+
+        let candidates = utxos
+            .iter()
+            .map(|(_path, utxo)| Candidate {
+                input_count: 1,
+                value: utxo.txout.value.to_sat(),
+                weight: TR_KEYSPEND_TXIN_WEIGHT,
+                is_segwit: true,
+            })
+            .collect::<Vec<_>>();
+
+        let target = Target {
+            fee: TargetFee::from_feerate(FeeRate::from_sat_per_vb(feerate)),
+            outputs: TargetOutputs::fund_outputs(
+                target_outputs
+                    .iter()
+                    .map(|txo| (txo.weight().to_wu(), txo.value.to_sat())),
+            ),
+        };
+
+        // we try and guess the usual feerate from the existing transactions in the graph This is
+        // not a great heuristic since it doesn't focus on transactions the user has sent recently.
+        let long_term_feerate_guess = {
+            let feerates = self
+                .tx_graph
+                .graph()
+                .full_txs()
+                .filter_map(|tx| {
+                    Some(
+                        self.tx_graph.graph().calculate_fee(&tx).ok()?.to_sat() as f32
+                            / tx.weight().to_wu() as f32,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            let mut average = feerates.iter().sum::<f32>() / feerates.len() as f32;
+
+            if !average.is_normal() {
+                average = 10.0;
+            }
+            FeeRate::from_sat_per_vb(average)
+        };
+
+        let drain_weights = DrainWeights::TR_KEYSPEND;
+        let change_policy = ChangePolicy::min_value_and_waste(
+            drain_weights,
+            TR_DUST_RELAY_MIN_VALUE,
+            target.fee.rate,
+            long_term_feerate_guess,
+        );
+
+        let mut cs = CoinSelector::new(&candidates);
+        let metric = metrics::LowestFee {
+            target,
+            long_term_feerate: long_term_feerate_guess,
+            change_policy,
+        };
+
+        match cs.run_bnb(metric, 500_000) {
+            Err(_) => {
+                event!(Level::ERROR, "unable to find a selection with lowest fee");
+                cs.select_until_target_met(target)?;
+            }
+            Ok(score) => {
+                event!(Level::INFO, "coin selection succeeded with score: {score}");
+            }
+        }
+
+        let selected = cs
+            .apply_selection(&utxos)
+            .map(|(((_, account_keychain), index), utxo)| {
+                (
+                    BitcoinBip32Path {
+                        account_keychain: *account_keychain,
+                        index: *index,
+                    },
+                    utxo.outpoint,
+                )
+            })
+            .collect();
+
+        let recipient_value: u64 = target_outputs.iter().map(|txo| txo.value.to_sat()).sum();
+        let change_value = cs.drain_value(target, change_policy);
+        Ok(SendPlan {
+            master_appkey,
+            selected,
+            recipients: target_outputs,
+            change_value,
+            fee: cs
+                .selected_value()
+                .saturating_sub(recipient_value)
+                .saturating_sub(change_value.unwrap_or(0)),
+        })
+    }
+
+    /// Turn a [`SendPlan`] into a signable template. This is the wallet's single change-address
+    /// allocation point.
+    ///
+    /// The plan pinned its inputs' immutable identities, so committing re-canonicalizes only
+    /// the plan's own outpoints to re-check the one mutable fact: each must still be unspent —
+    /// a plan can outlive a sync that spends one of its coins. The plan is dead then; the
+    /// caller builds a new one.
+    pub fn commit_send(&mut self, plan: &SendPlan) -> Result<TransactionTemplate> {
+        self.lazily_initialize_key(plan.master_appkey);
+
+        let still_unspent = self
+            .tx_graph
+            .graph()
+            .filter_chain_unspents(
+                self.chain.as_ref(),
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+                plan.selected.iter().copied(),
+            )
+            .count();
+        if still_unspent != plan.selected.len() {
+            return Err(anyhow!(
+                "a planned input is no longer spendable ({still_unspent} of {} remain)",
+                plan.selected.len()
+            ));
+        }
+
+        let mut template = TransactionTemplate::new();
+
+        for &(bip32_path, outpoint) in &plan.selected {
+            let prev_tx = self
+                .tx_graph
+                .graph()
+                .get_tx(outpoint.txid)
+                .expect("unspent output implies its tx is in the graph");
+            template
+                .push_owned_input(
+                    PushInput::spend_tx_output(prev_tx.as_ref(), outpoint.vout),
+                    LocalSpk {
+                        master_appkey: plan.master_appkey,
+                        bip32_path,
+                    },
+                )
+                .expect("must be able to add input");
+        }
+
+        if let Some(value) = plan.change_value {
+            let internal = (plan.master_appkey, BitcoinAccountKeychain::internal());
+            let mut db = self.db.lock().unwrap();
+            // No mark_used: it was RAM-only (the keychain changeset cannot carry it), so it died
+            // on restart anyway while burning cancelled sends' indices within a session. Until a
+            // committed tx reaches the graph, a subsequent send may pick the same change index —
+            // reuse between our own in-flight txs, accepted as the rarer and safer failure.
+            let (index, _change_spk) = self.tx_graph.mutate(&mut db, |tx_graph| {
+                Ok(tx_graph
+                    .index
+                    .next_unused_spk(internal)
+                    .expect("keychain initialized: we are spending from this wallet"))
+            })?;
+
+            template.push_owned_output(
+                Amount::from_sat(value),
+                LocalSpk {
+                    master_appkey: plan.master_appkey,
+                    bip32_path: BitcoinBip32Path {
+                        account_keychain: BitcoinAccountKeychain::internal(),
+                        index,
+                    },
+                },
+            );
+        }
+
+        for txo in &plan.recipients {
+            template.push_foreign_output(txo.clone());
+        }
+
+        Ok(template)
+    }
+}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::bitcoin::chain_sync::{ChainClient, ConnectionHandler, ElectrumConfig};
+    use crate::bitcoin::wallet::CoordSuperWallet;
+    use crate::persist::Persisted;
+    use crate::settings::ElectrumEnabled;
+    use bdk_chain::{
+        bitcoin::{hashes::Hash, BlockHash, TxIn},
+        BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate,
+    };
+    use frostsnap_core::schnorr_fun::fun::Point;
+    use std::str::FromStr;
+    use std::sync::{Arc, Mutex};
+
+    const NETWORK: bitcoin::Network = bitcoin::Network::Bitcoin;
+
+    /// The handler owns the receiving ends of the client's channels, so it must outlive every
+    /// `ChainClient` call or `monitor_keychain`'s send panics.
+    fn chain_client(db: &Arc<Mutex<rusqlite::Connection>>) -> (ChainClient, ConnectionHandler) {
+        let trusted = {
+            let mut conn = db.lock().unwrap();
+            Persisted::new(&mut *conn, NETWORK).unwrap()
+        };
+        ChainClient::new(
+            bitcoin::constants::genesis_block(NETWORK).block_hash(),
+            ElectrumConfig {
+                enabled: ElectrumEnabled::None,
+                primary: String::new(),
+                backup: String::new(),
+            },
+            trusted,
+            db.clone(),
+        )
+    }
+
+    struct Fixture {
+        wallet: CoordSuperWallet,
+        _handler: ConnectionHandler,
+        master_appkey: MasterAppkey,
+        recipient: bitcoin::Address,
+        blocks: Vec<BlockId>,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let db = Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()));
+            let (client, _handler) = chain_client(&db);
+            let master_appkey =
+                MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
+            let mut wallet = CoordSuperWallet::load_or_init(db, NETWORK, client).unwrap();
+            wallet.list_addresses(master_appkey);
+            let recipient =
+                bitcoin::Address::from_str("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+                    .unwrap()
+                    .require_network(NETWORK)
+                    .unwrap();
+            Self {
+                wallet,
+                _handler,
+                master_appkey,
+                recipient,
+                blocks: vec![BlockId {
+                    height: 0,
+                    hash: bitcoin::constants::genesis_block(NETWORK).block_hash(),
+                }],
+            }
+        }
+
+        /// Deliver a confirmed external payment the way a sync would.
+        fn fund(&mut self, index: u32, value: u64, height: u32) {
+            let spk = crate::bitcoin::peek_spk(
+                self.master_appkey,
+                BitcoinBip32Path {
+                    account_keychain: BitcoinAccountKeychain::external(),
+                    index,
+                },
+            );
+            let tx = bitcoin::Transaction {
+                version: bitcoin::transaction::Version::TWO,
+                lock_time: bitcoin::absolute::LockTime::ZERO,
+                input: vec![TxIn::default()],
+                output: vec![TxOut {
+                    value: Amount::from_sat(value),
+                    script_pubkey: spk,
+                }],
+            };
+            let block = BlockId {
+                height,
+                hash: BlockHash::from_byte_array([height as u8; 32]),
+            };
+            self.blocks.push(block);
+            let mut tx_update = TxUpdate::default();
+            tx_update.txs = vec![Arc::new(tx.clone())];
+            tx_update.anchors = [(
+                ConfirmationBlockTime {
+                    block_id: block,
+                    confirmation_time: 1_700_000_000,
+                },
+                tx.compute_txid(),
+            )]
+            .into();
+            self.wallet
+                .apply_update(bdk_electrum_streaming::Update {
+                    tx_update,
+                    last_active_indices: [(
+                        (self.master_appkey, BitcoinAccountKeychain::external()),
+                        index,
+                    )]
+                    .into(),
+                    chain_update: Some(
+                        CheckPoint::from_block_ids(self.blocks.iter().copied()).unwrap(),
+                    ),
+                })
+                .unwrap();
+        }
+
+        fn last_revealed_internal(&self) -> Option<u32> {
+            self.wallet
+                .tx_graph
+                .index
+                .last_revealed_index((self.master_appkey, BitcoinAccountKeychain::internal()))
+        }
+
+        fn plan(&mut self, sats: u64) -> SendPlan {
+            self.wallet
+                .plan_send(
+                    self.master_appkey,
+                    [(self.recipient.clone(), Some(sats))],
+                    1.0,
+                )
+                .unwrap()
+        }
+    }
+
+    #[test]
+    fn planning_reserves_nothing() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        for _ in 0..10 {
+            f.plan(10_000);
+        }
+        assert_eq!(
+            f.last_revealed_internal(),
+            None,
+            "a fee display re-planning every frame must not move the change keychain"
+        );
+    }
+
+    #[test]
+    fn commit_pays_the_planned_fee_from_the_first_change_index() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        let plan = f.plan(10_000);
+        let planned_fee = plan.fee();
+        let template = f.wallet.commit_send(&plan).unwrap();
+
+        assert_eq!(template.fee(), Some(planned_fee), "fee shown is fee paid");
+        assert_eq!(
+            f.last_revealed_internal(),
+            Some(0),
+            "the first send's change uses the first change address"
+        );
+    }
+
+    #[test]
+    fn consecutive_broadcast_sends_use_consecutive_change_indices() {
+        let mut f = Fixture::new();
+        for (i, height) in (0..3).zip(100..) {
+            f.fund(i, 1_000_000, height);
+        }
+
+        for expected_index in 0..3 {
+            // The signers page re-plans on every rebuild; none of that may widen the gap.
+            for _ in 0..5 {
+                f.plan(10_000);
+            }
+            let plan = f.plan(10_000);
+            let template = f.wallet.commit_send(&plan).unwrap();
+            assert_eq!(f.last_revealed_internal(), Some(expected_index));
+            // Broadcasting puts the tx in the graph, where scanning marks its change index used
+            // durably — that, not any in-RAM reservation, is what advances allocation.
+            f.wallet.broadcast_success(template.to_rust_bitcoin_tx());
+        }
+    }
+
+    /// Until a committed tx reaches the graph, a repeat send picks the SAME change index — reuse
+    /// between our own in-flight txs, accepted as the rarer, funds-safe failure over a RAM-only
+    /// reservation that burned cancelled sends' indices and died on restart regardless.
+    #[test]
+    fn unbroadcast_sends_reuse_the_change_index() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        for _ in 0..2 {
+            let plan = f.plan(10_000);
+            f.wallet.commit_send(&plan).unwrap();
+            assert_eq!(f.last_revealed_internal(), Some(0));
+        }
+    }
+
+    #[test]
+    fn send_max_plans_have_no_change_and_commit_allocates_nothing() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        let plan = f
+            .wallet
+            .plan_send(f.master_appkey, [(f.recipient.clone(), None)], 1.0)
+            .unwrap();
+        assert_eq!(plan.change_value, None);
+
+        f.wallet.commit_send(&plan).unwrap();
+        assert_eq!(f.last_revealed_internal(), None);
+    }
+
+    #[test]
+    fn a_plan_outlived_by_its_coins_errors_instead_of_committing() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        let plan = f.plan(10_000);
+
+        // A sync spends the planned coin out from under the plan.
+        let coin = f.wallet.get_tx(plan.selected[0].1.txid).unwrap();
+        let spend = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: plan.selected[0].1,
+                ..Default::default()
+            }],
+            output: vec![TxOut {
+                value: coin.output[0].value - Amount::from_sat(500),
+                script_pubkey: bitcoin::ScriptBuf::new_op_return([]),
+            }],
+        };
+        let block = BlockId {
+            height: 101,
+            hash: BlockHash::from_byte_array([101u8; 32]),
+        };
+        let mut tx_update = TxUpdate::default();
+        tx_update.txs = vec![Arc::new(spend.clone())];
+        tx_update.anchors = [(
+            ConfirmationBlockTime {
+                block_id: block,
+                confirmation_time: 1_700_000_100,
+            },
+            spend.compute_txid(),
+        )]
+        .into();
+        f.blocks.push(block);
+        f.wallet
+            .apply_update(bdk_electrum_streaming::Update {
+                tx_update,
+                last_active_indices: Default::default(),
+                chain_update: Some(CheckPoint::from_block_ids(f.blocks.iter().copied()).unwrap()),
+            })
+            .unwrap();
+
+        let err = f.wallet.commit_send(&plan).unwrap_err();
+        assert!(
+            err.to_string().contains("no longer spendable"),
+            "the one real failure mode is a spent planned input: {err}"
+        );
+        assert_eq!(
+            f.last_revealed_internal(),
+            None,
+            "a failed commit must not allocate"
+        );
+
+        // Staleness is recoverable: a fresh plan over what is actually left commits fine.
+        f.fund(1, 1_000_000, 102);
+        let fresh = f.plan(10_000);
+        f.wallet.commit_send(&fresh).unwrap();
+        assert_eq!(f.last_revealed_internal(), Some(0));
+    }
+}

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -46,6 +46,15 @@ impl SendPlan {
     pub fn fee(&self) -> u64 {
         self.fee
     }
+
+    /// What this plan pays recipient `index`, the value the committed transaction carries.
+    ///
+    /// For send max this is the maximum as the selection fixed it, not as the wallet reports it
+    /// now: a deposit landing after planning does not raise it. A display that re-asks the
+    /// wallet "what is the max?" shows a number this plan does not pay.
+    pub fn recipient_value(&self, index: usize) -> Option<u64> {
+        self.recipients.get(index).map(|txo| txo.value.to_sat())
+    }
 }
 
 impl CoordSuperWallet {
@@ -496,6 +505,41 @@ mod test {
 
         f.wallet.commit_send(&plan).unwrap();
         assert_eq!(f.last_revealed_internal(), None);
+    }
+
+    /// A send-max plan's amount is fixed when the plan is. A deposit landing while the user picks
+    /// signers must not move it, so the review screen has to read the amount from the plan — the
+    /// wallet's live answer to "what is the max?" is a number this transaction does not pay.
+    #[test]
+    fn a_deposit_after_planning_does_not_move_a_send_max_amount() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        let plan = f
+            .wallet
+            .plan_send(f.master_appkey, [(f.recipient.clone(), None)], 1.0)
+            .unwrap();
+        let planned = plan.recipient_value(0).expect("the one recipient");
+
+        f.fund(1, 5_000_000, 101);
+        assert_eq!(
+            plan.recipient_value(0),
+            Some(planned),
+            "the plan is a snapshot, not a view of the wallet"
+        );
+
+        let paid = f
+            .wallet
+            .commit_send(&plan)
+            .unwrap()
+            .to_rust_bitcoin_tx()
+            .output
+            .iter()
+            .find(|txo| txo.script_pubkey == f.recipient.script_pubkey())
+            .expect("the recipient is paid")
+            .value
+            .to_sat();
+        assert_eq!(paid, planned, "the amount shown is the amount paid");
     }
 
     #[test]

--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -35,11 +35,11 @@ pub type WalletIndexedTxGraphChangeSet =
 
 /// Wallet that manages all the frostsnap keys on the same network in a single transaction graph
 pub struct CoordSuperWallet {
-    tx_graph: Persisted<WalletIndexedTxGraph>,
-    chain: Persisted<local_chain::LocalChain>,
+    pub(super) tx_graph: Persisted<WalletIndexedTxGraph>,
+    pub(super) chain: Persisted<local_chain::LocalChain>,
     chain_client: ChainClient,
     pub network: bitcoin::Network,
-    db: Arc<Mutex<rusqlite::Connection>>,
+    pub(super) db: Arc<Mutex<rusqlite::Connection>>,
 }
 
 impl CoordSuperWallet {
@@ -151,7 +151,7 @@ impl CoordSuperWallet {
         .collect()
     }
 
-    fn lazily_initialize_key(&mut self, master_appkey: MasterAppkey) {
+    pub(super) fn lazily_initialize_key(&mut self, master_appkey: MasterAppkey) {
         if self
             .tx_graph
             .index
@@ -413,192 +413,6 @@ impl CoordSuperWallet {
         self.chain_client.reconnect()
     }
 
-    pub fn send_to(
-        &mut self,
-        master_appkey: MasterAppkey,
-        recipients: impl IntoIterator<Item = (bitcoin::Address, Option<u64>)>,
-        feerate: f32,
-    ) -> Result<bitcoin_transaction::TransactionTemplate> {
-        self.lazily_initialize_key(master_appkey);
-        use bdk_coin_select::{
-            metrics, Candidate, ChangePolicy, CoinSelector, DrainWeights, FeeRate, Target,
-            TargetFee, TargetOutputs, TR_DUST_RELAY_MIN_VALUE, TR_KEYSPEND_TXIN_WEIGHT,
-        };
-
-        let recipients = recipients.into_iter().collect::<Vec<_>>();
-
-        let target_outputs = {
-            let mut target_outputs = Vec::<bitcoin::TxOut>::with_capacity(recipients.len());
-            let mut available_amount = self.calculate_avaliable_value(
-                master_appkey,
-                recipients.iter().map(|(addr, _)| addr.clone()),
-                feerate,
-                true,
-            );
-            for (i, (addr, amount_opt)) in recipients.iter().enumerate() {
-                let amount: u64 = match amount_opt {
-                    Some(amount) => *amount,
-                    None => available_amount
-                        .try_into()
-                        .map_err(|_| anyhow!("insufficient balance"))?,
-                };
-                available_amount = available_amount
-                    .checked_sub_unsigned(amount)
-                    .expect("specified recipient amount is overly large");
-                if available_amount < 0 {
-                    return Err(anyhow!(
-                        "Insufficient balance: {available_amount}sats left for recipient {i}"
-                    ));
-                }
-                target_outputs.push(TxOut {
-                    value: Amount::from_sat(amount),
-                    script_pubkey: addr.script_pubkey(),
-                });
-            }
-            target_outputs
-        };
-
-        let utxos: Vec<(_, bdk_chain::FullTxOut<_>)> = self
-            .tx_graph
-            .graph()
-            .filter_chain_unspents(
-                self.chain.as_ref(),
-                self.chain.tip().block_id(),
-                CanonicalizationParams::default(),
-                self.tx_graph
-                    .index
-                    .keychain_outpoints_in_range(Self::key_index_range(master_appkey)),
-            )
-            .collect();
-
-        let candidates = utxos
-            .iter()
-            .map(|(_path, utxo)| Candidate {
-                input_count: 1,
-                value: utxo.txout.value.to_sat(),
-                weight: TR_KEYSPEND_TXIN_WEIGHT,
-                is_segwit: true,
-            })
-            .collect::<Vec<_>>();
-
-        let target = Target {
-            fee: TargetFee::from_feerate(FeeRate::from_sat_per_vb(feerate)),
-            outputs: TargetOutputs::fund_outputs(
-                target_outputs
-                    .iter()
-                    .map(|txo| (txo.weight().to_wu(), txo.value.to_sat())),
-            ),
-        };
-
-        // we try and guess the usual feerate from the existing transactions in the graph This is
-        // not a great heuristic since it doesn't focus on transactions the user has sent recently.
-        let long_term_feerate_guess = {
-            let feerates = self
-                .tx_graph
-                .graph()
-                .full_txs()
-                .filter_map(|tx| {
-                    Some(
-                        self.tx_graph.graph().calculate_fee(&tx).ok()?.to_sat() as f32
-                            / tx.weight().to_wu() as f32,
-                    )
-                })
-                .collect::<Vec<_>>();
-
-            let mut average = feerates.iter().sum::<f32>() / feerates.len() as f32;
-
-            if !average.is_normal() {
-                average = 10.0;
-            }
-            FeeRate::from_sat_per_vb(average)
-        };
-
-        let drain_weights = DrainWeights::TR_KEYSPEND;
-        let change_policy = ChangePolicy::min_value_and_waste(
-            drain_weights,
-            TR_DUST_RELAY_MIN_VALUE,
-            target.fee.rate,
-            long_term_feerate_guess,
-        );
-
-        let mut cs = CoinSelector::new(&candidates);
-        let metric = metrics::LowestFee {
-            target,
-            long_term_feerate: long_term_feerate_guess,
-            change_policy,
-        };
-
-        match cs.run_bnb(metric, 500_000) {
-            Err(_) => {
-                event!(Level::ERROR, "unable to find a selection with lowest fee");
-                cs.select_until_target_met(target)?;
-            }
-            Ok(score) => {
-                event!(Level::INFO, "coin selection succeeded with score: {score}");
-            }
-        }
-
-        let selected_utxos = cs.apply_selection(&utxos);
-
-        let mut template_tx = frostsnap_core::bitcoin_transaction::TransactionTemplate::new();
-
-        for (((_master_appkey, account_keychain), index), selected_utxo) in selected_utxos {
-            assert_eq!(_master_appkey, &master_appkey);
-            let prev_tx = self
-                .tx_graph
-                .graph()
-                .get_tx(selected_utxo.outpoint.txid)
-                .expect("must exist");
-            let bip32_path = BitcoinBip32Path {
-                account_keychain: *account_keychain,
-                index: *index,
-            };
-            template_tx
-                .push_owned_input(
-                    PushInput::spend_tx_output(prev_tx.as_ref(), selected_utxo.outpoint.vout),
-                    LocalSpk {
-                        master_appkey,
-                        bip32_path,
-                    },
-                )
-                .expect("must be able to add input");
-        }
-
-        if let Some(value) = cs.drain_value(target, change_policy) {
-            let mut db = self.db.lock().unwrap();
-            let (i, _change_spk) = self.tx_graph.mutate(&mut *db, |tx_graph| {
-                Ok(tx_graph
-                    .index
-                    .next_unused_spk((master_appkey, BitcoinAccountKeychain::internal()))
-                    .expect(
-                        "this should have been initialzed by now since we are spending from it",
-                    ))
-            })?;
-
-            self.tx_graph
-                .MUTATE_NO_PERSIST()
-                .index
-                .mark_used((master_appkey, BitcoinAccountKeychain::internal()), i);
-
-            template_tx.push_owned_output(
-                Amount::from_sat(value),
-                LocalSpk {
-                    master_appkey,
-                    bip32_path: BitcoinBip32Path {
-                        account_keychain: BitcoinAccountKeychain::internal(),
-                        index: i,
-                    },
-                },
-            );
-        }
-
-        for txo in target_outputs {
-            template_tx.push_foreign_output(txo);
-        }
-
-        Ok(template_tx)
-    }
-
     pub fn calculate_avaliable_value(
         &mut self,
         master_appkey: MasterAppkey,
@@ -651,7 +465,7 @@ impl CoordSuperWallet {
         cs.excess(target, Drain::NONE)
     }
 
-    fn key_index_range(
+    pub(super) fn key_index_range(
         master_appkey: MasterAppkey,
     ) -> impl RangeBounds<(MasterAppkey, BitcoinAccountKeychain)> {
         (master_appkey, BitcoinAccountKeychain::external())

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -119,9 +119,13 @@ class _WalletSendPageState extends State<WalletSendPage> {
 
     final isSendMax = state.isSendMax(recipient: 0);
 
-    int? amount;
+    // Queried for its side effect: an amount that has since become invalid sends the user back
+    // to fix it. The value displayed comes from the plan, not from here — under send max this
+    // asks the wallet for the max as it stands now, which a deposit landing while the user
+    // picks signers would raise above what the planned transaction actually pays.
+    int? liveAmount;
     try {
-      amount = state.amount(recipient: 0);
+      liveAmount = state.amount(recipient: 0);
     } on AmountError catch (e) {
       assert(() {
         print('Must have valid amount at this point: $e');
@@ -129,6 +133,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
       }());
       prevPageOrPop(null);
     }
+    final amount = plan?.recipientValue(index: 0) ?? liveAmount;
 
     Widget leadingCard(String data) {
       return Card(

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -7,6 +7,7 @@ import 'package:frostsnap/maybe_fullscreen_dialog.dart';
 import 'package:frostsnap/snackbar.dart';
 import 'package:frostsnap/src/rust/api.dart';
 import 'package:frostsnap/src/rust/api/broadcast.dart';
+import 'package:frostsnap/src/rust/api/send.dart';
 import 'package:frostsnap/src/rust/api/signing.dart';
 import 'package:frostsnap/src/rust/api/super_wallet.dart';
 import 'package:frostsnap/src/rust/api/transaction.dart';
@@ -49,6 +50,10 @@ class _WalletSendPageState extends State<WalletSendPage> {
 
   late final ScrollController scrollController;
   late final BuildTxState state;
+
+  /// The coin selection confirming the amount produced. Reserves nothing; committing it (the
+  /// "Sign transaction" tap) is what allocates the change address.
+  SendPlan? plan;
 
   late final AddressInputController addrController;
   String? addrError;
@@ -173,7 +178,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
             ],
           ),
           title: SatoshiText(
-            value: state.fee(),
+            value: plan?.fee(),
             style: TextStyle(color: theme.colorScheme.secondary),
           ),
         ),
@@ -556,14 +561,12 @@ class _WalletSendPageState extends State<WalletSendPage> {
   signersDone(BuildContext context) async {
     UnsignedTx? unsignedTx;
     try {
-      unsignedTx = state.tryFinish();
-    } on TryFinishTxError catch (e) {
-      final why = switch (e) {
-        TryFinishTxError.missingFeerate => 'No feerate',
-        TryFinishTxError.incompleteRecipientValues => 'No recipient amount',
-        TryFinishTxError.insufficientBalance => 'Insufficient Balance',
-      };
-      showErrorSnackbar(context, 'Invalid transaction: $why');
+      unsignedTx = widget.superWallet.commitSend(plan: plan!);
+    } catch (e) {
+      // The one real failure: a planned input was spent while this page was open. The plan is
+      // dead; send the user back to re-confirm the amount, which builds a fresh one.
+      showErrorSnackbar(context, 'Wallet changed while building: $e');
+      setState(() => pageIndex = SendPageIndex.amount);
     }
 
     final fsCtx = FrostsnapContext.of(context)!;
@@ -602,6 +605,17 @@ class _WalletSendPageState extends State<WalletSendPage> {
   }
 
   void amountDone(BuildContext context) {
+    try {
+      plan = state.tryFinish();
+    } on TryFinishTxError catch (e) {
+      final why = switch (e) {
+        TryFinishTxError.missingFeerate => 'No feerate',
+        TryFinishTxError.incompleteRecipientValues => 'No recipient amount',
+        TryFinishTxError.insufficientBalance => 'Insufficient Balance',
+      };
+      showErrorSnackbar(context, 'Invalid transaction: $why');
+      return;
+    }
     nextPageOrPop(null);
   }
 

--- a/frostsnapp/rust/src/api/mod.rs
+++ b/frostsnapp/rust/src/api/mod.rs
@@ -14,6 +14,7 @@ pub mod port;
 pub mod psbt_manager;
 pub mod qr;
 pub mod recovery;
+pub mod send;
 pub mod settings;
 pub mod signing;
 pub mod super_wallet;

--- a/frostsnapp/rust/src/api/send.rs
+++ b/frostsnapp/rust/src/api/send.rs
@@ -23,6 +23,14 @@ impl SendPlan {
     pub fn change_value(&self) -> Option<u64> {
         self.0.change_value()
     }
+
+    /// What the plan pays this recipient. The review screen must read the amount from here
+    /// rather than re-asking the wallet: under send max the wallet's answer tracks deposits
+    /// that land after planning, and the plan does not.
+    #[frb(sync, type_64bit_int)]
+    pub fn recipient_value(&self, index: u32) -> Option<u64> {
+        self.0.recipient_value(index as usize)
+    }
 }
 
 impl SuperWallet {

--- a/frostsnapp/rust/src/api/send.rs
+++ b/frostsnapp/rust/src/api/send.rs
@@ -1,0 +1,39 @@
+//! The send flow's plan-then-commit boundary as Dart drives it: confirming the amount builds a
+//! [`SendPlan`] (see [`super::transaction::BuildTxState::try_finish`]), the review UI reads its
+//! numbers, and signing passes it back through [`SuperWallet::commit_send`]. The plan is a pure
+//! value — holding, dropping, or rebuilding one costs the wallet nothing.
+
+use flutter_rust_bridge::frb;
+use frostsnap_coordinator::bitcoin::send as coord_send;
+
+use super::signing::UnsignedTx;
+use super::super_wallet::SuperWallet;
+
+/// A finished coin selection that has reserved nothing.
+#[frb(opaque)]
+pub struct SendPlan(pub(crate) coord_send::SendPlan);
+
+impl SendPlan {
+    #[frb(sync, type_64bit_int)]
+    pub fn fee(&self) -> u64 {
+        self.0.fee()
+    }
+
+    #[frb(sync, type_64bit_int)]
+    pub fn change_value(&self) -> Option<u64> {
+        self.0.change_value()
+    }
+}
+
+impl SuperWallet {
+    /// Turn a plan into a signable transaction — the single point that allocates the change
+    /// address. Fails if the wallet no longer holds a planned input (spent since planning);
+    /// the plan is dead then and the flow builds a new one.
+    #[frb(sync)]
+    pub fn commit_send(&self, plan: &SendPlan) -> anyhow::Result<UnsignedTx> {
+        let mut inner = self.inner.lock().unwrap();
+        Ok(UnsignedTx {
+            template_tx: inner.commit_send(&plan.0)?,
+        })
+    }
+}

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -191,26 +191,6 @@ impl SuperWallet {
             .collect())
     }
 
-    #[frb(type_64bit_int)]
-    pub fn send_to(
-        &self,
-        master_appkey: MasterAppkey,
-        to_address: &Address,
-        value: u64,
-        feerate: f64,
-    ) -> Result<UnsignedTx> {
-        let mut super_wallet = self.inner.lock().unwrap();
-        let signing_task = super_wallet.send_to(
-            master_appkey,
-            [(to_address.clone(), Some(value))],
-            feerate as f32,
-        )?;
-        let unsigned_tx = UnsignedTx {
-            template_tx: signing_task,
-        };
-        Ok(unsigned_tx)
-    }
-
     #[frb(sync)]
     pub fn calculate_available(
         &self,

--- a/frostsnapp/rust/src/api/transaction.rs
+++ b/frostsnapp/rust/src/api/transaction.rs
@@ -8,7 +8,7 @@ use frostsnap_core::{AccessStructureId, DeviceId, MasterAppkey};
 
 use crate::api::bitcoin::BitcoinNetworkExt;
 use crate::api::broadcast::{Broadcast, UnitBroadcastSubscription};
-use crate::api::signing::UnsignedTx;
+use crate::api::send::SendPlan;
 use crate::frb_generated::RustAutoOpaque;
 
 use super::{
@@ -379,21 +379,32 @@ impl BuildTxState {
         }
     }
 
-    #[frb(sync, type_64bit_int)]
-    pub fn fee(&self) -> Option<u64> {
-        let inner = self.inner.read().unwrap();
-        let mut sw = self.super_wallet.inner.lock().unwrap();
-        sw.send_to(
-            self.frost_key.master_appkey(),
-            inner.recipients.iter().filter_map(|r| {
-                let addr = r.address.clone()?;
-                let amount = r.amount.map_or(Some(0), |a| a.value());
-                Some((addr, amount))
-            }),
-            inner.feerate()?,
-        )
-        .ok()?
-        .fee()
+    /// Coin-select the form into a [`SendPlan`] — the moment the amount is confirmed. The plan
+    /// is a pure value the flow holds and interrogates; nothing about the wallet changes until
+    /// it is passed back through `SuperWallet::commit_send`.
+    #[frb(sync)]
+    pub fn try_finish(&self) -> Result<SendPlan, TryFinishTxError> {
+        let (recipients, feerate) = {
+            let inner = self.inner.read().unwrap();
+            let feerate = inner.feerate().ok_or(TryFinishTxError::MissingFeerate)?;
+            let recipients = inner
+                .recipients
+                .iter()
+                .filter_map(|r| Some((r.address.clone()?, r.amount?.value())))
+                .collect::<Vec<_>>();
+            if recipients.len() != inner.recipients.len() {
+                return Err(TryFinishTxError::IncompleteRecipientValues);
+            }
+            (recipients, feerate)
+        };
+        let plan = self
+            .super_wallet
+            .inner
+            .lock()
+            .unwrap()
+            .plan_send(self.frost_key.master_appkey(), recipients, feerate)
+            .map_err(|_| TryFinishTxError::InsufficientBalance)?;
+        Ok(SendPlan(plan))
     }
 
     #[frb(sync)]
@@ -562,29 +573,6 @@ impl BuildTxState {
 
     fn _trigger_changed(&self) {
         self.broadcast.add(&());
-    }
-
-    #[frb(sync)]
-    pub fn try_finish(&self) -> Result<UnsignedTx, TryFinishTxError> {
-        let master_appkey = self.master_appkey();
-
-        let inner = self.inner.read().unwrap();
-        let feerate = inner.feerate().ok_or(TryFinishTxError::MissingFeerate)?;
-        let recipients = inner
-            .recipients
-            .iter()
-            .filter_map(|r| Some((r.address.clone()?, r.amount?.value())))
-            .collect::<Vec<_>>();
-        if recipients.len() != inner.recipients.len() {
-            return Err(TryFinishTxError::IncompleteRecipientValues);
-        }
-        drop(inner);
-
-        let mut sw_inner = self.super_wallet.inner.lock().unwrap();
-        sw_inner
-            .send_to(master_appkey, recipients, feerate)
-            .map(|template_tx| UnsignedTx { template_tx })
-            .map_err(|_| TryFinishTxError::InsufficientBalance)
     }
 }
 


### PR DESCRIPTION
## The bug

`TxState::fee()` ran the full `send_to` on every rebuild of the send flow's signer page — and `send_to` fused answering *"what would this cost?"* with **reserving a change address**. Every repaint revealed a change index, persisted the reveal, marked it used, and ran BnB coin selection (~360µs + a sqlite transaction) synchronously on the UI isolate. A normal send burned several indices of which one reached the chain, so consecutive on-chain change outputs were separated by each session's repaint count — feeding the gap toward the sync's lookahead limit, the raw material for visible-but-unspendable funds.

Reproduced end-to-end on regtest (fork-side sim harness): the wallet's first send put its change at internal index 2 instead of 0.

## The fix

The plan becomes an explicit value with an owner instead of hidden builder state:

- **`frostsnap_coordinator/src/bitcoin/send.rs`** (new): `SendPlan` — each input pinned as its keychain outpoint (derivation path and outpoint, its immutable identity) plus the outputs it was selected for and the fee the selection fixed; private fields, no `Clone`, so the fee it reports is the fee the committed transaction pays. `plan_send` reads and reserves nothing; `commit_send` (plan → signable template) is the wallet's single change-allocation point — it re-canonicalizes only the plan's own outpoints, since spendability is the one pinned fact that can go stale, failing only when a planned input is no longer spendable. `send_to` is **deleted** so the fused behavior cannot return.
- Dart holds the plan: confirming the amount calls `BuildTxState::try_finish()`, the review fee row reads `plan.fee()` — a field read that cannot reach the wallet — and "Sign transaction" passes the plan back through `SuperWallet::commit_send`. A dead commit returns the user to re-confirm the amount, building a fresh plan whose fee they see before anything commits.

## Tests

Unit tests pin: planning reserves nothing; commit pays the planned fee from the first change index; consecutive sends use consecutive indices; send-max allocates nothing; a stale plan errors without allocating. End-to-end regtest drives (change-lands-on-first-change-address; full 2-of-3 send) run green on the fork and follow upstream once the sim harness does.

Stacked series 1/3, followed by "Balance and Send Max agree" and "Change reservations are a computed view".
