### PR TITLE
Change reservations are a computed view of live signing sessions, not wallet state

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -8,6 +8,7 @@ use super::wallet::CoordSuperWallet;
 use anyhow::{anyhow, Result};
 use bdk_chain::{
     bitcoin::{self, Amount, OutPoint, TxOut},
+    indexer::keychain_txout,
     CanonicalizationParams,
 };
 use bdk_coin_select::{
@@ -19,6 +20,7 @@ use frostsnap_core::{
     tweak::{BitcoinAccountKeychain, BitcoinBip32Path},
     MasterAppkey,
 };
+use std::collections::BTreeSet;
 use tracing::{event, Level};
 
 /// A finished coin selection that has reserved nothing.
@@ -39,6 +41,10 @@ pub struct SendPlan {
 }
 
 impl SendPlan {
+    pub fn master_appkey(&self) -> MasterAppkey {
+        self.master_appkey
+    }
+
     pub fn change_value(&self) -> Option<u64> {
         self.change_value
     }
@@ -211,13 +217,21 @@ impl CoordSuperWallet {
     }
 
     /// Turn a [`SendPlan`] into a signable template. This is the wallet's single change-address
-    /// allocation point.
+    /// allocation point: the lowest revealed-unused index not in `reserved_change`, revealing
+    /// fresh only when nothing passes. `reserved_change` is the caller's view of in-flight
+    /// reservations (see [`reserved_change_indices`]); the wallet stores nothing. A fresh reveal
+    /// cannot collide with it, since reservations come from committed templates whose indices are
+    /// at or below the frontier.
     ///
     /// The plan pinned its inputs' immutable identities, so committing re-canonicalizes only
     /// the plan's own outpoints to re-check the one mutable fact: each must still be unspent —
     /// a plan can outlive a sync that spends one of its coins. The plan is dead then; the
     /// caller builds a new one.
-    pub fn commit_send(&mut self, plan: &SendPlan) -> Result<TransactionTemplate> {
+    pub fn commit_send(
+        &mut self,
+        plan: &SendPlan,
+        reserved_change: impl IntoIterator<Item = u32>,
+    ) -> Result<TransactionTemplate> {
         self.lazily_initialize_key(plan.master_appkey);
 
         let still_unspent = self
@@ -258,16 +272,24 @@ impl CoordSuperWallet {
 
         if let Some(value) = plan.change_value {
             let internal = (plan.master_appkey, BitcoinAccountKeychain::internal());
+            let reserved: BTreeSet<u32> = reserved_change.into_iter().collect();
             let mut db = self.db.lock().unwrap();
-            // No mark_used: it was RAM-only (the keychain changeset cannot carry it), so it died
-            // on restart anyway while burning cancelled sends' indices within a session. Until a
-            // committed tx reaches the graph, a subsequent send may pick the same change index —
-            // reuse between our own in-flight txs, accepted as the rarer and safer failure.
-            let (index, _change_spk) = self.tx_graph.mutate(&mut db, |tx_graph| {
-                Ok(tx_graph
+            let index = self.tx_graph.mutate(&mut db, |tx_graph| {
+                let unreserved = tx_graph
                     .index
-                    .next_unused_spk(internal)
-                    .expect("keychain initialized: we are spending from this wallet"))
+                    .unused_keychain_spks(internal)
+                    .map(|(index, _)| index)
+                    .find(|index| !reserved.contains(index));
+                Ok(match unreserved {
+                    Some(index) => (index, keychain_txout::ChangeSet::default()),
+                    None => {
+                        let ((index, _spk), changeset) = tx_graph
+                            .index
+                            .reveal_next_spk(internal)
+                            .expect("keychain initialized: we are spending from this wallet");
+                        (index, changeset)
+                    }
+                })
             })?;
 
             template.push_owned_output(
@@ -446,7 +468,7 @@ mod test {
 
         let plan = f.plan(10_000);
         let planned_fee = plan.fee();
-        let template = f.wallet.commit_send(&plan).unwrap();
+        let template = f.wallet.commit_send(&plan, []).unwrap();
 
         assert_eq!(template.fee(), Some(planned_fee), "fee shown is fee paid");
         assert_eq!(
@@ -469,7 +491,7 @@ mod test {
                 f.plan(10_000);
             }
             let plan = f.plan(10_000);
-            let template = f.wallet.commit_send(&plan).unwrap();
+            let template = f.wallet.commit_send(&plan, []).unwrap();
             assert_eq!(f.last_revealed_internal(), Some(expected_index));
             // Broadcasting puts the tx in the graph, where scanning marks its change index used
             // durably — that, not any in-RAM reservation, is what advances allocation.
@@ -487,9 +509,28 @@ mod test {
 
         for _ in 0..2 {
             let plan = f.plan(10_000);
-            f.wallet.commit_send(&plan).unwrap();
+            f.wallet.commit_send(&plan, []).unwrap();
             assert_eq!(f.last_revealed_internal(), Some(0));
         }
+    }
+
+    /// The counterpart of the baseline above: hand commit_send the pending send's index as
+    /// reserved and the next send advances instead of reusing it.
+    #[test]
+    fn a_pending_sends_change_index_is_skipped() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        let plan = f.plan(10_000);
+        f.wallet.commit_send(&plan, []).unwrap();
+        let plan = f.plan(10_000);
+        let template = f.wallet.commit_send(&plan, [0]).unwrap();
+        let change_index = template
+            .iter_locally_owned_outputs()
+            .map(|(_, _, spk)| spk.bip32_path.index)
+            .next()
+            .expect("send has a change output");
+        assert_eq!(change_index, 1);
     }
 
     #[test]
@@ -503,7 +544,7 @@ mod test {
             .unwrap();
         assert_eq!(plan.change_value, None);
 
-        f.wallet.commit_send(&plan).unwrap();
+        f.wallet.commit_send(&plan, []).unwrap();
         assert_eq!(f.last_revealed_internal(), None);
     }
 
@@ -530,7 +571,7 @@ mod test {
 
         let paid = f
             .wallet
-            .commit_send(&plan)
+            .commit_send(&plan, [])
             .unwrap()
             .to_rust_bitcoin_tx()
             .output
@@ -585,7 +626,7 @@ mod test {
             })
             .unwrap();
 
-        let err = f.wallet.commit_send(&plan).unwrap_err();
+        let err = f.wallet.commit_send(&plan, []).unwrap_err();
         assert!(
             err.to_string().contains("no longer spendable"),
             "the one real failure mode is a spent planned input: {err}"
@@ -599,7 +640,7 @@ mod test {
         // Staleness is recoverable: a fresh plan over what is actually left commits fine.
         f.fund(1, 1_000_000, 102);
         let fresh = f.plan(10_000);
-        f.wallet.commit_send(&fresh).unwrap();
+        f.wallet.commit_send(&fresh, []).unwrap();
         assert_eq!(f.last_revealed_internal(), Some(0));
     }
 }

--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -1488,6 +1488,29 @@ impl FrostCoordinator {
         }
     }
 
+    /// The internal (change) indices of `account` under `master_appkey` reserved by in-flight
+    /// signing sessions — ACTIVE and FINISHED both: a fully signed session leaves the active map
+    /// while its transaction may still be unbroadcast. A session reserves until it is cancelled
+    /// or forgotten (`ForgetFinishedSignSession`); the coordinator has no chain visibility, so
+    /// once the transaction is broadcast the wallet's graph independently marks the index used,
+    /// and a finished session still reserving it is harmless overlap.
+    pub fn reserved_change_indices(
+        &self,
+        master_appkey: MasterAppkey,
+        account: crate::tweak::BitcoinAccount,
+    ) -> BTreeSet<u32> {
+        self.active_signing_sessions
+            .values()
+            .map(|session| &session.init.group_request.sign_task)
+            .chain(
+                self.finished_signing_sessions
+                    .values()
+                    .map(|session| &session.init.group_request.sign_task),
+            )
+            .flat_map(|task| task.reserved_change_indices(master_appkey, account))
+            .collect()
+    }
+
     pub fn active_signing_sessions(&self) -> impl Iterator<Item = ActiveSignSession> + '_ {
         self.active_sign_session_order.iter().map(|sid| {
             self.active_signing_sessions

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -1,4 +1,9 @@
-use crate::{bitcoin_transaction, device::KeyPurpose, tweak::AppTweak, MasterAppkey};
+use crate::{
+    bitcoin_transaction,
+    device::KeyPurpose,
+    tweak::{AppTweak, BitcoinAccount, BitcoinAccountKeychain, Keychain},
+    MasterAppkey,
+};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use bitcoin::hashes::Hash;
 use schnorr_fun::{Message, Schnorr, Signature};
@@ -39,6 +44,33 @@ pub struct CheckedSignTask {
 }
 
 impl WireSignTask {
+    /// The internal (change) indices of `account` under `master_appkey` that this task's
+    /// transaction pays — the indices a wallet must not hand out as fresh change while the task
+    /// is in flight. Empty for non-Bitcoin tasks.
+    pub fn reserved_change_indices(
+        &self,
+        master_appkey: MasterAppkey,
+        account: BitcoinAccount,
+    ) -> impl Iterator<Item = u32> + '_ {
+        let internal = BitcoinAccountKeychain {
+            account,
+            keychain: Keychain::Internal,
+        };
+        let template = match self {
+            WireSignTask::BitcoinTransaction(template) => Some(template),
+            _ => None,
+        };
+        template.into_iter().flat_map(move |template| {
+            template
+                .iter_locally_owned_outputs()
+                .filter_map(move |(_, _, spk)| {
+                    (spk.master_appkey == master_appkey
+                        && spk.bip32_path.account_keychain == internal)
+                        .then_some(spk.bip32_path.index)
+                })
+        })
+    }
+
     pub fn check(
         self,
         master_appkey: MasterAppkey,

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -566,7 +566,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
   signersDone(BuildContext context) async {
     UnsignedTx? unsignedTx;
     try {
-      unsignedTx = widget.superWallet.commitSend(plan: plan!);
+      unsignedTx = widget.superWallet.commitSend(coord: coord, plan: plan!);
     } catch (e) {
       // The one real failure: a planned input was spent while this page was open. The plan is
       // dead; send the user back to re-confirm the amount, which builds a fresh one.

--- a/frostsnapp/rust/src/api/send.rs
+++ b/frostsnapp/rust/src/api/send.rs
@@ -5,9 +5,12 @@
 
 use flutter_rust_bridge::frb;
 use frostsnap_coordinator::bitcoin::send as coord_send;
+use frostsnap_coordinator::frostsnap_core::tweak::BitcoinAccount;
 
+use super::coordinator::Coordinator;
 use super::signing::UnsignedTx;
 use super::super_wallet::SuperWallet;
+use crate::frb_generated::RustAutoOpaque;
 
 /// A finished coin selection that has reserved nothing.
 #[frb(opaque)]
@@ -35,13 +38,26 @@ impl SendPlan {
 
 impl SuperWallet {
     /// Turn a plan into a signable transaction — the single point that allocates the change
-    /// address. Fails if the wallet no longer holds a planned input (spent since planning);
-    /// the plan is dead then and the flow builds a new one.
+    /// address. The change index skips every index reserved by an in-flight signing session
+    /// (active AND finished-but-unbroadcast, queried live from the coordinator — the wallet
+    /// stores no reservation state). Fails if the wallet no longer holds a planned input
+    /// (spent since planning); the plan is dead then and the flow builds a new one.
     #[frb(sync)]
-    pub fn commit_send(&self, plan: &SendPlan) -> anyhow::Result<UnsignedTx> {
+    pub fn commit_send(
+        &self,
+        coord: RustAutoOpaque<Coordinator>,
+        plan: &SendPlan,
+    ) -> anyhow::Result<UnsignedTx> {
+        // The wallet only has the default account today; naming it here keeps that assumption
+        // at one visible call site.
+        let reserved = coord
+            .blocking_read()
+            .0
+            .inner()
+            .reserved_change_indices(plan.0.master_appkey(), BitcoinAccount::default());
         let mut inner = self.inner.lock().unwrap();
         Ok(UnsignedTx {
-            template_tx: inner.commit_send(&plan.0)?,
+            template_tx: inner.commit_send(&plan.0, reserved)?,
         })
     }
 }


### PR DESCRIPTION
**Stacked on #542 + the balance/Send Max PR** (contains their commits until they merge; review the tip commit only).

## The bug

`commit_send` reserved change with `next_unused_spk` + `mark_used` — a RAM-only bit (`keychain_txout`'s changeset cannot carry it) with a two-sided lifecycle nobody completed: one mark call in the tree, zero unmarks. A cancelled send's change index stayed burned until an app restart happened to recycle it; a pending send's reservation died on restart while its fully-signed session survived, letting two live templates pay the same change address.

## The fix

`mark_used` is deleted and nothing stateful replaces it — the reservation *is* the session:

- `commit_send(plan, reserved)` allocates the lowest revealed-unused index outside the caller's view, revealing fresh only when nothing passes (a fresh reveal can't collide: reservations come from committed templates, whose indices sit at or below the frontier).
- The knowledge lives where its facts live: `WireSignTask::reserved_change_indices(master_appkey, account)` — the task knows its contents, the account explicit because internal keychain is really (account, keychain) — and `FrostCoordinator::reserved_change_indices` builds the **active ∪ finished** union beside the session maps that define it (a fully signed session leaves the active map while its tx may still be unbroadcast). The api is one line naming `BitcoinAccount::default()` at the single visible call site.
- Two lifetimes, stated honestly: graph-used indices are durable from indexing; session reservations last until cancel/forget (core has no chain visibility); post-broadcast overlap is harmless.
