### PR TITLE
Balance and Send Max agree: persisted reveals and a 50-script lookahead

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -400,11 +400,10 @@ impl CoordSuperWallet {
                 let indexer_changeset = tx_graph
                     .index
                     .reveal_to_target_multi(&update.last_active_indices);
-                let tx_changeset = tx_graph.apply_update(update.tx_update);
-                let changed = !(chain_changeset.is_empty()
-                    && indexer_changeset.is_empty()
-                    && tx_changeset.is_empty());
-                Ok((changed, (tx_changeset, chain_changeset)))
+                let mut changeset = tx_graph.apply_update(update.tx_update);
+                changeset.indexer.merge(indexer_changeset);
+                let changed = !(chain_changeset.is_empty() && changeset.is_empty());
+                Ok((changed, (changeset, chain_changeset)))
             })?;
         Ok(changed)
     }

--- a/frostsnap_coordinator/src/bitcoin/wallet_persist.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet_persist.rs
@@ -25,7 +25,13 @@ impl Persist<rusqlite::Connection> for WalletIndexedTxGraph {
 
     fn load(conn: &mut rusqlite::Connection, _: Self::LoadParams) -> anyhow::Result<Self> {
         let db_tx = conn.transaction()?;
-        let mut indexed_tx_graph = Self::default();
+        // 50 scripts past the reveal frontier are derived, indexed against, and watched by the
+        // chain source (bdk's default is 25): slop for indices the frontier doesn't know about -
+        // restored wallets, other devices on the key, externally built PSBTs paying our own far
+        // indices. Anything further past the frontier is outside the discovery contract.
+        let mut indexed_tx_graph = Self::new(
+            bdk_chain::indexer::keychain_txout::KeychainTxOutIndex::new(50, false),
+        );
         indexed_tx_graph.apply_changeset(WalletIndexedTxGraphChangeSet {
             tx_graph: bdk_chain::tx_graph::ChangeSet::from_sqlite(&db_tx)?,
             indexer: bdk_chain::indexer::keychain_txout::ChangeSet::from_sqlite(&db_tx)?,


### PR DESCRIPTION
**Stacked on #542** (contains its commit until it merges; review the tip commit only).

## The bug

A confirmed output past the wallet's *persisted* reveal frontier showed in the balance but not in Send Max, and every restart reproduced it. Balance re-derives ownership from the spk map per call (a later reveal repairs it); coin selection reads the outpoint set, which bdk writes only at scan time and never backfills. The reveal that repaired the balance each session was the exact changeset `apply_update` discarded — so persisted `last_revealed` never advanced, every reload re-indexed stored txs against a too-narrow window, and the coin stayed permanently invisible to spending. Reproduced end-to-end on the fork's regtest harness across app restarts: balance 120000000 sats vs Send Max 99999901.

## The fix

The discipline every wallet uses, not a reconciliation pass:

- **Persist every mutation**: `apply_update` merges the reveal changeset (and the ratchet changesets new-tx indexing produces) into the persisted changeset. The frontier on disk is the frontier in use.
- **Lookahead 50**, set at the indexer's single construction site (was bdk's default 25, implicit via `Default`): the load window `frontier+50` absorbs every index the frontier doesn't know — restored wallets, other devices, externally built PSBTs — and heals wallets already broken by the old discard on their first load. Beyond 50 past the frontier is outside the discovery contract, per the standard gap-limit contract. The electrum tracker inherits the same value.

## Tests

No unit tests ship with this PR (kept fix-only at maintainer direction); the restart-crossing balance==send-max drive runs green on the fork’s harness.

Series 2/3.




