### PR TITLE
[coord] Test that a synced coin stays spendable after a restart

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -542,6 +542,103 @@ mod test {
         assert_eq!(paid, planned, "the amount shown is the amount paid");
     }
 
+    /// A reveal the wallet only learned about from a sync must survive a restart, and the coin it
+    /// makes visible must stay spendable. The reveal was the exact changeset `apply_update`
+    /// discarded, so every reload re-indexed stored txs against a too-narrow window and the coin
+    /// showed in the balance but never in coin selection.
+    #[test]
+    fn a_synced_reveal_survives_a_restart_and_its_coin_stays_spendable() {
+        const VALUE: u64 = 1_000_000;
+
+        let db = Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()));
+        let master_appkey =
+            MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
+        let recipient = bitcoin::Address::from_str("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+            .unwrap()
+            .require_network(NETWORK)
+            .unwrap();
+        let external = (master_appkey, BitcoinAccountKeychain::external());
+        let blocks = [
+            BlockId {
+                height: 0,
+                hash: bitcoin::constants::genesis_block(NETWORK).block_hash(),
+            },
+            BlockId {
+                height: 100,
+                hash: BlockHash::from_byte_array([100u8; 32]),
+            },
+        ];
+
+        // First run: a sync reports activity at an index the wallet had not revealed itself.
+        let far;
+        {
+            let (client, _handler) = chain_client(&db);
+            let mut wallet = CoordSuperWallet::load_or_init(db.clone(), NETWORK, client).unwrap();
+            wallet.list_addresses(master_appkey);
+
+            // Past the window the wallet re-derives at load, so only the persisted reveal can
+            // bring the coin back: inside it the load-time re-index finds the coin unaided and the
+            // test would pass with or without the fix. Read off the wallet rather than written as
+            // a literal, so widening the lookahead cannot quietly make this vacuous.
+            far = wallet.lookahead() + 10;
+
+            let tx = bitcoin::Transaction {
+                version: bitcoin::transaction::Version::TWO,
+                lock_time: bitcoin::absolute::LockTime::ZERO,
+                input: vec![TxIn::default()],
+                output: vec![TxOut {
+                    value: Amount::from_sat(VALUE),
+                    script_pubkey: crate::bitcoin::peek_spk(
+                        master_appkey,
+                        BitcoinBip32Path {
+                            account_keychain: BitcoinAccountKeychain::external(),
+                            index: far,
+                        },
+                    ),
+                }],
+            };
+            let mut tx_update = TxUpdate::default();
+            tx_update.txs = vec![Arc::new(tx.clone())];
+            tx_update.anchors = [(
+                ConfirmationBlockTime {
+                    block_id: blocks[1],
+                    confirmation_time: 1_700_000_000,
+                },
+                tx.compute_txid(),
+            )]
+            .into();
+
+            wallet
+                .apply_update(bdk_electrum_streaming::Update {
+                    tx_update,
+                    last_active_indices: [(external, far)].into(),
+                    chain_update: Some(CheckPoint::from_block_ids(blocks).unwrap()),
+                })
+                .unwrap();
+
+            assert!(
+                wallet.calculate_avaliable_value(master_appkey, [recipient.clone()], 1.0, true) > 0,
+                "the coin is spendable in the session that discovered it"
+            );
+        }
+
+        // Restart: same database, fresh wallet.
+        let (client, _handler) = chain_client(&db);
+        let mut wallet = CoordSuperWallet::load_or_init(db.clone(), NETWORK, client).unwrap();
+        wallet.list_addresses(master_appkey);
+
+        assert_eq!(
+            wallet.tx_graph.index.last_revealed_index(external),
+            Some(far),
+            "the frontier the sync established must be on disk"
+        );
+        let available = wallet.calculate_avaliable_value(master_appkey, [recipient], 1.0, true);
+        assert!(
+            available > 0,
+            "balance and send max must agree across a restart; send max saw {available}"
+        );
+    }
+
     #[test]
     fn a_plan_outlived_by_its_coins_errors_instead_of_committing() {
         let mut f = Fixture::new();


### PR DESCRIPTION
This is @nickfarrow's test from LLFourn/frostsnap#18, carried to this repo now that the fix it pins (#543) has merged here. The regression belongs next to the fix rather than in a fork branch. The commit keeps him as author.

A coin arrives at an address the wallet only knows about because a sync reported it, the app restarts, and the coin must still be spendable. That is the invariant `apply_update` broke by computing the reveal changeset from `reveal_to_target_multi`, using it only for the `changed` flag, and dropping it: the frontier a sync taught us was RAM-only, so after a restart the stored txs re-indexed against a stale window. Balance re-derives from the spk map and healed itself every session; coin selection reads the outpoint set, which does not. Full balance shown, nothing spendable.

The test asserts both layers — that the frontier is on disk, and that send max can still see the coin — so a failure says which one broke.

**One change from #18.** The coin's index is read off `wallet.lookahead()` rather than written as the literal `60`. `60` was correct against today's lookahead of `50`, but the two are independent numbers in different files: raise the lookahead past `60` and the load-time re-index finds the coin unaided, so the test passes whether or not the fix is present. Verified rather than argued — with `changeset.indexer.merge` ablated and `KeychainTxOutIndex::new(50, false)` raised to `100`, the literal version passes and the derived version still fails.

Evidence run locally on `f0e6bdb0`:

- `cargo test -p frostsnap_coordinator bitcoin::send` — 8/8 pass.
- Ablate `changeset.indexer.merge(indexer_changeset)` (`wallet.rs:404`) → fails with *"the frontier the sync established must be on disk"*.
- Ablate it **and** widen the lookahead 50 → 100 → still fails.
- `cargo fmt --check` and `cargo clippy --all-features --tests` clean.

Test-only, so no media.
