### PR TITLE
app: disable look for address button on invalid or wrong-network input

### DIFF
--- a/frostsnapp/lib/address.dart
+++ b/frostsnapp/lib/address.dart
@@ -32,18 +32,18 @@ class _CheckAddressPageState extends State<CheckAddressPage> {
     super.dispose();
   }
 
+  // Rebuilds on every change rather than on validity transitions: the error text
+  // reads both the field's emptiness and its validity, and `_isValidAddress` is
+  // false for both, so a validity-only trigger misses empty<->invalid entirely.
   void _onTextChanged() {
     final walletCtx = WalletContext.of(context);
     final text = textInputController.text.trim();
-    final isValid =
-        text.isNotEmpty &&
-        walletCtx != null &&
-        Address.fromString(s: text, network: walletCtx.network) != null;
-    if (isValid != _isValidAddress) {
-      setState(() {
-        _isValidAddress = isValid;
-      });
-    }
+    setState(() {
+      _isValidAddress =
+          text.isNotEmpty &&
+          walletCtx != null &&
+          Address.fromString(s: text, network: walletCtx.network) != null;
+    });
   }
 
   Future<SearchResult> searchAddress() async {
@@ -65,8 +65,8 @@ class _CheckAddressPageState extends State<CheckAddressPage> {
   }
 
   Widget _buildSearchResults(SearchResult? result) {
-    final walletCtx = WalletContext.of(context)!;
     if (result == null) return const SizedBox.shrink();
+    final walletCtx = WalletContext.of(context)!;
 
     final children = <Widget>[
       Text(

--- a/frostsnapp/lib/address.dart
+++ b/frostsnapp/lib/address.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/src/rust/api/bitcoin.dart';
 import 'package:frostsnap/src/rust/api/super_wallet.dart';
 import 'package:frostsnap/theme.dart';
 import 'package:frostsnap/wallet_receive.dart';
@@ -16,17 +17,33 @@ class _CheckAddressPageState extends State<CheckAddressPage> {
   Future<SearchResult>? searchFuture;
   int currentDepth = 0;
   int searchSize = 100;
+  bool _isValidAddress = false;
 
   @override
   void initState() {
     super.initState();
     textInputController = TextEditingController();
+    textInputController.addListener(_onTextChanged);
   }
 
   @override
   void dispose() {
     textInputController.dispose();
     super.dispose();
+  }
+
+  void _onTextChanged() {
+    final walletCtx = WalletContext.of(context);
+    final text = textInputController.text.trim();
+    final isValid =
+        text.isNotEmpty &&
+        walletCtx != null &&
+        Address.fromString(s: text, network: walletCtx.network) != null;
+    if (isValid != _isValidAddress) {
+      setState(() {
+        _isValidAddress = isValid;
+      });
+    }
   }
 
   Future<SearchResult> searchAddress() async {
@@ -132,18 +149,26 @@ class _CheckAddressPageState extends State<CheckAddressPage> {
               controller: textInputController,
               minLines: 2,
               maxLines: 6,
-              decoration: const InputDecoration(counterText: ''),
+              decoration: InputDecoration(
+                counterText: '',
+                errorText:
+                    textInputController.text.isNotEmpty && !_isValidAddress
+                    ? 'Invalid address for this network'
+                    : null,
+              ),
             ),
           ),
           const SizedBox(height: 32),
           FilledButton(
-            onPressed: () {
-              currentDepth = 0;
-              searchSize = 100;
-              setState(() {
-                searchFuture = searchAddress();
-              });
-            },
+            onPressed: _isValidAddress
+                ? () {
+                    currentDepth = 0;
+                    searchSize = 100;
+                    setState(() {
+                      searchFuture = searchAddress();
+                    });
+                  }
+                : null,
             child: const Text('Look for address'),
           ),
           const SizedBox(height: 16),

--- a/frostsnapp/test/address_check_error_test.dart
+++ b/frostsnapp/test/address_check_error_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frostsnap/address.dart';
+
+const _error = 'Invalid address for this network';
+
+/// Pumped without a [WalletContext], which makes every non-empty entry invalid —
+/// the same branch a malformed or wrong-network address takes, and reachable
+/// without the Rust bridge.
+Widget _page() => const MaterialApp(home: Scaffold(body: CheckAddressPage()));
+
+void main() {
+  testWidgets('the error appears on the first invalid entry', (tester) async {
+    await tester.pumpWidget(_page());
+
+    await tester.enterText(find.byType(TextFormField), 'notanaddress');
+    await tester.pump();
+
+    expect(find.text(_error), findsOneWidget);
+  });
+
+  testWidgets('the error clears when the field is emptied', (tester) async {
+    await tester.pumpWidget(_page());
+
+    await tester.enterText(find.byType(TextFormField), 'notanaddress');
+    await tester.pump();
+    // Asserted before clearing so the test cannot pass by the error never having
+    // been shown — which is how it passed against the unfixed page.
+    expect(find.text(_error), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField), '');
+    await tester.pump();
+
+    expect(find.text(_error), findsNothing);
+  });
+}


### PR DESCRIPTION
fixes #252

What changed:

1. Added a listener on CheckAddressPage's textInputController that re-validates the input text against the active wallet network using Address.fromString.

2. Disabled the "Look for address" button (onPressed: null) whenever the input is empty, malformed, or for the wrong network.

Added explicit error feedback (Invalid address for this network) directly on the input field when non-empty text fails validation.