### PR TITLE
Recover change a gap-limit restore missed and make it spendable again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_electrum_streaming"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e86daa7b72258672522b521569386692d51ef70b5a4e879cdd8e6a6caa427f"
+checksum = "a16576b1efa0960f4c6d65d588005889ee9bee600d47540adca62d21003154bc"
 dependencies = [
  "anyhow",
  "bdk_core",

--- a/frostsnap_coordinator/Cargo.toml
+++ b/frostsnap_coordinator/Cargo.toml
@@ -23,7 +23,7 @@ rsa.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 
 bdk_chain = { version = "0.23.3", features = ["rusqlite"] }
-bdk_electrum_streaming = { version = "0.5.2" }
+bdk_electrum_streaming = { version = "0.5.3" }
 bdk_coin_select = { version = "0.4.1" }
 
 

--- a/frostsnap_coordinator/src/bitcoin.rs
+++ b/frostsnap_coordinator/src/bitcoin.rs
@@ -2,8 +2,11 @@ pub mod chain_sync;
 mod handler_state;
 pub mod outgoing;
 pub mod psbt;
+pub mod recovery_scan;
 pub mod send;
 pub mod status_tracker;
+#[cfg(test)]
+pub(crate) mod test_util;
 pub mod tofu;
 pub mod wallet;
 mod wallet_persist;

--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -182,6 +182,9 @@ impl ChainClient {
         block_on(response)?
     }
 
+    /// Track `keychain` through `next_index` plus lookahead. Re-calling with a larger
+    /// `next_index` widens the live subscription window in place (bdk_electrum_streaming
+    /// >= 0.5.3); equal or smaller is a no-op, so the window never narrows.
     pub fn monitor_keychain(&self, keychain: KeychainId, next_index: u32) {
         self.start_client();
         let descriptor = descriptor_for_account_keychain(
@@ -413,8 +416,24 @@ impl ConnectionHandler {
                     continue;
                 }
             };
-            if changed {
-                for master_appkey in master_appkeys {
+            for master_appkey in master_appkeys {
+                // A sync can deliver an outgoing tx whose change is stranded past the reveal
+                // frontier; reconcile before emitting so the txs below already carry the
+                // recovered attributions. Not gated on `changed`: for a wallet whose stranded
+                // tx is already persisted, every update is a no-op changeset and this is the
+                // only automatic caller. Cheap when nothing new arrived.
+                let recovered = match wallet.recovery_scan(master_appkey) {
+                    Ok(report) => !report.revealed.is_empty(),
+                    Err(err) => {
+                        tracing::error!(
+                            master_appkey = master_appkey.to_redacted_string(),
+                            error = err.to_string(),
+                            "recovery scan after sync failed"
+                        );
+                        false
+                    }
+                };
+                if changed || recovered {
                     let txs = wallet.list_transactions(master_appkey);
                     action(master_appkey, txs);
                 }
@@ -714,4 +733,203 @@ pub enum ChainStatusState {
     Connecting,
     Connected,
     Disconnected,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::bitcoin::test_util::{
+        foreign_spk, test_chain_client, test_db, tx_paying, Fixture, EXTERNAL, INTERNAL,
+    };
+    use bdk_chain::bitcoin::OutPoint;
+    use bdk_electrum_streaming::electrum_streaming_client::ElectrumScriptHash;
+    use bdk_electrum_streaming::ClientAction;
+    use frostsnap_core::schnorr_fun::fun::Point;
+    use frostsnap_core::tweak::{BitcoinAccountKeychain, BitcoinBip32Path};
+
+    fn test_client() -> (ChainClient, ConnectionHandler) {
+        test_chain_client(&test_db())
+    }
+
+    fn spk_hash_at(keychain: KeychainId, index: u32) -> ElectrumScriptHash {
+        let spk = crate::bitcoin::peek_spk(
+            keychain.0,
+            BitcoinBip32Path {
+                account_keychain: keychain.1,
+                index,
+            },
+        );
+        ElectrumScriptHash::new(&spk)
+    }
+
+    /// Pins the upstream contract the recovery scan's monitoring handoff rides on
+    /// (bdk_electrum_streaming >= 0.5.3): re-inserting the SAME descriptor with a larger
+    /// `next_index` widens the tracked window in place, and equal or smaller never narrows it.
+    #[test]
+    fn re_tracking_a_descriptor_widens_and_never_narrows() {
+        let master_appkey =
+            MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
+        let keychain = (master_appkey, BitcoinAccountKeychain::internal());
+        let lookahead = 50;
+        let descriptor = descriptor_for_account_keychain(keychain, bitcoin::NetworkKind::Main);
+
+        let mut tracker = DerivedSpkTracker::new(lookahead);
+        tracker.insert_descriptor(keychain, descriptor.clone(), 5);
+        assert_eq!(tracker.index_of_spk_hash(spk_hash_at(keychain, 900)), None);
+
+        let widened = tracker.insert_descriptor(keychain, descriptor.clone(), 901);
+        assert!(
+            !widened.is_empty(),
+            "widening must hand back new hashes to subscribe"
+        );
+        assert_eq!(
+            tracker.index_of_spk_hash(spk_hash_at(keychain, 900)),
+            Some((keychain, 900)),
+            "the matched index must be watched"
+        );
+        assert_eq!(
+            tracker.index_of_spk_hash(spk_hash_at(keychain, 901 + lookahead + 1)),
+            Some((keychain, 901 + lookahead + 1)),
+            "lookahead extends past next_index"
+        );
+        assert_eq!(
+            tracker.index_of_spk_hash(spk_hash_at(keychain, 901 + lookahead + 2)),
+            None
+        );
+
+        assert!(
+            tracker
+                .insert_descriptor(keychain, descriptor, 5)
+                .is_empty(),
+            "a smaller next_index must be a no-op"
+        );
+        assert_eq!(
+            tracker.index_of_spk_hash(spk_hash_at(keychain, 900)),
+            Some((keychain, 900)),
+            "the window must never narrow"
+        );
+    }
+
+    #[test]
+    fn monitor_keychain_forwards_the_widened_window() {
+        let (client, mut handler) = test_client();
+        let master_appkey =
+            MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
+        let keychain = (master_appkey, BitcoinAccountKeychain::external());
+
+        client.monitor_keychain(keychain, 5);
+        assert!(matches!(
+            handler.client_recv.try_recv().unwrap(),
+            ClientAction::AddDescriptor { next_index: 5, .. }
+        ));
+
+        client.monitor_keychain(keychain, 901);
+        assert!(matches!(
+            handler.client_recv.try_recv().unwrap(),
+            ClientAction::AddDescriptor {
+                next_index: 901,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn a_sync_update_triggers_the_recovery_scan() {
+        let fixture = Fixture::new();
+        let wallet = Arc::new(sync::Mutex::new(fixture.wallet()));
+
+        let receive = tx_paying(vec![], vec![(fixture.spk(EXTERNAL(), 0), 100_000)]);
+        let burn = tx_paying(
+            vec![OutPoint {
+                txid: receive.compute_txid(),
+                vout: 0,
+            }],
+            vec![
+                (foreign_spk(), 60_000),
+                (fixture.spk(INTERNAL(), 800), 30_000),
+            ],
+        );
+        let burn_txid = burn.compute_txid();
+
+        let (update_tx, update_rx) = mpsc::unbounded();
+        update_tx
+            .unbounded_send(fixture.update(vec![receive], 100, Some((EXTERNAL(), 0))))
+            .unwrap();
+        // the spend shows up in external 0's history, which is what attributes it to the key
+        update_tx
+            .unbounded_send(fixture.update(vec![burn], 101, Some((EXTERNAL(), 0))))
+            .unwrap();
+        drop(update_tx);
+
+        let emitted: Arc<sync::Mutex<Vec<Vec<crate::bitcoin::wallet::Transaction>>>> =
+            Default::default();
+        ConnectionHandler::handle_wallet_updates(wallet.clone(), update_rx, {
+            let emitted = emitted.clone();
+            move |_, txs| emitted.lock().unwrap().push(txs)
+        });
+
+        let wallet = wallet.lock().unwrap();
+        assert_eq!(
+            wallet
+                .tx_graph
+                .index
+                .last_revealed_index((fixture.master_appkey, INTERNAL())),
+            Some(800),
+            "the update handler must run the recovery scan"
+        );
+        let emitted = emitted.lock().unwrap();
+        let last = emitted.last().unwrap();
+        let burn_row = last.iter().find(|tx| tx.txid == burn_txid).unwrap();
+        assert!(
+            !burn_row.is_mine.is_empty(),
+            "the emitted txs must already carry the recovered attribution"
+        );
+    }
+
+    /// An upgraded wallet can hold a stranded outgoing tx that is already fully persisted:
+    /// every sync then applies as an empty changeset, and an update naming the key is the only
+    /// signal there is. Recovery must not be gated on the changeset.
+    #[test]
+    fn a_no_op_update_still_triggers_the_recovery_scan() {
+        let fixture = Fixture::new();
+        let mut prepopulated = fixture.wallet();
+        let (_, burn_txid) = crate::bitcoin::test_util::fund_and_burn(
+            &fixture,
+            &mut prepopulated,
+            Some((800, 30_000)),
+        );
+        drop(prepopulated);
+        let wallet = Arc::new(sync::Mutex::new(fixture.wallet()));
+
+        let (update_tx, update_rx) = mpsc::unbounded();
+        update_tx
+            .unbounded_send(bdk_electrum_streaming::Update {
+                tx_update: bdk_chain::TxUpdate::default(),
+                chain_update: None,
+                last_active_indices: [((fixture.master_appkey, EXTERNAL()), 0)].into(),
+            })
+            .unwrap();
+        drop(update_tx);
+
+        let emitted: Arc<sync::Mutex<Vec<Vec<crate::bitcoin::wallet::Transaction>>>> =
+            Default::default();
+        ConnectionHandler::handle_wallet_updates(wallet.clone(), update_rx, {
+            let emitted = emitted.clone();
+            move |_, txs| emitted.lock().unwrap().push(txs)
+        });
+
+        let wallet = wallet.lock().unwrap();
+        assert_eq!(
+            wallet
+                .tx_graph
+                .index
+                .last_revealed_index((fixture.master_appkey, INTERNAL())),
+            Some(800),
+            "an empty changeset must not skip the scan"
+        );
+        let emitted = emitted.lock().unwrap();
+        let last = emitted.last().expect("recovery alone must emit");
+        let burn_row = last.iter().find(|tx| tx.txid == burn_txid).unwrap();
+        assert!(!burn_row.is_mine.is_empty());
+    }
 }

--- a/frostsnap_coordinator/src/bitcoin/recovery_scan.rs
+++ b/frostsnap_coordinator/src/bitcoin/recovery_scan.rs
@@ -1,0 +1,512 @@
+//! Finds change that a gap-limit restore missed and makes it spendable again.
+//!
+//! An outgoing transaction is discoverable even when its change is not: a transaction is ours
+//! if we own a spent prevout, so the change script of every outgoing transaction is already
+//! sitting in the local graph as an unattributed txout. Recovering it is therefore a purely
+//! local comparison against candidate scripts derived past the reveal frontier — the network
+//! holds no information we lack.
+
+use super::wallet::{CoordSuperWallet, KeychainId, WalletIndexedTxGraphChangeSet};
+use anyhow::Result;
+use bdk_chain::{
+    bitcoin::{self, ScriptBuf, Txid},
+    indexer::keychain_txout,
+    CanonicalizationParams, Indexer, Merge, SpkIterator,
+};
+use frostsnap_core::{tweak::BitcoinAccountKeychain, MasterAppkey};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::Arc;
+use tracing::{event, Level};
+
+/// How many indices past the reveal frontier each keychain's candidates are derived. Applied per
+/// keychain rather than shared across them: derivation is local and near-free, so the budget is
+/// about coverage, not cost.
+pub const RECOVERY_SCAN_STOP_GAP: u32 = 1000;
+
+/// Scan progress, persisted apart from wallet derivation state.
+///
+/// Progress must never ride in `last_revealed`: persisting an unused frontier advances this
+/// database's address allocation, manufacturing the very gap the scan exists to heal. This state
+/// changes on every scan — matched or not — while derivation state changes only on a match.
+///
+/// Rows exist only while transactions are outstanding: `compared` records the candidate index
+/// every outstanding transaction has been compared up to, so an unchanged wallet can skip the
+/// derivation work entirely on the next scan.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RecoveryScanState {
+    pub(super) compared: BTreeMap<KeychainId, u32>,
+    pub(super) outstanding: BTreeMap<MasterAppkey, BTreeSet<Txid>>,
+}
+
+impl RecoveryScanState {
+    pub(super) fn apply_update(&mut self, update: &RecoveryScanUpdate) {
+        self.compared
+            .retain(|(key, _), _| *key != update.master_appkey);
+        for (&account_keychain, &index) in &update.compared {
+            self.compared
+                .insert((update.master_appkey, account_keychain), index);
+        }
+        if update.outstanding.is_empty() {
+            self.outstanding.remove(&update.master_appkey);
+        } else {
+            self.outstanding
+                .insert(update.master_appkey, update.outstanding.clone());
+        }
+    }
+
+    fn key_snapshot(&self, master_appkey: MasterAppkey) -> RecoveryScanUpdate {
+        RecoveryScanUpdate {
+            master_appkey,
+            compared: self
+                .compared
+                .iter()
+                .filter(|((key, _), _)| *key == master_appkey)
+                .map(|((_, account_keychain), &index)| (*account_keychain, index))
+                .collect(),
+            outstanding: self
+                .outstanding
+                .get(&master_appkey)
+                .cloned()
+                .unwrap_or_default(),
+        }
+    }
+}
+
+/// Replaces one key's scan progress.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecoveryScanUpdate {
+    pub master_appkey: MasterAppkey,
+    pub compared: BTreeMap<BitcoinAccountKeychain, u32>,
+    pub outstanding: BTreeSet<Txid>,
+}
+
+/// What one [`CoordSuperWallet::recovery_scan`] call did and what it could not resolve.
+#[derive(Debug, Clone, Default)]
+pub struct RecoveryScanReport {
+    /// Keychains a match advanced, with their new frontier.
+    pub revealed: BTreeMap<BitcoinAccountKeychain, u32>,
+    /// Outgoing transactions still missing an owned output after the budget — the honest
+    /// "there may be funds we cannot see" set.
+    pub outstanding: BTreeSet<Txid>,
+    /// False when persisted progress already covered the wallet's current state and nothing was
+    /// derived or compared.
+    pub did_compare: bool,
+}
+
+impl CoordSuperWallet {
+    /// Find change on outgoing transactions that a gap-limit restore left unattributed, reveal
+    /// the matched indices and make the coins spendable.
+    ///
+    /// Detection, candidate derivation and comparison are all local; the network is never asked
+    /// about candidates. On a match the reveal frontier advances exactly to the highest matched
+    /// index and every stored transaction is re-indexed against the expanded script set.
+    /// Iterates until every flagged transaction is reconciled or the budget is exhausted;
+    /// whatever remains is reported as outstanding. Progress is durable, so a scan over an
+    /// unchanged wallet does no work.
+    pub fn recovery_scan(&mut self, master_appkey: MasterAppkey) -> Result<RecoveryScanReport> {
+        self.lazily_initialize_key(master_appkey);
+        let account_keychains = [
+            BitcoinAccountKeychain::external(),
+            BitcoinAccountKeychain::internal(),
+        ];
+
+        let mut report = RecoveryScanReport::default();
+
+        let final_unreconciled = loop {
+            let unreconciled = self.unreconciled_txs(master_appkey);
+            if unreconciled.is_empty() {
+                break unreconciled;
+            }
+
+            let ranges = account_keychains.map(|account_keychain| {
+                let keychain_id = (master_appkey, account_keychain);
+                let frontier = self.tx_graph.index.last_revealed_index(keychain_id);
+                let start = frontier.map_or(0, |f| f + 1);
+                let end = frontier.map_or(RECOVERY_SCAN_STOP_GAP - 1, |f| {
+                    f.saturating_add(RECOVERY_SCAN_STOP_GAP)
+                });
+                (keychain_id, start..=end)
+            });
+
+            let covered = {
+                let outstanding = self
+                    .recovery_scan_state
+                    .outstanding
+                    .get(&master_appkey)
+                    .cloned()
+                    .unwrap_or_default();
+                unreconciled.keys().all(|txid| outstanding.contains(txid))
+                    && ranges.iter().all(|(keychain_id, range)| {
+                        self.recovery_scan_state.compared.get(keychain_id).copied()
+                            >= Some(*range.end())
+                    })
+            };
+            if covered {
+                break unreconciled;
+            }
+            report.did_compare = true;
+
+            let target_spks: HashSet<&ScriptBuf> = unreconciled
+                .values()
+                .flat_map(|tx| tx.output.iter().map(|txout| &txout.script_pubkey))
+                .collect();
+
+            let mut matches = BTreeMap::<KeychainId, u32>::new();
+            for (keychain_id, range) in &ranges {
+                let descriptor = super::descriptor_for_account_keychain(
+                    *keychain_id,
+                    // spks don't depend on the network
+                    bitcoin::NetworkKind::Main,
+                );
+                for (index, spk) in SpkIterator::new_with_range(descriptor, range.clone()) {
+                    if target_spks.contains(&spk) {
+                        // ascending, so the last hit is the highest
+                        matches.insert(*keychain_id, index);
+                    }
+                }
+            }
+
+            if matches.is_empty() {
+                let mut db = self.db.lock().unwrap();
+                self.recovery_scan_state.mutate(&mut db, |state| {
+                    let update = RecoveryScanUpdate {
+                        master_appkey,
+                        compared: ranges
+                            .iter()
+                            .map(|((_, account_keychain), range)| (*account_keychain, *range.end()))
+                            .collect(),
+                        outstanding: unreconciled.keys().copied().collect(),
+                    };
+                    state.apply_update(&update);
+                    Ok(((), update))
+                })?;
+                break unreconciled;
+            }
+
+            event!(
+                Level::INFO,
+                master_appkey = master_appkey.to_redacted_string(),
+                ?matches,
+                "recovery scan matched stranded change"
+            );
+
+            {
+                let mut db = self.db.lock().unwrap();
+                self.tx_graph.mutate(&mut db, |tx_graph| {
+                    let mut indexer_changeset = keychain_txout::ChangeSet::default();
+                    for (&keychain_id, &target) in &matches {
+                        let (_, changeset) = tx_graph
+                            .index
+                            .reveal_to_target(keychain_id, target)
+                            .expect("keychain initialized above");
+                        indexer_changeset.merge(changeset);
+                    }
+                    // bdk indexes a tx only against the spks derived at that moment, so a reveal
+                    // strands the outputs of txs already in the graph unless every one is
+                    // re-indexed — and any stored tx may pay a newly derived index, not just the
+                    // tx that triggered the match.
+                    let txs = tx_graph
+                        .graph()
+                        .full_txs()
+                        .map(|tx_node| tx_node.tx.clone())
+                        .collect::<Vec<_>>();
+                    for tx in &txs {
+                        indexer_changeset.merge(tx_graph.index.index_tx(tx));
+                    }
+                    Ok((
+                        (),
+                        WalletIndexedTxGraphChangeSet {
+                            indexer: indexer_changeset,
+                            ..Default::default()
+                        },
+                    ))
+                })?;
+            }
+
+            for &keychain_id in matches.keys() {
+                let frontier = self
+                    .tx_graph
+                    .index
+                    .last_revealed_index(keychain_id)
+                    .expect("just revealed");
+                report.revealed.insert(keychain_id.1, frontier);
+            }
+            // matching extends reach: a newly indexed output can make an already-stored
+            // descendant spend outgoing-and-unreconciled, so go around again
+        };
+
+        for (&account_keychain, &frontier) in &report.revealed {
+            self.chain_client
+                .monitor_keychain((master_appkey, account_keychain), frontier + 1);
+        }
+
+        report.outstanding = final_unreconciled.keys().copied().collect();
+
+        let snapshot = RecoveryScanUpdate {
+            master_appkey,
+            compared: if final_unreconciled.is_empty() {
+                BTreeMap::new()
+            } else {
+                self.recovery_scan_state
+                    .key_snapshot(master_appkey)
+                    .compared
+            },
+            outstanding: report.outstanding.clone(),
+        };
+        if snapshot != self.recovery_scan_state.key_snapshot(master_appkey) {
+            let mut db = self.db.lock().unwrap();
+            self.recovery_scan_state.mutate(&mut db, |state| {
+                state.apply_update(&snapshot);
+                Ok(((), snapshot))
+            })?;
+        }
+
+        Ok(report)
+    }
+
+    /// Outgoing (a prevout is ours) with more than one output, none of them ours: the change has
+    /// to be somewhere, and it isn't attributed to us. Single-output spends are deliberately not
+    /// flagged — send-max legitimately has no change.
+    fn unreconciled_txs(
+        &self,
+        master_appkey: MasterAppkey,
+    ) -> BTreeMap<Txid, Arc<bitcoin::Transaction>> {
+        self.tx_graph
+            .graph()
+            .list_ordered_canonical_txs(
+                self.chain.as_ref(),
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+            )
+            .filter_map(|canonical_tx| {
+                let tx = &canonical_tx.tx_node.tx;
+                if tx.output.len() < 2 {
+                    return None;
+                }
+                let any_output_ours = tx.output.iter().any(|txout| {
+                    self.spk_index(master_appkey, txout.script_pubkey.clone())
+                        .is_some()
+                });
+                if any_output_ours {
+                    return None;
+                }
+                let spends_ours = tx.input.iter().any(|txin| {
+                    self.tx_graph
+                        .graph()
+                        .get_txout(txin.previous_output)
+                        .is_some_and(|txout| {
+                            self.spk_index(master_appkey, txout.script_pubkey.clone())
+                                .is_some()
+                        })
+                });
+                spends_ours.then(|| (canonical_tx.tx_node.txid, canonical_tx.tx_node.tx.clone()))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::bitcoin::test_util::{
+        foreign_spk, fund_and_burn, last_revealed_rows, tx_paying, unspent_sum, Fixture, EXTERNAL,
+        INTERNAL,
+    };
+    use bdk_chain::bitcoin::{hashes::Hash, OutPoint};
+
+    #[test]
+    fn no_match_mutates_nothing_but_records_progress() {
+        let fixture = Fixture::new();
+        let mut wallet = fixture.wallet();
+        let (_, burn_txid) = fund_and_burn(&fixture, &mut wallet, None);
+
+        let frontier_rows_before = last_revealed_rows(&fixture.db);
+        let external = (fixture.master_appkey, EXTERNAL());
+        let internal = (fixture.master_appkey, INTERNAL());
+        assert_eq!(wallet.tx_graph.index.last_revealed_index(external), Some(0));
+        assert_eq!(wallet.tx_graph.index.last_revealed_index(internal), None);
+
+        let report = wallet.recovery_scan(fixture.master_appkey).unwrap();
+
+        assert!(report.did_compare);
+        assert!(report.revealed.is_empty());
+        assert_eq!(report.outstanding, BTreeSet::from([burn_txid]));
+        assert_eq!(wallet.tx_graph.index.last_revealed_index(external), Some(0));
+        assert_eq!(wallet.tx_graph.index.last_revealed_index(internal), None);
+        assert_eq!(last_revealed_rows(&fixture.db), frontier_rows_before);
+
+        let state = fixture.reload_scan_state();
+        assert_eq!(
+            state.compared,
+            BTreeMap::from([(external, 1000), (internal, 999)])
+        );
+        assert_eq!(
+            state.outstanding,
+            BTreeMap::from([(fixture.master_appkey, BTreeSet::from([burn_txid]))])
+        );
+    }
+
+    #[test]
+    fn match_reveals_to_matched_index_and_no_farther() {
+        let fixture = Fixture::new();
+        let mut wallet = fixture.wallet();
+        let (_, _) = fund_and_burn(&fixture, &mut wallet, Some((800, 30_000)));
+
+        assert_eq!(
+            unspent_sum(&wallet, fixture.master_appkey),
+            0,
+            "the change is past the derived window, so nothing should be spendable yet"
+        );
+
+        let report = wallet.recovery_scan(fixture.master_appkey).unwrap();
+
+        assert!(report.did_compare);
+        assert!(report.outstanding.is_empty());
+        assert_eq!(report.revealed, BTreeMap::from([(INTERNAL(), 800)]));
+        assert_eq!(
+            wallet
+                .tx_graph
+                .index
+                .last_revealed_index((fixture.master_appkey, INTERNAL())),
+            Some(800),
+            "frontier must land exactly on the matched index, never the scan budget"
+        );
+        assert_eq!(
+            wallet
+                .tx_graph
+                .index
+                .last_revealed_index((fixture.master_appkey, EXTERNAL())),
+            Some(0)
+        );
+        assert_eq!(unspent_sum(&wallet, fixture.master_appkey), 30_000);
+
+        let state = fixture.reload_scan_state();
+        assert_eq!(state, RecoveryScanState::default());
+    }
+
+    #[test]
+    fn match_reindexes_every_stored_tx_not_just_the_trigger() {
+        let fixture = Fixture::new();
+        let mut wallet = fixture.wallet();
+
+        let stray = tx_paying(
+            vec![OutPoint {
+                txid: Txid::from_byte_array([7u8; 32]),
+                vout: 0,
+            }],
+            vec![(fixture.spk(INTERNAL(), 700), 40_000)],
+        );
+        let stray_txid = stray.compute_txid();
+        fixture.deliver(&mut wallet, vec![stray], 99, None);
+
+        fund_and_burn(&fixture, &mut wallet, Some((800, 30_000)));
+
+        assert!(
+            !wallet
+                .list_transactions(fixture.master_appkey)
+                .iter()
+                .any(|tx| tx.txid == stray_txid),
+            "the stray tx must be invisible before the scan"
+        );
+
+        wallet.recovery_scan(fixture.master_appkey).unwrap();
+
+        assert_eq!(
+            unspent_sum(&wallet, fixture.master_appkey),
+            70_000,
+            "the stray output below the new frontier must become spendable too"
+        );
+        assert!(wallet
+            .list_transactions(fixture.master_appkey)
+            .iter()
+            .any(|tx| tx.txid == stray_txid));
+    }
+
+    #[test]
+    fn restart_resumes_from_the_scan_table() {
+        let fixture = Fixture::new();
+        let mut wallet = fixture.wallet();
+        let (_, burn_txid) = fund_and_burn(&fixture, &mut wallet, None);
+
+        let first = wallet.recovery_scan(fixture.master_appkey).unwrap();
+        assert!(first.did_compare);
+
+        let again = wallet.recovery_scan(fixture.master_appkey).unwrap();
+        assert!(!again.did_compare, "unchanged wallet, same session");
+        assert_eq!(again.outstanding, BTreeSet::from([burn_txid]));
+
+        drop(wallet);
+        let mut wallet = fixture.wallet();
+        let after_restart = wallet.recovery_scan(fixture.master_appkey).unwrap();
+        assert!(
+            !after_restart.did_compare,
+            "progress must come back from the scan table, not be redone"
+        );
+        assert_eq!(after_restart.outstanding, BTreeSet::from([burn_txid]));
+        assert_eq!(
+            wallet
+                .tx_graph
+                .index
+                .last_revealed_index((fixture.master_appkey, INTERNAL())),
+            None,
+            "scan progress must not ride in last_revealed"
+        );
+    }
+
+    #[test]
+    fn one_scan_reconciles_descendant_spends_already_in_the_graph() {
+        let fixture = Fixture::new();
+        let mut wallet = fixture.wallet();
+        let (_, burn_txid) = fund_and_burn(&fixture, &mut wallet, Some((800, 30_000)));
+
+        let descendant = tx_paying(
+            vec![OutPoint {
+                txid: burn_txid,
+                vout: 1,
+            }],
+            vec![
+                (foreign_spk(), 10_000),
+                (fixture.spk(INTERNAL(), 900), 15_000),
+            ],
+        );
+        fixture.deliver(&mut wallet, vec![descendant], 102, None);
+
+        let report = wallet.recovery_scan(fixture.master_appkey).unwrap();
+
+        assert!(report.outstanding.is_empty());
+        assert_eq!(
+            report.revealed,
+            BTreeMap::from([(INTERNAL(), 900)]),
+            "the reveal from the first match must surface the descendant's change in the same scan"
+        );
+        assert_eq!(unspent_sum(&wallet, fixture.master_appkey), 15_000);
+    }
+
+    #[test]
+    fn descendant_arriving_by_sync_is_reconciled_by_the_next_scan() {
+        let fixture = Fixture::new();
+        let mut wallet = fixture.wallet();
+        let (_, burn_txid) = fund_and_burn(&fixture, &mut wallet, Some((800, 30_000)));
+
+        let first = wallet.recovery_scan(fixture.master_appkey).unwrap();
+        assert_eq!(first.revealed, BTreeMap::from([(INTERNAL(), 800)]));
+
+        // ordinary monitoring of the now-revealed script delivers the spend later
+        let descendant = tx_paying(
+            vec![OutPoint {
+                txid: burn_txid,
+                vout: 1,
+            }],
+            vec![
+                (foreign_spk(), 10_000),
+                (fixture.spk(INTERNAL(), 900), 15_000),
+            ],
+        );
+        fixture.deliver(&mut wallet, vec![descendant], 102, None);
+
+        let second = wallet.recovery_scan(fixture.master_appkey).unwrap();
+        assert_eq!(second.revealed, BTreeMap::from([(INTERNAL(), 900)]));
+        assert!(second.outstanding.is_empty());
+        assert_eq!(unspent_sum(&wallet, fixture.master_appkey), 15_000);
+    }
+}

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -274,6 +274,40 @@ impl CoordSuperWallet {
             .collect()
     }
 
+    /// How many spendable coins a [`RISKY_GAP`]-window restore could not discover, and their
+    /// total value in sats. These are exactly the coins the next outgoing plan
+    /// force-consolidates (see [`Self::plan_send`]) — surfacing them lets the app nudge the
+    /// user to make that transaction. Coins below their own spend cost at a modest 10 sat/vB
+    /// are excluded: rescuing one of those eats the coin, so it isn't worth nudging about.
+    pub fn gap_stranded_value(&mut self, master_appkey: MasterAppkey) -> (u64, u64) {
+        self.lazily_initialize_key(master_appkey);
+        let (keychain_indices, utxos): (Vec<(KeychainId, u32)>, Vec<bdk_chain::FullTxOut<_>>) =
+            self.tx_graph
+                .graph()
+                .filter_chain_unspents(
+                    self.chain.as_ref(),
+                    self.chain.tip().block_id(),
+                    CanonicalizationParams::default(),
+                    self.tx_graph
+                        .index
+                        .keychain_outpoints_in_range(Self::key_index_range(master_appkey)),
+                )
+                .unzip();
+        self.gap_stranded(master_appkey, &keychain_indices)
+            .into_iter()
+            .filter_map(|position| {
+                let candidate = Candidate {
+                    input_count: 1,
+                    value: utxos[position].txout.value.to_sat(),
+                    weight: TR_KEYSPEND_TXIN_WEIGHT,
+                    is_segwit: true,
+                };
+                (candidate.effective_value(FeeRate::from_sat_per_vb(10.0)) > 0.0)
+                    .then_some(candidate.value)
+            })
+            .fold((0, 0), |(count, sats), value| (count + 1, sats + value))
+    }
+
     /// Turn a [`SendPlan`] into a signable template. This is the wallet's single change-address
     /// allocation point: the lowest revealed-unused index not in `reserved_change`, revealing
     /// fresh only when nothing passes. `reserved_change` is the caller's view of in-flight
@@ -705,6 +739,21 @@ mod test {
                 .any(|&(_, outpoint)| outpoint == stranded_change),
             "change past the risky gap must be force-spent too"
         );
+    }
+
+    /// The nudge and the rescue must agree: the summary counts exactly the coins a plan would
+    /// force, so a banner built on it can always be satisfied by one send.
+    #[test]
+    fn gap_stranded_value_counts_only_rescuable_coins() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (0, 0));
+
+        f.fund(30, 500_000, 101);
+        // Stranded and above its spend cost at the 1 sat/vB relay floor, but below it at the
+        // summary's 10 sat/vB bar — pins that the bar is 10, not merely relayable.
+        f.fund(45, 300, 102);
+        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 500_000));
     }
 
     /// Rescue must not cost the user their send. A coin worth less than it costs to spend is

--- a/frostsnap_coordinator/src/bitcoin/test_util.rs
+++ b/frostsnap_coordinator/src/bitcoin/test_util.rs
@@ -1,0 +1,233 @@
+//! Shared fixtures for wallet-level tests: an in-memory wallet, a disconnected chain client, and
+//! hand-built sync updates delivered through the same `apply_update` path real syncs use.
+
+use super::chain_sync::{ChainClient, ConnectionHandler, ElectrumConfig};
+use super::wallet::{CoordSuperWallet, KeychainId};
+use crate::persist::Persisted;
+use crate::settings::ElectrumEnabled;
+use bdk_chain::bitcoin::{self, hashes::Hash, Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid};
+use bdk_chain::{BlockId, CanonicalizationParams, CheckPoint, ConfirmationBlockTime, TxUpdate};
+use frostsnap_core::schnorr_fun::fun::Point;
+use frostsnap_core::tweak::{BitcoinAccountKeychain, BitcoinBip32Path};
+use frostsnap_core::MasterAppkey;
+use std::sync::{Arc, Mutex};
+
+pub(crate) const NETWORK: bitcoin::Network = bitcoin::Network::Bitcoin;
+
+pub(crate) const EXTERNAL: fn() -> BitcoinAccountKeychain = BitcoinAccountKeychain::external;
+pub(crate) const INTERNAL: fn() -> BitcoinAccountKeychain = BitcoinAccountKeychain::internal;
+
+pub(crate) fn test_db() -> Arc<Mutex<rusqlite::Connection>> {
+    Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()))
+}
+
+/// The handler owns the receiving ends of the client's channels, so it has to outlive every
+/// `ChainClient` call or `monitor_keychain`'s send panics.
+pub(crate) fn test_chain_client(
+    db: &Arc<Mutex<rusqlite::Connection>>,
+) -> (ChainClient, ConnectionHandler) {
+    let trusted_certificates = {
+        let mut conn = db.lock().unwrap();
+        Persisted::new(&mut *conn, NETWORK).unwrap()
+    };
+    ChainClient::new(
+        bitcoin::constants::genesis_block(NETWORK).block_hash(),
+        ElectrumConfig {
+            enabled: ElectrumEnabled::None,
+            primary: String::new(),
+            backup: String::new(),
+        },
+        trusted_certificates,
+        db.clone(),
+    )
+}
+
+pub(crate) struct Fixture {
+    pub(crate) db: Arc<Mutex<rusqlite::Connection>>,
+    pub(crate) chain_client: ChainClient,
+    _handler: ConnectionHandler,
+    pub(crate) master_appkey: MasterAppkey,
+    blocks: std::cell::RefCell<Vec<BlockId>>,
+}
+
+impl Fixture {
+    pub(crate) fn new() -> Self {
+        let db = test_db();
+        let (chain_client, _handler) = test_chain_client(&db);
+        Self {
+            db,
+            chain_client,
+            _handler,
+            master_appkey: MasterAppkey::derive_from_rootkey(
+                Point::random(&mut rand::thread_rng()),
+            ),
+            blocks: std::cell::RefCell::new(vec![BlockId {
+                height: 0,
+                hash: bitcoin::constants::genesis_block(NETWORK).block_hash(),
+            }]),
+        }
+    }
+
+    pub(crate) fn wallet(&self) -> CoordSuperWallet {
+        let mut wallet =
+            CoordSuperWallet::load_or_init(self.db.clone(), NETWORK, self.chain_client.clone())
+                .unwrap();
+        wallet.list_addresses(self.master_appkey);
+        wallet
+    }
+
+    pub(crate) fn spk(&self, account_keychain: BitcoinAccountKeychain, index: u32) -> ScriptBuf {
+        super::peek_spk(
+            self.master_appkey,
+            BitcoinBip32Path {
+                account_keychain,
+                index,
+            },
+        )
+    }
+
+    /// What a real sync would deliver for `txs` confirmed at `height`: anchors, a connectable
+    /// chain update, and the keychain activity the server's notification would have attributed.
+    pub(crate) fn update(
+        &self,
+        txs: Vec<bitcoin::Transaction>,
+        height: u32,
+        last_active: Option<(BitcoinAccountKeychain, u32)>,
+    ) -> bdk_electrum_streaming::Update<KeychainId> {
+        let block_id = BlockId {
+            height,
+            hash: BlockHash::from_byte_array([height as u8; 32]),
+        };
+        let anchor = ConfirmationBlockTime {
+            block_id,
+            confirmation_time: 1_700_000_000 + height as u64,
+        };
+        let mut tx_update = TxUpdate::default();
+        tx_update.anchors = txs.iter().map(|tx| (anchor, tx.compute_txid())).collect();
+        tx_update.txs = txs.into_iter().map(Arc::new).collect();
+        self.blocks.borrow_mut().push(block_id);
+        self.blocks.borrow_mut().sort_by_key(|block| block.height);
+        bdk_electrum_streaming::Update {
+            tx_update,
+            chain_update: Some(
+                CheckPoint::from_block_ids(self.blocks.borrow().iter().copied()).unwrap(),
+            ),
+            last_active_indices: last_active
+                .into_iter()
+                .map(|(account_keychain, index)| ((self.master_appkey, account_keychain), index))
+                .collect(),
+        }
+    }
+
+    pub(crate) fn deliver(
+        &self,
+        wallet: &mut CoordSuperWallet,
+        txs: Vec<bitcoin::Transaction>,
+        height: u32,
+        last_active: Option<(BitcoinAccountKeychain, u32)>,
+    ) {
+        wallet
+            .apply_update(self.update(txs, height, last_active))
+            .unwrap();
+    }
+
+    pub(crate) fn reload_scan_state(&self) -> super::recovery_scan::RecoveryScanState {
+        let mut conn = self.db.lock().unwrap();
+        let persisted: Persisted<super::recovery_scan::RecoveryScanState> =
+            Persisted::new(&mut *conn, ()).unwrap();
+        (*persisted).clone()
+    }
+}
+
+pub(crate) fn foreign_spk() -> ScriptBuf {
+    let key = MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
+    super::peek_spk(key, BitcoinBip32Path::external(0))
+}
+
+pub(crate) fn tx_paying(
+    inputs: Vec<OutPoint>,
+    outputs: Vec<(ScriptBuf, u64)>,
+) -> bitcoin::Transaction {
+    bitcoin::Transaction {
+        version: bitcoin::transaction::Version::TWO,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: if inputs.is_empty() {
+            vec![bitcoin::TxIn::default()]
+        } else {
+            inputs
+                .into_iter()
+                .map(|previous_output| bitcoin::TxIn {
+                    previous_output,
+                    ..Default::default()
+                })
+                .collect()
+        },
+        output: outputs
+            .into_iter()
+            .map(|(script_pubkey, value)| TxOut {
+                value: Amount::from_sat(value),
+                script_pubkey,
+            })
+            .collect(),
+    }
+}
+
+/// Receive on external 0, then spend it all to outputs of which `change` may pay us back at an
+/// internal index far past the reveal frontier.
+pub(crate) fn fund_and_burn(
+    fixture: &Fixture,
+    wallet: &mut CoordSuperWallet,
+    change: Option<(u32, u64)>,
+) -> (Txid, Txid) {
+    let receive = tx_paying(vec![], vec![(fixture.spk(EXTERNAL(), 0), 100_000)]);
+    let receive_txid = receive.compute_txid();
+    fixture.deliver(wallet, vec![receive], 100, Some((EXTERNAL(), 0)));
+
+    let change_output = match change {
+        Some((index, value)) => (fixture.spk(INTERNAL(), index), value),
+        None => (foreign_spk(), 30_000),
+    };
+    let burn = tx_paying(
+        vec![OutPoint {
+            txid: receive_txid,
+            vout: 0,
+        }],
+        vec![(foreign_spk(), 60_000), change_output],
+    );
+    let burn_txid = burn.compute_txid();
+    fixture.deliver(wallet, vec![burn], 101, None);
+    (receive_txid, burn_txid)
+}
+
+pub(crate) fn unspent_sum(wallet: &CoordSuperWallet, master_appkey: MasterAppkey) -> u64 {
+    wallet
+        .tx_graph
+        .graph()
+        .filter_chain_unspents(
+            wallet.chain.as_ref(),
+            wallet.chain.tip().block_id(),
+            CanonicalizationParams::default(),
+            wallet
+                .tx_graph
+                .index
+                .keychain_outpoints_in_range(CoordSuperWallet::key_index_range(master_appkey)),
+        )
+        .map(|(_, utxo)| utxo.txout.value.to_sat())
+        .sum()
+}
+
+pub(crate) fn last_revealed_rows(db: &Arc<Mutex<rusqlite::Connection>>) -> Vec<(String, u32)> {
+    let conn = db.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT descriptor_id, last_revealed FROM bdk_descriptor_last_revealed \
+             ORDER BY descriptor_id",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    rows
+}

--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -37,7 +37,8 @@ pub type WalletIndexedTxGraphChangeSet =
 pub struct CoordSuperWallet {
     pub(super) tx_graph: Persisted<WalletIndexedTxGraph>,
     pub(super) chain: Persisted<local_chain::LocalChain>,
-    chain_client: ChainClient,
+    pub(super) recovery_scan_state: Persisted<super::recovery_scan::RecoveryScanState>,
+    pub(super) chain_client: ChainClient,
     pub network: bitcoin::Network,
     pub(super) db: Arc<Mutex<rusqlite::Connection>>,
 }
@@ -61,12 +62,15 @@ impl CoordSuperWallet {
             bitcoin::constants::genesis_block(network).block_hash(),
         )
         .context("loading chain from database")?;
+        let recovery_scan_state =
+            Persisted::new(&mut *db_, ()).context("loading recovery scan state")?;
 
         drop(db_);
 
         Ok(Self {
             tx_graph,
             chain,
+            recovery_scan_state,
             chain_client,
             db,
             network,

--- a/frostsnap_coordinator/src/bitcoin/wallet_persist.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet_persist.rs
@@ -1,13 +1,17 @@
 use std::collections::btree_map;
 
+use super::recovery_scan::{RecoveryScanState, RecoveryScanUpdate};
 use super::wallet::{WalletIndexedTxGraph, WalletIndexedTxGraphChangeSet};
-use crate::persist::Persist;
+use crate::persist::{Persist, SqlMasterAppkey, SqlTxid};
 use anyhow::Result;
 use bdk_chain::{
     bitcoin::BlockHash,
     local_chain::{self, LocalChain},
+    rusqlite_impl::migrate_schema,
     ConfirmationBlockTime,
 };
+use frostsnap_core::tweak::BitcoinBip32Path;
+use rusqlite::named_params;
 
 impl Persist<rusqlite::Connection> for WalletIndexedTxGraph {
     type Update = WalletIndexedTxGraphChangeSet;
@@ -45,6 +49,125 @@ impl Persist<rusqlite::Connection> for WalletIndexedTxGraph {
 
         update.tx_graph.persist_to_sqlite(&db_tx)?;
         update.indexer.persist_to_sqlite(&db_tx)?;
+
+        db_tx.commit()?;
+        Ok(())
+    }
+}
+
+impl Persist<rusqlite::Connection> for RecoveryScanState {
+    type Update = RecoveryScanUpdate;
+    type LoadParams = ();
+
+    fn migrate(conn: &mut rusqlite::Connection) -> Result<()> {
+        const SCHEMA_NAME: &str = "frostsnap_recovery_scan";
+        const MIGRATIONS: &[&str] = &["CREATE TABLE fs_recovery_scan_compared ( \
+                master_appkey TEXT NOT NULL, \
+                account_kind INTEGER NOT NULL, \
+                account_index INTEGER NOT NULL, \
+                keychain INTEGER NOT NULL, \
+                compared_index INTEGER NOT NULL, \
+                PRIMARY KEY (master_appkey, account_kind, account_index, keychain) \
+            ) WITHOUT ROWID, STRICT; \
+            CREATE TABLE fs_recovery_scan_outstanding ( \
+                master_appkey TEXT NOT NULL, \
+                txid TEXT NOT NULL, \
+                PRIMARY KEY (master_appkey, txid) \
+            ) WITHOUT ROWID, STRICT;"];
+
+        let db_tx = conn.transaction()?;
+        migrate_schema(&db_tx, SCHEMA_NAME, MIGRATIONS)?;
+        db_tx.commit()?;
+        Ok(())
+    }
+
+    fn load(conn: &mut rusqlite::Connection, _: Self::LoadParams) -> Result<Self> {
+        let mut state = RecoveryScanState::default();
+
+        let mut compared_stmt = conn.prepare_cached(
+            "SELECT master_appkey, account_kind, account_index, keychain, compared_index \
+             FROM fs_recovery_scan_compared",
+        )?;
+        let rows = compared_stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, SqlMasterAppkey>("master_appkey")?,
+                row.get::<_, u32>("account_kind")?,
+                row.get::<_, u32>("account_index")?,
+                row.get::<_, u32>("keychain")?,
+                row.get::<_, u32>("compared_index")?,
+            ))
+        })?;
+        for row in rows {
+            let (SqlMasterAppkey(master_appkey), kind, index, keychain, compared_index) = row?;
+            let path = BitcoinBip32Path::from_u32_slice(&[kind, index, keychain, 0])
+                .ok_or_else(|| anyhow::anyhow!("invalid keychain row in recovery scan table"))?;
+            state
+                .compared
+                .insert((master_appkey, path.account_keychain), compared_index);
+        }
+
+        let mut outstanding_stmt =
+            conn.prepare_cached("SELECT master_appkey, txid FROM fs_recovery_scan_outstanding")?;
+        let rows = outstanding_stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, SqlMasterAppkey>("master_appkey")?,
+                row.get::<_, SqlTxid>("txid")?,
+            ))
+        })?;
+        for row in rows {
+            let (SqlMasterAppkey(master_appkey), SqlTxid(txid)) = row?;
+            state
+                .outstanding
+                .entry(master_appkey)
+                .or_default()
+                .insert(txid);
+        }
+
+        Ok(state)
+    }
+
+    fn persist_update(&self, conn: &mut rusqlite::Connection, update: Self::Update) -> Result<()> {
+        let db_tx = conn.transaction()?;
+
+        db_tx.execute(
+            "DELETE FROM fs_recovery_scan_compared WHERE master_appkey=:master_appkey",
+            named_params! { ":master_appkey": SqlMasterAppkey(update.master_appkey) },
+        )?;
+        db_tx.execute(
+            "DELETE FROM fs_recovery_scan_outstanding WHERE master_appkey=:master_appkey",
+            named_params! { ":master_appkey": SqlMasterAppkey(update.master_appkey) },
+        )?;
+
+        for (account_keychain, compared_index) in &update.compared {
+            let mut segments = account_keychain.path_segments_from_bitcoin_appkey();
+            let (kind, index, keychain) = (
+                segments.next().expect("has kind"),
+                segments.next().expect("has account index"),
+                segments.next().expect("has keychain"),
+            );
+            db_tx.execute(
+                "INSERT INTO fs_recovery_scan_compared \
+                 (master_appkey, account_kind, account_index, keychain, compared_index) \
+                 VALUES (:master_appkey, :account_kind, :account_index, :keychain, :compared_index)",
+                named_params! {
+                    ":master_appkey": SqlMasterAppkey(update.master_appkey),
+                    ":account_kind": kind,
+                    ":account_index": index,
+                    ":keychain": keychain,
+                    ":compared_index": compared_index,
+                },
+            )?;
+        }
+        for txid in &update.outstanding {
+            db_tx.execute(
+                "INSERT INTO fs_recovery_scan_outstanding (master_appkey, txid) \
+                 VALUES (:master_appkey, :txid)",
+                named_params! {
+                    ":master_appkey": SqlMasterAppkey(update.master_appkey),
+                    ":txid": SqlTxid(*txid),
+                },
+            )?;
+        }
 
         db_tx.commit()?;
         Ok(())

--- a/frostsnap_coordinator/src/persist.rs
+++ b/frostsnap_coordinator/src/persist.rs
@@ -181,6 +181,23 @@ impl<T: Deref<Target = bdk_chain::bitcoin::Transaction>> ToSql for SqlBitcoinTra
     }
 }
 
+pub struct SqlMasterAppkey(pub frostsnap_core::MasterAppkey);
+
+impl FromSql for SqlMasterAppkey {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        Ok(SqlMasterAppkey(
+            frostsnap_core::MasterAppkey::from_str(value.as_str()?)
+                .map_err(|e| FromSqlError::Other(Box::new(e)))?,
+        ))
+    }
+}
+
+impl ToSql for SqlMasterAppkey {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.0.to_string()))
+    }
+}
+
 pub struct SqlTxid(pub bdk_chain::bitcoin::Txid);
 
 impl FromSql for SqlTxid {

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -26,6 +26,7 @@ import 'package:frostsnap/wallet_more.dart';
 import 'package:frostsnap/wallet_receive.dart';
 import 'package:frostsnap/wallet_send.dart';
 import 'package:frostsnap/settings.dart';
+import 'package:frostsnap/wallet_stranded_coins.dart';
 import 'package:frostsnap/wallet_tx_details.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -375,6 +376,7 @@ class _TxListState extends State<TxList> {
             frostKey: frostKey,
           ),
         ),
+        SliverToBoxAdapter(child: StrandedCoinsBanner()),
         StreamBuilder(
           stream: MergeStream<void>([
             walletCtx.signingSessionSignals,

--- a/frostsnapp/lib/wallet_stranded_coins.dart
+++ b/frostsnapp/lib/wallet_stranded_coins.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/src/rust/api/super_wallet.dart';
+import 'package:frostsnap/theme.dart';
+import 'package:frostsnap/wallet.dart';
+import 'package:frostsnap/wallet_send.dart';
+
+/// Nudges the user to consolidate coins sitting past the recovery gap.
+///
+/// A standard restore crawls addresses and stalls at the first unused stretch wider than its
+/// gap limit, so a coin past such a stretch would be missed. Any outgoing transaction
+/// consolidates those coins automatically (`plan_send` force-selects them); this banner exists
+/// so the user knows one is worth making. Mounting it also kicks the recovery scan, so change
+/// the wallet can't yet see is attributed first and then counted here.
+class StrandedCoinsBanner extends StatefulWidget {
+  const StrandedCoinsBanner({super.key});
+
+  @override
+  State<StrandedCoinsBanner> createState() => _StrandedCoinsBannerState();
+}
+
+class _StrandedCoinsBannerState extends State<StrandedCoinsBanner> {
+  bool scanKicked = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (scanKicked) return;
+    scanKicked = true;
+    final walletCtx = WalletContext.of(context)!;
+    walletCtx.superWallet
+        .recoveryScan(masterAppkey: walletCtx.masterAppkey)
+        .catchError((Object err) {
+          debugPrint('recovery scan failed: $err');
+        });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final walletCtx = WalletContext.of(context)!;
+
+    return StreamBuilder<TxState>(
+      stream: walletCtx.txStream,
+      builder: (context, snapshot) {
+        var count = 0;
+        var sats = 0;
+        if (snapshot.hasData) {
+          final (strandedCount, strandedSats) = walletCtx.superWallet
+              .gapStrandedValue(masterAppkey: walletCtx.masterAppkey);
+          count = strandedCount;
+          sats = strandedSats;
+        }
+
+        final card = count == 0
+            ? SizedBox(width: double.infinity)
+            : Card(
+                margin: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                shape: cardShape(context),
+                color: tintSurfaceContainer(context, tint: cautionColor),
+                clipBehavior: Clip.hardEdge,
+                child: ListTile(
+                  onTap: () => showBottomSheetOrDialog(
+                    context,
+                    title: Text('Send'),
+                    builder: (context, scrollController) => walletCtx.wrap(
+                      WalletSendPage(
+                        scrollController: scrollController,
+                        superWallet: walletCtx.superWallet,
+                        masterAppkey: walletCtx.masterAppkey,
+                      ),
+                    ),
+                  ),
+                  leading: Icon(Icons.merge_rounded, color: cautionColor),
+                  trailing: Icon(Icons.chevron_right),
+                  title: Text(
+                    count == 1
+                        ? 'A coin could be missed by a future restore'
+                        : '$count coins could be missed by a future restore',
+                  ),
+                  subtitle: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          count == 1
+                              ? 'Your next payment consolidates it automatically'
+                              : 'Your next payment consolidates them automatically',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                      SatoshiText(
+                        value: sats,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+
+        return AnimatedSize(
+          duration: Durations.medium4,
+          curve: Curves.easeInOutCubicEmphasized,
+          alignment: Alignment.topCenter,
+          child: card,
+        );
+      },
+    );
+  }
+}

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -275,6 +275,34 @@ impl SuperWallet {
         }
     }
 
+    /// Scan for change that a gap-limit restore left invisible and reclaim it.
+    ///
+    /// Entirely local (no network requests) and cheap when nothing changed since the last scan,
+    /// so fire-and-forget this whenever a wallet is opened — offline included. There is
+    /// deliberately no blocking scan UI: a full first pass (two keychains × 1000 candidate
+    /// derivations) measures 70–90ms (release/debug, Apple M-series) — the async call just
+    /// keeps it off the UI thread. A recovery pushes the refreshed tx list to wallet
+    /// subscribers, which is also what refreshes the gap-stranded banner.
+    pub fn recovery_scan(&self, master_appkey: MasterAppkey) -> Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+        let report = inner.recovery_scan(master_appkey)?;
+        if !report.revealed.is_empty() {
+            let wallet_streams = self.wallet_streams.lock().unwrap();
+            if let Some(stream) = wallet_streams.get(&master_appkey) {
+                let txs = inner.list_transactions(master_appkey);
+                let _ = stream.add(txs.into());
+            }
+        }
+        Ok(())
+    }
+
+    /// How many spendable coins a standard restore could miss, and their total sats — the
+    /// wallet's next outgoing transaction consolidates them automatically.
+    #[frb(sync, type_64bit_int)]
+    pub fn gap_stranded_value(&self, master_appkey: MasterAppkey) -> (u64, u64) {
+        self.inner.lock().unwrap().gap_stranded_value(master_appkey)
+    }
+
     pub fn psbt_to_unsigned_tx(
         &self,
         psbt: &Psbt,


### PR DESCRIPTION
A restored wallet walks the gap limit and stops at the first gap wider than its scan window. Change revealed far past the last genuinely used index — as manufactured by the `fee()` defect fixed in #542 — is invisible after restore: not in the balance, not spendable. #545 attacks this from the sending side so the gap never forms; this is the other half, recovery for wallets where it already has.

## How it works

An outgoing transaction is discoverable even when its change is not: `is_mine` chains outputs with prevouts, so owning a spent prevout is enough to hold the tx — its unattributed change script is already sitting in the local graph. Recovery is therefore a **purely local comparison**; the network holds no information we lack, and no candidate script is ever sent to a server.

`CoordSuperWallet::recovery_scan`:

1. Flags canonical txs that spend ours, have more than one output, and pay us nothing (send-max legitimately has no change, so single-output spends are exempt).
2. Derives candidate spks locally out to **1000 indices past each keychain's frontier** (~80ms for the full 2000 on a laptop — which is why there is no blocking scan UI).
3. On a match, reveals to **exactly the highest matched index** — never the budget — through the ordinary `reveal_to_target` path, then re-indexes every stored transaction (bdk indexes a tx once, against the spks derived at that moment, so a reveal strands already-stored outputs without a full re-index).
4. Iterates: a reveal can make an already-stored descendant spend outgoing-and-unreconciled.

Scan progress (compared-to high-water marks, outstanding txids) persists in its **own tables, never in `last_revealed`** — parking progress in the frontier would advance address allocation and manufacture the next restore's gap. Only a real match mutates wallet derivation state, and only up to the matched index.

The scan runs automatically: on every sync update naming a key (deliberately not gated on the changeset — an upgraded wallet whose stranded tx is already persisted applies every sync as a no-op) and fire-and-forget at wallet open, offline included. Repeat scans over an unchanged wallet are one canonicalization pass, zero derivations.

After a far match, the revealed range reaches the electrum server in the same session: `bdk_electrum_streaming` 0.5.3 widens a tracked descriptor's subscription window in place when it is re-tracked with a larger `next_index` (evanlinjin/experiments#8, released for this), so `monitor_keychain` simply re-announces the keychain on the live connection and the new range is subscribed with no reconnect. A unit test pins that upstream contract against future dep bumps.

## The consolidation nudge

A recovered coin still sits at an index a standard restore would miss, so the wallet home gains a banner counting the spendable coins past the risky gap — computed by the same crawl simulation #545's `plan_send` (now merged) force-consolidates by, and counting **only coins a plan would actually rescue** (the relay-floor rule), so one send always clears it. Tapping it opens Send; the copy tells the user their next payment consolidates automatically. It applies equally to organically stranded coins — no recovery scan required.

Transactions the scan budget cannot account for get **no dedicated surface**: the detection predicate cannot distinguish missing change from a legitimately changeless exact-value send (two recipients, no change), so a warning there would mostly cry wolf on wallets missing nothing. In practice the budget also covers the realistic #542 shapes — matches act as stepping stones, extending reach another 1000 past each recovered index.

## Testing

- 9 coordinator tests pin the recovery contract: no-match leaves wallet derivation state byte-identical while progress persists; match reveals exactly to the matched index; every stored tx is re-indexed (a stray output below the new frontier becomes spendable off an unrelated match); restart resumes from the scan table with no work; descendants reconcile both within one scan and across a sync boundary; a no-op update still triggers recovery; the electrum tracker widen contract; the banner summary counts exactly the coins a plan would rescue.
- Demoed end-to-end on regtest against a real bitcoind+electrs: a device-signed tx paying change to the wallet's own change descriptor at index 800 is recovered silently, flagged by the consolidation banner, and swept back on-chain via a send. GIFs in the comments.

