### PR TITLE
Device sign prompt discloses self-spend outputs, and both surfaces name them

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -123,14 +123,23 @@ impl CoordSuperWallet {
     }
 
     pub fn is_spk_mine(&self, master_appkey: MasterAppkey, spk: ScriptBuf) -> bool {
-        self.spk_index(master_appkey, spk).is_some()
+        self.spk_path(master_appkey, spk).is_some()
     }
 
-    pub fn spk_index(&self, master_appkey: MasterAppkey, spk: ScriptBuf) -> Option<u32> {
-        self.tx_graph
-            .index
-            .index_of_spk(spk)
-            .and_then(|((key, _), index)| (*key == master_appkey).then_some(*index))
+    /// The derivation this wallet reaches `spk` by, or `None` if it does not reach it.
+    /// The keychain is half the answer: receive #5 and change #5 are different scripts,
+    /// and an index alone cannot say which one was found.
+    pub fn spk_path(
+        &self,
+        master_appkey: MasterAppkey,
+        spk: ScriptBuf,
+    ) -> Option<BitcoinBip32Path> {
+        let &((key, account_keychain), index) = self.tx_graph.index.index_of_spk(spk)?;
+        (key == master_appkey).then(|| BitcoinBip32Path {
+            account_keychain,
+            index: NormalIndex::new(index)
+                .expect("bdk derived this spk, so its index is a normal child"),
+        })
     }
 
     fn descriptors_for_key(

--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -9,7 +9,7 @@ use bitcoin::{
 };
 
 use crate::{
-    tweak::{AppTweak, BitcoinBip32Path},
+    tweak::{AppTweak, BitcoinBip32Path, Keychain},
     MasterAppkey,
 };
 
@@ -302,22 +302,51 @@ impl TransactionTemplate {
             self.fee()
                 .expect("transaction validity should have already been checked"),
         );
-        let foreign_recipients = self
-            .foreign_recipients()
-            .map(|(spk, value)| {
-                (
-                    bitcoin::Address::from_script(spk, network)
-                        .expect("has address representation"),
-                    bitcoin::Amount::from_sat(value),
-                )
-            })
-            .collect::<Vec<_>>();
-
         // Calculate fee rate in sats/vB
         let fee_rate_sats_per_vbyte = self.feerate();
 
+        let any_foreign = self
+            .outputs
+            .iter()
+            .any(|output| matches!(output.owner, SpkOwner::Foreign(_)));
+        let internal_count = self
+            .iter_locally_owned_outputs()
+            .filter(|(_, _, local)| {
+                local.bip32_path.account_keychain.keychain == Keychain::Internal
+            })
+            .count();
+        // A single change output alongside a foreign recipient is the shape of an
+        // ordinary send; disclosing it would train users to skim past their own
+        // outputs. Any other local output — or more than one change output — is
+        // value returning to us that the signer must be shown.
+        let hide_single_change = any_foreign && internal_count == 1;
+
+        let recipients = self
+            .outputs
+            .iter()
+            .filter_map(|output| {
+                let owned = match &output.owner {
+                    SpkOwner::Foreign(_) => None,
+                    SpkOwner::Local(local) => {
+                        if hide_single_change
+                            && local.bip32_path.account_keychain.keychain == Keychain::Internal
+                        {
+                            return None;
+                        }
+                        Some(local.bip32_path)
+                    }
+                };
+                Some(PromptRecipient {
+                    address: bitcoin::Address::from_script(&output.owner.spk(), network)
+                        .expect("has address representation"),
+                    amount: bitcoin::Amount::from_sat(output.value),
+                    owned,
+                })
+            })
+            .collect();
+
         PromptSignBitcoinTx {
-            foreign_recipients,
+            recipients,
             fee,
             fee_rate_sats_per_vbyte,
         }
@@ -325,20 +354,55 @@ impl TransactionTemplate {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct PromptRecipient {
+    pub address: bitcoin::Address,
+    pub amount: bitcoin::Amount,
+    /// `Some` iff the signing wallet itself derives [`address`](Self::address) at this
+    /// path — the prompt renders such a recipient as our own.
+    pub owned: Option<BitcoinBip32Path>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct PromptSignBitcoinTx {
-    pub foreign_recipients: Vec<(bitcoin::Address, bitcoin::Amount)>,
+    /// Disclosed outputs in transaction order. The single change output of an ordinary
+    /// send is not disclosed.
+    pub recipients: Vec<PromptRecipient>,
     pub fee: bitcoin::Amount,
     /// Fee rate in sats/vB
     pub fee_rate_sats_per_vbyte: Option<f64>,
 }
 
 impl PromptSignBitcoinTx {
-    /// Calculate the total amount being sent to foreign recipients
-    pub fn total_sent(&self) -> bitcoin::Amount {
-        self.foreign_recipients
+    /// Total value the prompt itemises as moving.
+    pub fn value_moved(&self) -> bitcoin::Amount {
+        self.recipients.iter().map(|r| r.amount).sum()
+    }
+
+    /// What the proportional high-fee warning is measured against: the value at risk of
+    /// leaving the wallet.
+    ///
+    /// When anything goes to a foreign recipient that is the foreign total alone — outputs
+    /// returning to us are not at risk, and counting them would let a self-payment dilute the
+    /// ratio until a disproportionate fee stopped warning. When nothing leaves, the fee is the
+    /// only value the transaction actually consumes, so the self-spend total is the proxy that
+    /// keeps the warning armed.
+    pub fn value_at_risk(&self) -> bitcoin::Amount {
+        match self.foreign_value() {
+            Some(foreign) => foreign,
+            None => self.value_moved(),
+        }
+    }
+
+    /// The value leaving the wallet, or `None` when nothing does. Whichever arm this takes decides
+    /// both the denominator above and how the warning describes itself, so the two cannot drift.
+    pub fn foreign_value(&self) -> Option<bitcoin::Amount> {
+        let foreign: bitcoin::Amount = self
+            .recipients
             .iter()
-            .map(|(_, amount)| *amount)
-            .sum()
+            .filter(|r| r.owned.is_none())
+            .map(|r| r.amount)
+            .sum();
+        (foreign > bitcoin::Amount::ZERO).then_some(foreign)
     }
 }
 

--- a/frostsnap_core/src/tweak.rs
+++ b/frostsnap_core/src/tweak.rs
@@ -158,6 +158,17 @@ impl BitcoinBip32Path {
             index,
         }
     }
+
+    /// How an output the wallet derives is named to the user: "Receive #3", "Change #2".
+    /// Defined here because the device screen and the app both name it, and one output
+    /// read two ways is a worse answer than either.
+    pub fn label(&self) -> alloc::string::String {
+        let keychain = match self.account_keychain.keychain {
+            Keychain::External => "Receive",
+            Keychain::Internal => "Change",
+        };
+        alloc::format!("{} #{}", keychain, self.index)
+    }
 }
 
 #[derive(
@@ -503,6 +514,7 @@ impl DerivationPathExt for DerivationPath {
 
 #[cfg(test)]
 mod test {
+
     use super::*;
     use alloc::vec::Vec;
     use bitcoin::secp256k1::Secp256k1;

--- a/frostsnap_core/tests/user_prompt.rs
+++ b/frostsnap_core/tests/user_prompt.rs
@@ -1,0 +1,171 @@
+use bitcoin::{Amount, ScriptBuf, TxOut};
+use frostsnap_core::bitcoin_transaction::{LocalSpk, PromptSignBitcoinTx, TransactionTemplate};
+use frostsnap_core::tweak::{BitcoinBip32Path, NormalIndex};
+use frostsnap_core::MasterAppkey;
+use schnorr_fun::fun::G;
+
+fn local_spk(bip32_path: BitcoinBip32Path) -> LocalSpk {
+    LocalSpk {
+        master_appkey: MasterAppkey::derive_from_rootkey(G.normalize()),
+        bip32_path,
+    }
+}
+
+fn template_with_input(input_sats: u64) -> TransactionTemplate {
+    let mut template = TransactionTemplate::new();
+    template.push_imaginary_owned_input(
+        local_spk(BitcoinBip32Path::external(NormalIndex::new(0).unwrap())),
+        Amount::from_sat(input_sats),
+    );
+    template
+}
+
+fn push_foreign(template: &mut TransactionTemplate, sats: u64) {
+    let spk =
+        ScriptBuf::from_hex("5120a62baa9e7c1aeda63492f2129cc8226a39db1bc05a9c11e45a61cb751a11061d")
+            .unwrap();
+    template.push_foreign_output(TxOut {
+        value: Amount::from_sat(sats),
+        script_pubkey: spk,
+    });
+}
+
+fn push_to_self(template: &mut TransactionTemplate, sats: u64, index: u32) {
+    template.push_owned_output(
+        Amount::from_sat(sats),
+        local_spk(BitcoinBip32Path::external(NormalIndex::new(index).unwrap())),
+    );
+}
+
+fn push_change(template: &mut TransactionTemplate, sats: u64, index: u32) {
+    template.push_owned_output(
+        Amount::from_sat(sats),
+        local_spk(BitcoinBip32Path::internal(NormalIndex::new(index).unwrap())),
+    );
+}
+
+fn prompt(template: &TransactionTemplate) -> PromptSignBitcoinTx {
+    template.user_prompt(bitcoin::Network::Bitcoin)
+}
+
+fn summary(prompt: &PromptSignBitcoinTx) -> Vec<(u64, Option<BitcoinBip32Path>)> {
+    prompt
+        .recipients
+        .iter()
+        .map(|r| (r.amount.to_sat(), r.owned))
+        .collect()
+}
+
+#[test]
+fn ordinary_send_hides_the_single_change_output() {
+    let mut template = template_with_input(100_000);
+    push_foreign(&mut template, 60_000);
+    push_change(&mut template, 39_000, 0);
+
+    let prompt = prompt(&template);
+    assert_eq!(summary(&prompt), vec![(60_000, None)]);
+    assert_eq!(prompt.value_moved(), Amount::from_sat(60_000));
+    assert_eq!(prompt.value_at_risk(), Amount::from_sat(60_000));
+}
+
+#[test]
+fn foreign_only_has_no_owned_recipients() {
+    let mut template = template_with_input(100_000);
+    push_foreign(&mut template, 99_000);
+
+    let prompt = prompt(&template);
+    assert_eq!(summary(&prompt), vec![(99_000, None)]);
+    assert_eq!(prompt.value_moved(), Amount::from_sat(99_000));
+    assert_eq!(prompt.value_at_risk(), Amount::from_sat(99_000));
+}
+
+#[test]
+fn send_that_also_pays_our_own_external_address_discloses_it_in_order() {
+    let mut template = template_with_input(100_000);
+    push_foreign(&mut template, 50_000);
+    push_to_self(&mut template, 30_000, 1);
+    push_change(&mut template, 19_000, 0);
+
+    let prompt = prompt(&template);
+    assert_eq!(
+        summary(&prompt),
+        vec![
+            (50_000, None),
+            (
+                30_000,
+                Some(BitcoinBip32Path::external(NormalIndex::new(1).unwrap()))
+            ),
+        ]
+    );
+    assert_eq!(prompt.value_moved(), Amount::from_sat(80_000));
+    // Disclosed but not at risk: counting the self payment would dilute the
+    // proportional ratio, letting a large enough one silence the fee warning.
+    assert_eq!(prompt.value_at_risk(), Amount::from_sat(50_000));
+}
+
+#[test]
+fn pure_self_spend_discloses_everything_including_change() {
+    let mut template = template_with_input(100_000);
+    push_to_self(&mut template, 70_000, 1);
+    push_change(&mut template, 29_000, 0);
+
+    let prompt = prompt(&template);
+    assert_eq!(
+        summary(&prompt),
+        vec![
+            (
+                70_000,
+                Some(BitcoinBip32Path::external(NormalIndex::new(1).unwrap()))
+            ),
+            (
+                29_000,
+                Some(BitcoinBip32Path::internal(NormalIndex::new(0).unwrap()))
+            ),
+        ]
+    );
+    assert_eq!(prompt.value_moved(), Amount::from_sat(99_000));
+    // Nothing leaves, so the fee is the only value consumed and the self total
+    // is what keeps the proportional rule armed rather than dividing by zero.
+    assert_eq!(prompt.value_at_risk(), Amount::from_sat(99_000));
+}
+
+#[test]
+fn consolidation_to_change_only_is_still_disclosed() {
+    let mut template = template_with_input(100_000);
+    push_change(&mut template, 99_000, 0);
+
+    let prompt = prompt(&template);
+    assert_eq!(
+        summary(&prompt),
+        vec![(
+            99_000,
+            Some(BitcoinBip32Path::internal(NormalIndex::new(0).unwrap()))
+        )]
+    );
+}
+
+#[test]
+fn two_change_outputs_with_a_foreign_recipient_are_disclosed() {
+    let mut template = template_with_input(100_000);
+    push_foreign(&mut template, 50_000);
+    push_change(&mut template, 25_000, 0);
+    push_change(&mut template, 24_000, 1);
+
+    let prompt = prompt(&template);
+    assert_eq!(
+        summary(&prompt),
+        vec![
+            (50_000, None),
+            (
+                25_000,
+                Some(BitcoinBip32Path::internal(NormalIndex::new(0).unwrap()))
+            ),
+            (
+                24_000,
+                Some(BitcoinBip32Path::internal(NormalIndex::new(1).unwrap()))
+            ),
+        ]
+    );
+    assert_eq!(prompt.value_moved(), Amount::from_sat(99_000));
+    assert_eq!(prompt.value_at_risk(), Amount::from_sat(50_000));
+}

--- a/frostsnap_widgets/src/demo_widget.rs
+++ b/frostsnap_widgets/src/demo_widget.rs
@@ -428,7 +428,7 @@ macro_rules! demo_widget {
             }
             "sign_prompt" => {
                 use $crate::sign_prompt::SignTxPrompt;
-                use frostsnap_core::bitcoin_transaction::PromptSignBitcoinTx;
+                use frostsnap_core::bitcoin_transaction::{PromptRecipient, PromptSignBitcoinTx};
                 use core::str::FromStr;
 
                 // Create dummy transaction data with all address types
@@ -458,15 +458,29 @@ macro_rules! demo_widget {
                     .unwrap()
                     .assume_checked();
 
+                let recipient = |address: bitcoin::Address, sats: u64| PromptRecipient {
+                    address,
+                    amount: bitcoin::Amount::from_sat(sats),
+                    owned: None,
+                };
                 let prompt = PromptSignBitcoinTx {
-                    foreign_recipients: $crate::alloc::vec![
-                        (p2tr_address, bitcoin::Amount::from_sat(100_000)),   // 0.001 BTC
-                        (p2wsh_address, bitcoin::Amount::from_sat(200_000)),  // 0.002 BTC
-                        (p2wpkh_address, bitcoin::Amount::from_sat(300_000)), // 0.003 BTC
-                        (p2sh_address, bitcoin::Amount::from_sat(400_000)),   // 0.004 BTC
-                        (p2pkh_address, bitcoin::Amount::from_sat(500_000)),  // 0.005 BTC
+                    recipients: $crate::alloc::vec![
+                        recipient(p2tr_address.clone(), 100_000),
+                        recipient(p2wsh_address, 200_000),
+                        recipient(p2wpkh_address, 300_000),
+                        recipient(p2sh_address, 400_000),
+                        recipient(p2pkh_address, 500_000),
+                        // Taproot: an output the wallet derives is always taproot, so a
+                        // non-taproot "to self" is a state the device can never be shown.
+                        PromptRecipient {
+                            address: p2tr_address,
+                            amount: bitcoin::Amount::from_sat(150_000),
+                            owned: Some(frostsnap_core::tweak::BitcoinBip32Path::internal(
+                                frostsnap_core::tweak::NormalIndex::new(3).unwrap(),
+                            )),
+                        },
                     ],
-                    fee: bitcoin::Amount::from_sat(80_000), // 0.00080 BTC (>5% fee triggers warning)
+                    fee: bitcoin::Amount::from_sat(90_000), // >5% of the value moved, so the warning page shows
                     fee_rate_sats_per_vbyte: Some(12.5), // Example: 12.5 sats/vB fee rate
                 };
 

--- a/frostsnap_widgets/src/sign_prompt.rs
+++ b/frostsnap_widgets/src/sign_prompt.rs
@@ -97,23 +97,46 @@ impl AmountPage {
 #[derive(Clone, frostsnap_macros::Widget)]
 pub struct AddressPage {
     #[widget_delegate]
-    center: Center<Padding<Column<(Text<Gray4TextStyle>, AddressDisplay)>>>,
+    center: Center<
+        Padding<
+            Column<(
+                Text<Gray4TextStyle>,
+                AddressDisplay,
+                Option<Text<Gray4TextStyle>>,
+            )>,
+        >,
+    >,
 }
 
 impl AddressPage {
     #[inline(never)]
-    pub fn new_with_seed(index: usize, address: &bitcoin::Address, rand_seed: u32) -> Self {
+    pub fn new_with_seed(
+        index: usize,
+        address: &bitcoin::Address,
+        rand_seed: u32,
+        owned: Option<&BitcoinBip32Path>,
+    ) -> Self {
         let title = Text::new(
             format!("To Address #{}", index + 1),
             Gray4TextStyle::new(FONT_PAGE_HEADER, PALETTE.text_secondary),
         );
+        // Names the keychain rather than printing its number: this is a threshold
+        // wallet, and a bare "1/3" reads as one-of-three signers — a claim about the
+        // access structure, not about where the money went.
+        let footnote = owned.map(|path| {
+            Text::new(
+                path.label(),
+                Gray4TextStyle::new(FONT_TO_SELF_FOOTNOTE, PALETTE.text_secondary),
+            )
+        });
 
         let mixed_seed = rand_seed.wrapping_add((index as u32).wrapping_mul(0x9e3779b9));
         let address_display = AddressDisplay::new_with_seed(address.clone(), mixed_seed);
 
-        let mut column = Column::new((title, address_display))
+        let mut column = Column::new((title, address_display, footnote))
             .with_main_axis_alignment(MainAxisAlignment::Start);
         column.set_gap(0, 10);
+        column.set_gap(1, if owned.is_some() { 8 } else { 0 });
         let padded = Padding::only(column).bottom(40).build();
 
         Self {
@@ -380,6 +403,7 @@ impl WidgetList for SignPromptPageList {
                         recipient_idx,
                         &recipient.address,
                         self.rand_seed,
+                        recipient.owned.as_ref(),
                     )),
                     true,
                 )

--- a/frostsnap_widgets/src/sign_prompt.rs
+++ b/frostsnap_widgets/src/sign_prompt.rs
@@ -14,7 +14,7 @@ use embedded_graphics::{
     geometry::Size,
     pixelcolor::{Gray8, Rgb565},
 };
-use frostsnap_core::bitcoin_transaction::PromptSignBitcoinTx;
+use frostsnap_core::{bitcoin_transaction::PromptSignBitcoinTx, tweak::BitcoinBip32Path};
 use frostsnap_fonts::{
     Gray4Font, NOTO_SANS_17_REGULAR, NOTO_SANS_18_LIGHT, NOTO_SANS_18_MEDIUM, NOTO_SANS_24_BOLD,
 };
@@ -30,6 +30,8 @@ const FONT_CAUTION_TEXT: &Gray4Font = &NOTO_SANS_17_REGULAR;
 const HIGH_FEE_ABSOLUTE_THRESHOLD_SATS: u64 = 100_000;
 const HIGH_FEE_PERCENTAGE_THRESHOLD: u64 = 5;
 const HOLD_TO_SIGN_TIME_MS: u32 = 3000;
+
+const FONT_TO_SELF_FOOTNOTE: &Gray4Font = &NOTO_SANS_17_REGULAR;
 
 /// Widget list that generates sign prompt pages
 #[derive(Clone)]
@@ -48,17 +50,26 @@ pub struct AmountPage {
             Text<Gray4TextStyle>,
             BitcoinAmountDisplay,
             Text<Gray4TextStyle>,
+            Option<Text<Gray4TextStyle>>,
         )>,
     >,
 }
 
 impl AmountPage {
     #[inline(never)]
-    pub fn new(index: usize, amount_sats: u64) -> Self {
+    pub fn new(index: usize, amount_sats: u64, owned: Option<&BitcoinBip32Path>) -> Self {
         let title = Text::new(
             format!("Send Amount #{}", index + 1),
             Gray4TextStyle::new(FONT_PAGE_HEADER, PALETTE.text_secondary),
         );
+        // Under the amount, the whole answer to "where is this value going" is that it
+        // comes back to us; WHICH of our scripts it lands on belongs under the address.
+        let footnote = owned.map(|_| {
+            Text::new(
+                "To Self".to_string(),
+                Gray4TextStyle::new(FONT_TO_SELF_FOOTNOTE, PALETTE.text_secondary),
+            )
+        });
 
         let amount_display = BitcoinAmountDisplay::new(amount_sats);
 
@@ -67,10 +78,14 @@ impl AmountPage {
             Gray4TextStyle::new(FONT_PAGE_HEADER, PALETTE.text_secondary),
         );
 
-        let mut column = Column::new((title, amount_display, btc_text))
+        let mut column = Column::new((title, amount_display, btc_text, footnote))
             .with_main_axis_alignment(MainAxisAlignment::Center)
             .with_cross_axis_alignment(CrossAxisAlignment::Center);
-        column.set_uniform_gap(10);
+        // Gaps keep an unowned page pixel-identical to the pre-footnote layout: the
+        // empty slot contributes no height and no gap.
+        column.set_gap(0, 10);
+        column.set_gap(1, 10);
+        column.set_gap(2, if owned.is_some() { 8 } else { 0 });
 
         Self {
             center: Center::new(column),
@@ -174,7 +189,7 @@ pub struct WarningPage {
 
 impl WarningPage {
     #[inline(never)]
-    fn new(fee_sats: u64, _total_sent: u64) -> Self {
+    fn new(fee_sats: u64, leaves_wallet: bool) -> Self {
         let warning_bmp =
             Bmp::<Gray8>::from_slice(WARNING_ICON_DATA).expect("Failed to load warning icon BMP");
         let warning_icon = Image::new(GrayToAlpha::new(warning_bmp, PALETTE.warning));
@@ -197,12 +212,20 @@ impl WarningPage {
             Gray4TextStyle::new(FONT_CAUTION_TITLE, PALETTE.on_background),
         );
 
+        // The wording must name the quantity the rule divided by: in a mixed send every
+        // output is titled "Send Amount #n", owned ones included, so anything reading as
+        // the total is wrong — the proportional rule uses only what leaves.
         let (line1, line2) = if fee_sats > HIGH_FEE_ABSOLUTE_THRESHOLD_SATS {
             ("Fee is greater".to_string(), "than 0.001 BTC".to_string())
+        } else if leaves_wallet {
+            (
+                "Fee exceeds 5% of".to_string(),
+                "the amount leaving".to_string(),
+            )
         } else {
             (
-                "Fee exceeds 5% of the".to_string(),
-                "amount being sent".to_string(),
+                "Fee exceeds 5% of".to_string(),
+                "the value moved".to_string(),
             )
         };
 
@@ -289,11 +312,11 @@ type SignPromptPage = AnyOf<(
 )>;
 
 impl SignPromptPageList {
-    fn new_with_seed(prompt: PromptSignBitcoinTx, rand_seed: u32) -> Self {
-        let num_recipients = prompt.foreign_recipients.len();
+    pub fn new_with_seed(prompt: PromptSignBitcoinTx, rand_seed: u32) -> Self {
+        let num_recipients = prompt.recipients.len();
         let has_warning = Self::has_high_fee(&prompt);
 
-        let total_pages = num_recipients * 2 + 1 + if has_warning { 1 } else { 0 } + 1;
+        let total_pages = num_recipients * 2 + has_warning as usize + 2;
 
         Self {
             prompt,
@@ -309,16 +332,8 @@ impl SignPromptPageList {
             return true;
         }
 
-        let total_sent: u64 = prompt
-            .foreign_recipients
-            .iter()
-            .map(|(_, amount)| amount.to_sat())
-            .sum();
-        if total_sent > 0 && fee_sats > total_sent * HIGH_FEE_PERCENTAGE_THRESHOLD / 100 {
-            return true;
-        }
-
-        false
+        let at_risk_sats = prompt.value_at_risk().to_sat();
+        at_risk_sats > 0 && fee_sats > at_risk_sats * HIGH_FEE_PERCENTAGE_THRESHOLD / 100
     }
 }
 
@@ -334,45 +349,50 @@ impl WidgetList for SignPromptPageList {
             return None;
         }
 
-        let num_recipients = self.prompt.foreign_recipients.len();
+        let num_recipients = self.prompt.recipients.len();
         let recipient_pages = num_recipients * 2;
         let has_warning = Self::has_high_fee(&self.prompt);
 
+        let warning_page = if has_warning {
+            Some(recipient_pages)
+        } else {
+            None
+        };
+        let fee_page = recipient_pages + has_warning as usize;
+
         let (page, use_fb) = if index < recipient_pages {
             let recipient_idx = index / 2;
+            let recipient = &self.prompt.recipients[recipient_idx];
             let is_amount = index.is_multiple_of(2);
 
             if is_amount {
-                let (_, amount) = &self.prompt.foreign_recipients[recipient_idx];
                 (
-                    SignPromptPage::new(AmountPage::new(recipient_idx, amount.to_sat())),
+                    SignPromptPage::new(AmountPage::new(
+                        recipient_idx,
+                        recipient.amount.to_sat(),
+                        recipient.owned.as_ref(),
+                    )),
                     false,
                 )
             } else {
-                let (address, _) = &self.prompt.foreign_recipients[recipient_idx];
                 (
                     SignPromptPage::new(AddressPage::new_with_seed(
                         recipient_idx,
-                        address,
+                        &recipient.address,
                         self.rand_seed,
                     )),
                     true,
                 )
             }
-        } else if has_warning && index == recipient_pages {
-            let total_sent: u64 = self
-                .prompt
-                .foreign_recipients
-                .iter()
-                .map(|(_, amount)| amount.to_sat())
-                .sum();
+        } else if Some(index) == warning_page {
             (
-                SignPromptPage::new(WarningPage::new(self.prompt.fee.to_sat(), total_sent)),
+                SignPromptPage::new(WarningPage::new(
+                    self.prompt.fee.to_sat(),
+                    self.prompt.foreign_value().is_some(),
+                )),
                 false,
             )
-        } else if (has_warning && index == recipient_pages + 1)
-            || (!has_warning && index == recipient_pages)
-        {
+        } else if index == fee_page {
             (
                 SignPromptPage::new(FeePage::new(
                     self.prompt.fee.to_sat(),

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -82,7 +82,47 @@ class _WalletSendPageState extends State<WalletSendPage> {
     sub.start().listen((_) => mounted ? setState(() {}) : null);
 
     addrController = AddressInputController(state);
+    addrController.controller.addListener(_onRecipientTextChanged);
     amountController = AmountInputController(state: state);
+  }
+
+  // The page doesn't otherwise rebuild while typing — the TextField repaints
+  // itself and AddressInputController only notifies on error changes — so the
+  // pill's visibility needs this poke.
+  void _onRecipientTextChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// Derived, not stored, from whichever recipient is on screen: the raw field
+  /// text while editing (a stale submitted recipient must not keep the pill
+  /// alive), the submitted recipient after advancing (a BIP21 paste's parsed
+  /// address rather than its URI text). Null when the recipient is not ours.
+  String? get ownedRecipientLabel {
+    final submitted = pageIndex.index > SendPageIndex.recipient.index
+        ? state.recipient(recipient: 0)?.address?.toString()
+        : null;
+    return widget.superWallet.ownedAddressLabel(
+      masterAppkey: widget.masterAppkey,
+      addressStr: submitted ?? addrController.controller.text,
+    );
+  }
+
+  /// Quiet tonal chip naming the output the way the signing device will.
+  Widget _toSelfPill(BuildContext context, String label) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 4.0),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        'To self: $label',
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: theme.colorScheme.onSecondaryContainer,
+        ),
+      ),
+    );
   }
 
   @override
@@ -213,6 +253,16 @@ class _WalletSendPageState extends State<WalletSendPage> {
                 textAlign: TextAlign.right,
                 style: monospaceTextStyle,
               ),
+              subtitle: switch (ownedRecipientLabel) {
+                null => null,
+                final label => Padding(
+                  padding: const EdgeInsets.only(top: 4.0),
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: _toSelfPill(context, label),
+                  ),
+                ),
+              },
             ),
           if (pageIndex.index > SendPageIndex.amount.index)
             _buildCompletedAmountAndFee(context),
@@ -303,6 +353,11 @@ class _WalletSendPageState extends State<WalletSendPage> {
                 errorMaxLines: 2,
               ),
             ),
+            if (ownedRecipientLabel case final label?)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: _toSelfPill(context, label),
+              ),
             Row(
               spacing: 8.0,
               children: [

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -190,8 +190,8 @@ impl UnsignedTx {
                 .filter_map(|txout| {
                     let spk = txout.script_pubkey.clone();
                     super_wallet
-                        .spk_index(master_appkey, spk.clone())
-                        .map(|index| (spk, index))
+                        .spk_path(master_appkey, spk.clone())
+                        .map(|path| (spk, path.index.to_u32()))
                 })
                 .collect::<HashMap<_, _>>(),
             inner: raw_tx,

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -154,6 +154,25 @@ impl SuperWallet {
             .search_for_address(master_appkey, address_str, start, stop)
     }
 
+    /// How this wallet names `address_str` if it derives it — "Receive #3", "Change #2" —
+    /// or `None` when the address is not ours, not this network's, or not an address.
+    /// The wording is core's, the same the device's own footnote is built from, so one
+    /// output reads identically in the app and on the screen that signs it.
+    #[frb(sync)]
+    pub fn owned_address_label(
+        &self,
+        master_appkey: MasterAppkey,
+        address_str: String,
+    ) -> Option<String> {
+        let address = address_str.trim().parse::<bitcoin::Address<_>>().ok()?;
+        let address = address.require_network(self.network).ok()?;
+        self.inner
+            .lock()
+            .unwrap()
+            .spk_path(master_appkey, address.script_pubkey())
+            .map(|path| path.label())
+    }
+
     pub fn mark_address_shared(
         &self,
         master_appkey: MasterAppkey,


### PR DESCRIPTION
The device sign prompt modelled "what leaves the wallet to strangers". A transaction with no foreign recipient rendered as two pages — **Network Fee → Hold to Sign** — naming nothing at all, and the proportional high-fee guard short-circuited on the empty recipient list, dead in exactly the case where the fee is the whole cost of the transaction. Two commits on master.

## 1. The device discloses the outputs that come back to us

`PromptSignBitcoinTx` carries one **recipients** list in transaction output order, each entry knowing whether the wallet derives it — computed on the device from the `LocalSpk` keychain already in the sign task, so nothing new crosses the wire. A disclosed output of our own gets the same **Send Amount #n** / **To Address #n** pages as any recipient, with **`To Self`** under the amount.

- **Disclosure**: the single change output of an ordinary send stays undisclosed noise. Our own external addresses, change with no foreign recipient, and **two or more** change outputs are disclosed — several change outputs are not a shape this wallet produces on an ordinary send, so hiding them would hide structure the user never saw.
- **The warning is always armed, and measures value at risk rather than value displayed.** Where anything leaves the wallet, the denominator is the foreign total alone: outputs coming back to us are not at risk, and counting them lets a self-payment dilute the ratio — foreign 200k with a 60k fee warns, and adding a 1M output back to ourselves would silence it on a fee that is 30% of what actually leaves. Where nothing leaves, the fee is the only value the transaction consumes, so the self-spend total keeps the rule armed rather than dividing by zero.
- Unowned pages are pixel-identical to before, no new `AnyOf` variant, and stack-check's largest frame is unchanged at 7872 bytes (24.5% of the 25% cap).

## 2. Naming which of our addresses it pays — on both surfaces

`To Self` says the value comes back but not where, and the app said nothing at all until the device did. Both now name the script: the device prints **`Receive #0`** / **`Change #3`** under the address it derives, and Send carries a pill reading **`To self: Receive #0`**. The wording is `BitcoinBip32Path::label`, defined once because both call it. It names the keychain rather than printing its number — on a threshold device a bare `1/3` is indistinguishable from one-of-three signers, a claim about the access structure rather than about where the money went.

Naming it meant fixing what the wallet's lookup returned: `spk_index` gave `Option<u32>`, an index with the keychain thrown away, so receive #5 and change #5 came back indistinguishable. It is now `spk_path -> Option<BitcoinBip32Path>`, with `is_spk_mine` expressed in terms of it and the one caller that genuinely wants a bare index projecting at its own call site.

> **Two things found and deliberately left alone.** `psbt_to_tx_template` still classifies outputs with `Some(&((_, account_keychain), index))` — ignoring the owning appkey, so with two wallets loaded a PSBT paying wallet B's address, signed by wallet A, builds a `LocalSpk` whose derived spk differs from the real output. `spk_path` is exactly the appkey-scoped accessor that site wants. And `Transaction::is_mine` carries the same discarded keychain, which the tx-details screen renders as `Received at #3`, so a payment received at a change address reads there as a receive index.

## The screens

Device-framebuffer recordings; the last is a desktop capture showing the app and the signer together.

| | |
|---|---|
| Pure self-spend | ![pure self-spend](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-546/18-pure-self-spend.gif) |
| High-fee warning on a self-spend — previously impossible to trigger | ![high fee](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-546/19-high-fee-self-spend.gif) |
| Foreign recipient plus our own external address | ![send plus self](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-546/20-send-plus-self-output.gif) |
| Ordinary send, one change output — the control, unchanged | ![ordinary send](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-546/15-ordinary-send.gif) |

Pill and device naming the same output identically, ending with a cold-start relaunch where the pill still appears immediately:

![pill and device agree](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-546/23-to-self-named.gif)

## Verification

`lint-ordinary`, `test-ordinary --release --all-features`, `lint-device`, legacy + frontier firmware, `stack-check --max-pct 25`, `lint-app`. Tests: 6 core policy tests over `user_prompt` (classification, ordering, disclosure), `label()` pinned to its exact wording since that string is the contract between the two surfaces, and `spk_path` pinned to return the whole path for both keychains and `None` for another appkey. The app-side behaviour — pill present for our address, absent for a foreign one, gone again after swapping back, and present on a cold start — is driven end to end against a real regtest wallet in the fork's `self_send_recognition` driver, which is what produced the capture above.
