### PR TITLE
Force-spend coins stranded past a risky gap

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -4,7 +4,7 @@
 //! re-plan) as often as it likes — a fee display bound to a plan cannot move the wallet's
 //! keychain indices.
 
-use super::wallet::CoordSuperWallet;
+use super::wallet::{CoordSuperWallet, KeychainId};
 use anyhow::{anyhow, Result};
 use bdk_chain::{
     bitcoin::{self, Amount, OutPoint, TxOut},
@@ -20,8 +20,16 @@ use frostsnap_core::{
     tweak::{BitcoinAccountKeychain, BitcoinBip32Path},
     MasterAppkey,
 };
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use tracing::{event, Level};
+
+/// A coin a restore with this scan window cannot reach gets force-spent by every plan. From
+/// last used index p a restore derives p+1..=p+window and stalls where no history appears; 20
+/// is BIP44's gap limit, the strictest convention in common use, and defending it covers every
+/// wider window too (bdk's default 25 included) — whatever a 20-window crawl reaches, a wider
+/// one reaches a fortiori. It must stay below the wallet's own lookahead — a coin past a bigger
+/// gap never enters the UTXO set, so there is nothing to force.
+const RISKY_GAP: u32 = 20;
 
 /// A finished coin selection that has reserved nothing.
 ///
@@ -109,22 +117,22 @@ impl CoordSuperWallet {
             target_outputs
         };
 
-        let utxos: Vec<(_, bdk_chain::FullTxOut<_>)> = self
-            .tx_graph
-            .graph()
-            .filter_chain_unspents(
-                self.chain.as_ref(),
-                self.chain.tip().block_id(),
-                CanonicalizationParams::default(),
-                self.tx_graph
-                    .index
-                    .keychain_outpoints_in_range(Self::key_index_range(master_appkey)),
-            )
-            .collect();
+        let (keychain_indices, utxos): (Vec<(KeychainId, u32)>, Vec<bdk_chain::FullTxOut<_>>) =
+            self.tx_graph
+                .graph()
+                .filter_chain_unspents(
+                    self.chain.as_ref(),
+                    self.chain.tip().block_id(),
+                    CanonicalizationParams::default(),
+                    self.tx_graph
+                        .index
+                        .keychain_outpoints_in_range(Self::key_index_range(master_appkey)),
+                )
+                .unzip();
 
         let candidates = utxos
             .iter()
-            .map(|(_path, utxo)| Candidate {
+            .map(|utxo| Candidate {
                 input_count: 1,
                 value: utxo.txout.value.to_sat(),
                 weight: TR_KEYSPEND_TXIN_WEIGHT,
@@ -173,6 +181,9 @@ impl CoordSuperWallet {
         );
 
         let mut cs = CoinSelector::new(&candidates);
+        for position in self.gap_stranded(master_appkey, &keychain_indices) {
+            cs.select(position);
+        }
         let metric = metrics::LowestFee {
             target,
             long_term_feerate: long_term_feerate_guess,
@@ -190,14 +201,16 @@ impl CoordSuperWallet {
         }
 
         let selected = cs
-            .apply_selection(&utxos)
-            .map(|(((_, account_keychain), index), utxo)| {
+            .selected_indices()
+            .iter()
+            .map(|&position| {
+                let ((_, account_keychain), index) = keychain_indices[position];
                 (
                     BitcoinBip32Path {
-                        account_keychain: *account_keychain,
-                        index: *index,
+                        account_keychain,
+                        index,
                     },
-                    utxo.outpoint,
+                    utxos[position].outpoint,
                 )
             })
             .collect();
@@ -214,6 +227,43 @@ impl CoordSuperWallet {
                 .saturating_sub(recipient_value)
                 .saturating_sub(change_value.unwrap_or(0)),
         })
+    }
+
+    /// Positions in `coins` of ones a [`RISKY_GAP`]-window restore cannot discover, found by
+    /// simulating its crawl per keychain: the window starts covering the first RISKY_GAP indices,
+    /// and each REACHABLE used index u extends it through u + RISKY_GAP. Reachability is
+    /// transitive — history sitting above the window extends nothing, so a whole cluster above
+    /// one wide gap is stranded together; measuring only the run below each coin would let
+    /// unreachable history reset the gap and leave the cluster's upper coins stranded forever.
+    /// "Used" is the indexer's is_used semantics — some txout was indexed there, spent or not —
+    /// because spent history feeds a restore's crawl just the same.
+    fn gap_stranded(&self, master_appkey: MasterAppkey, coins: &[(KeychainId, u32)]) -> Vec<usize> {
+        let mut used: BTreeMap<KeychainId, BTreeSet<u32>> = BTreeMap::new();
+        for ((keychain, index), _) in self
+            .tx_graph
+            .index
+            .keychain_outpoints_in_range(Self::key_index_range(master_appkey))
+        {
+            used.entry(keychain).or_default().insert(index);
+        }
+        let mut stranded: BTreeMap<KeychainId, BTreeSet<u32>> = BTreeMap::new();
+        for (keychain, indices) in &used {
+            let unreachable = stranded.entry(*keychain).or_default();
+            let mut reach = RISKY_GAP - 1;
+            for &index in indices {
+                if index <= reach {
+                    reach = index + RISKY_GAP;
+                } else {
+                    unreachable.insert(index);
+                }
+            }
+        }
+        coins
+            .iter()
+            .enumerate()
+            .filter(|(_, (keychain, index))| stranded[keychain].contains(index))
+            .map(|(position, _)| position)
+            .collect()
     }
 
     /// Turn a [`SendPlan`] into a signable template. This is the wallet's single change-address
@@ -381,7 +431,7 @@ mod test {
         }
 
         /// Deliver a confirmed external payment the way a sync would.
-        fn fund(&mut self, index: u32, value: u64, height: u32) {
+        fn fund(&mut self, index: u32, value: u64, height: u32) -> OutPoint {
             let spk = crate::bitcoin::peek_spk(
                 self.master_appkey,
                 BitcoinBip32Path {
@@ -426,6 +476,10 @@ mod test {
                     ),
                 })
                 .unwrap();
+            OutPoint {
+                txid: tx.compute_txid(),
+                vout: 0,
+            }
         }
 
         fn last_revealed_internal(&self) -> Option<u32> {
@@ -531,6 +585,92 @@ mod test {
             .next()
             .expect("send has a change output");
         assert_eq!(change_index, 1);
+    }
+
+    /// The external-keychain indices the policy would force-spend, straight off the fixture.
+    fn stranded_external_indices(f: &Fixture) -> Vec<u32> {
+        let w = &f.wallet;
+        let (keychain_indices, _): (Vec<(KeychainId, u32)>, Vec<bdk_chain::FullTxOut<_>>) =
+            w.tx_graph
+                .graph()
+                .filter_chain_unspents(
+                    w.chain.as_ref(),
+                    w.chain.tip().block_id(),
+                    CanonicalizationParams::default(),
+                    w.tx_graph.index.keychain_outpoints_in_range(
+                        CoordSuperWallet::key_index_range(f.master_appkey),
+                    ),
+                )
+                .unzip();
+        w.gap_stranded(f.master_appkey, &keychain_indices)
+            .into_iter()
+            .map(|position| keychain_indices[position].1)
+            .collect()
+    }
+
+    /// The first index a BIP44-window restore cannot discover is 21 past the last used one (20
+    /// never-used below it) — an ordinary send must consolidate the coin sitting there even
+    /// though the target needs nothing from it.
+    #[test]
+    fn an_ordinary_send_consolidates_gap_stranded_coins() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        let stranded = f.fund(21, 500_000, 101);
+
+        let plan = f.plan(10_000);
+        assert!(
+            plan.selected
+                .iter()
+                .any(|&(_, outpoint)| outpoint == stranded),
+            "the coin past the risky gap must be force-spent"
+        );
+        f.wallet.commit_send(&plan, []).unwrap();
+    }
+
+    /// One index closer and a restore still finds it: a gap of 19 forces nothing.
+    #[test]
+    fn a_lookahead_safe_gap_is_not_forced() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        f.fund(20, 500_000, 101);
+        assert_eq!(stranded_external_indices(&f), Vec::<u32>::new());
+    }
+
+    /// Recovery is transitive: history a restore cannot reach extends nothing. With coins at 30
+    /// and 45 above one wide gap, BOTH are invisible to a restore stalled at the gap — forcing
+    /// only 30 (whose local run is wide) and not 45 (whose local run is 14) would leave 45
+    /// stranded forever, since 30's spent history keeps 45's local run short after the sweep.
+    #[test]
+    fn coins_clustered_above_one_gap_are_all_forced() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        f.fund(30, 500_000, 101);
+        f.fund(45, 500_000, 102);
+        assert_eq!(stranded_external_indices(&f), vec![30, 45]);
+    }
+
+    /// A spent-through index still shows history to a restore's crawl, so it resets the gap
+    /// here too: with index 13 spent, the crawl chains 0 → 13 → 26 in sub-window hops.
+    #[test]
+    fn spent_history_resets_the_gap() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        let spent = f.fund(13, 200_000, 101);
+        let spend = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: spent,
+                ..Default::default()
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(150_000),
+                script_pubkey: bitcoin::ScriptBuf::new_op_return([]),
+            }],
+        };
+        f.wallet.broadcast_success(spend);
+        f.fund(26, 500_000, 102);
+        assert_eq!(stranded_external_indices(&f), Vec::<u32>::new());
     }
 
     #[test]

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -182,7 +182,12 @@ impl CoordSuperWallet {
 
         let mut cs = CoinSelector::new(&candidates);
         for position in self.gap_stranded(master_appkey, &keychain_indices) {
-            cs.select(position);
+            // A coin below its spend cost is the same coin `calculate_avaliable_value` leaves
+            // out of the spendable figure, so forcing it would both destroy value and set a
+            // target the selection can no longer fund.
+            if candidates[position].effective_value(target.fee.rate) > 0.0 {
+                cs.select(position);
+            }
         }
         let metric = metrics::LowestFee {
             target,
@@ -237,6 +242,9 @@ impl CoordSuperWallet {
     /// unreachable history reset the gap and leave the cluster's upper coins stranded forever.
     /// "Used" is the indexer's is_used semantics — some txout was indexed there, spent or not —
     /// because spent history feeds a restore's crawl just the same.
+    ///
+    /// Send max is deliberately not special-cased: its target is every effective coin, so a
+    /// stranded coin worth spending is already in the selection and forcing it changes nothing.
     fn gap_stranded(&self, master_appkey: MasterAppkey, coins: &[(KeychainId, u32)]) -> Vec<usize> {
         let mut used: BTreeMap<KeychainId, BTreeSet<u32>> = BTreeMap::new();
         for ((keychain, index), _) in self
@@ -432,10 +440,22 @@ mod test {
 
         /// Deliver a confirmed external payment the way a sync would.
         fn fund(&mut self, index: u32, value: u64, height: u32) -> OutPoint {
+            self.fund_keychain(BitcoinAccountKeychain::external(), index, value, height)
+        }
+
+        /// Deliver a confirmed payment to either keychain. Change lands on the internal one,
+        /// which is where the burned indices are.
+        fn fund_keychain(
+            &mut self,
+            account_keychain: BitcoinAccountKeychain,
+            index: u32,
+            value: u64,
+            height: u32,
+        ) -> OutPoint {
             let spk = crate::bitcoin::peek_spk(
                 self.master_appkey,
                 BitcoinBip32Path {
-                    account_keychain: BitcoinAccountKeychain::external(),
+                    account_keychain,
                     index,
                 },
             );
@@ -466,11 +486,7 @@ mod test {
             self.wallet
                 .apply_update(bdk_electrum_streaming::Update {
                     tx_update,
-                    last_active_indices: [(
-                        (self.master_appkey, BitcoinAccountKeychain::external()),
-                        index,
-                    )]
-                    .into(),
+                    last_active_indices: [((self.master_appkey, account_keychain), index)].into(),
                     chain_update: Some(
                         CheckPoint::from_block_ids(self.blocks.iter().copied()).unwrap(),
                     ),
@@ -641,7 +657,7 @@ mod test {
     /// only 30 (whose local run is wide) and not 45 (whose local run is 14) would leave 45
     /// stranded forever, since 30's spent history keeps 45's local run short after the sweep.
     #[test]
-    fn coins_clustered_above_one_gap_are_all_forced() {
+    fn gap_stranded_reports_a_whole_cluster() {
         let mut f = Fixture::new();
         f.fund(0, 1_000_000, 100);
         f.fund(30, 500_000, 101);
@@ -671,6 +687,49 @@ mod test {
         f.wallet.broadcast_success(spend);
         f.fund(26, 500_000, 102);
         assert_eq!(stranded_external_indices(&f), Vec::<u32>::new());
+    }
+
+    /// The internal keychain is where the burned change indices are, so scattered change is
+    /// what a restore cannot reach. The policy has to defend it exactly as it defends receive
+    /// addresses.
+    #[test]
+    fn a_stranded_change_coin_is_forced_too() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        let stranded_change = f.fund_keychain(BitcoinAccountKeychain::internal(), 21, 500_000, 101);
+
+        let plan = f.plan(10_000);
+        assert!(
+            plan.selected
+                .iter()
+                .any(|&(_, outpoint)| outpoint == stranded_change),
+            "change past the risky gap must be force-spent too"
+        );
+    }
+
+    /// Rescue must not cost the user their send. A coin worth less than it costs to spend is
+    /// left out of the spendable figure, so forcing it would set a target the selection cannot
+    /// fund and send max would fail outright on a wallet with a full balance.
+    #[test]
+    fn a_stranded_coin_below_its_spend_cost_is_left_alone() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        let dust = f.fund(21, 300, 101); // past the risky gap, under its own spend cost here
+
+        let available =
+            f.wallet
+                .calculate_avaliable_value(f.master_appkey, [f.recipient.clone()], 10.0, true);
+        let plan = match f
+            .wallet
+            .plan_send(f.master_appkey, [(f.recipient.clone(), None)], 10.0)
+        {
+            Ok(plan) => plan,
+            Err(e) => panic!("wallet advertises {available} spendable but send max fails: {e}"),
+        };
+        assert!(
+            !plan.selected.iter().any(|&(_, outpoint)| outpoint == dust),
+            "moving it costs more than it carries, so it stays where it is"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #544 (contains #542–#544; review the tip commit).

A restore discovers history by crawling: from last used index p it derives p+1..=p+20 (BIP44’s gap limit, the strictest convention in common use) and **stalls at the first window with no history**. Any coin above the stall point is invisible to it — including a whole cluster of coins above one wide gap, however dense their own spacing. Letting such coins sit there makes recovery silently lossy.

## Change

- Every outgoing plan consolidates them: `plan_send` **simulates that crawl per keychain** (reach starts at the baseline window; each reachable used index u extends it through u + `RISKY_GAP`; unreachable history extends nothing — recovery is transitive) and **preselects every unreachable utxo in the `CoinSelector`** before the bnb run. Change absorbs the overfunding and lands at a low index — which is what moves the value back inside every scanner's reach. Send-max needs nothing (it already spends everything).
- "Used" is the indexer's `is_used` semantics — spent history resets a restore's gap counter, so it resets ours.
- Defending 20 covers every wider window (bdk’s default 25 included) a fortiori. The threshold sits deliberately below the wallet's own lookahead of 50: a coin past a bigger gap never enters the UTXO set at all, so this is proactive protection for coins the wallet can still see, not rescue for coins it cannot.
- Preselection composes with `bdk_coin_select` 0.4.1 by construction: the selection set holds original candidate indices, the metric's sort only permutes iteration order, and bnb branches only over unselected candidates; the `select_until_target_met` fallback keeps the base selection.

## Tests

Boundary regressions on the existing send fixtures: a gap of 19 forces nothing, exactly 20 forces, a spent-through index chains the windows, and a cluster above one gap is forced whole. Verified end to end on the fork's regtest harness: an ordinary small send sweeps far external and internal coins staged from the exported descriptor, with the change landing at internal index 0.

