### PR TITLE
Let users consolidate coins a restore would miss, and stop losing them to a narrow window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_electrum_streaming"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e86daa7b72258672522b521569386692d51ef70b5a4e879cdd8e6a6caa427f"
+checksum = "a16576b1efa0960f4c6d65d588005889ee9bee600d47540adca62d21003154bc"
 dependencies = [
  "anyhow",
  "bdk_core",

--- a/frostsnap_coordinator/Cargo.toml
+++ b/frostsnap_coordinator/Cargo.toml
@@ -23,7 +23,7 @@ rsa.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 
 bdk_chain = { version = "0.23.3", features = ["rusqlite"] }
-bdk_electrum_streaming = { version = "0.5.2" }
+bdk_electrum_streaming = { version = "0.5.3" }
 bdk_coin_select = { version = "0.4.1" }
 
 

--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -68,6 +68,20 @@ impl<I: Send, O: Send> ReqAndResponse<I, O> {
     }
 }
 
+/// Scripts past a keychain's frontier that we subscribe to on the server.
+///
+/// Slop for activity the frontier doesn't know about yet: another device on the key, a restored
+/// wallet, an externally built PSBT paying one of our addresses. The tracker also extends this past
+/// any index it sees activity on, so it crawls.
+///
+/// Kept small on purpose, and deliberately NOT the indexer's [`LOOKAHEAD`]: every script here is
+/// one we hand to the server, which costs a subscription, per-block work for every client on it,
+/// and a larger fingerprint of our wallet. Finding stranded change is the indexer's job precisely
+/// because it can look far without telling anyone.
+///
+/// [`LOOKAHEAD`]: super::wallet::LOOKAHEAD
+const SUBSCRIPTION_LOOKAHEAD: u32 = 50;
+
 pub const SUPPORTED_NETWORKS: [bitcoin::Network; 4] = {
     use bitcoin::Network::*;
     [Bitcoin, Signet, Testnet, Regtest]
@@ -182,6 +196,9 @@ impl ChainClient {
         block_on(response)?
     }
 
+    /// Track `keychain` through `next_index` plus lookahead. Re-calling with a larger
+    /// `next_index` widens the live subscription window in place (bdk_electrum_streaming
+    /// >= 0.5.3); equal or smaller is a no-op, so the window never narrows.
     pub fn monitor_keychain(&self, keychain: KeychainId, next_index: u32) {
         self.start_client();
         let descriptor = descriptor_for_account_keychain(
@@ -333,18 +350,29 @@ pub struct ConnectionHandler {
 }
 
 impl ConnectionHandler {
+    /// The tracking messages the client has queued and nothing has consumed. Tests never run the
+    /// handler, so this queue is where `monitor_keychain` ends up, and reading it needs no server.
+    #[cfg(test)]
+    pub(super) fn drain_tracked(
+        &mut self,
+    ) -> Vec<bdk_electrum_streaming::AsyncClientAction<KeychainId>> {
+        let mut drained = vec![];
+        while let Ok(action) = self.client_recv.try_recv() {
+            drained.push(action);
+        }
+        drained
+    }
+
     pub fn run<SW, F>(mut self, super_wallet: SW, update_action: F)
     where
         SW: Deref<Target = sync::Mutex<CoordSuperWallet>> + Clone + Send + 'static,
         F: FnMut(MasterAppkey, Vec<crate::bitcoin::wallet::Transaction>) + Send + 'static,
     {
-        let lookahead: u32;
         let chain_tip: CheckPoint;
         let network: bitcoin::Network;
         {
             let super_wallet = super_wallet.lock().expect("must lock");
             network = super_wallet.network;
-            lookahead = super_wallet.lookahead();
             chain_tip = super_wallet.chain_tip();
             self.cache.txs.extend(super_wallet.tx_cache());
             self.cache.anchors.extend(super_wallet.anchor_cache());
@@ -374,7 +402,7 @@ impl ConnectionHandler {
         let electrum_state = AsyncState::<KeychainId>::new(
             ReqCoord::new(rand::random::<u32>()),
             self.cache,
-            DerivedSpkTracker::new(lookahead),
+            DerivedSpkTracker::new(SUBSCRIPTION_LOOKAHEAD),
             chain_tip,
         );
 
@@ -714,4 +742,72 @@ pub enum ChainStatusState {
     Connecting,
     Connected,
     Disconnected,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bdk_electrum_streaming::electrum_streaming_client::ElectrumScriptHash;
+    use frostsnap_core::schnorr_fun::fun::Point;
+    use frostsnap_core::tweak::{BitcoinAccountKeychain, BitcoinBip32Path, NormalIndex};
+
+    fn spk_hash_at(keychain: KeychainId, index: u32) -> ElectrumScriptHash {
+        let spk = crate::bitcoin::peek_spk(
+            keychain.0,
+            BitcoinBip32Path {
+                account_keychain: keychain.1,
+                index: NormalIndex::new(index).unwrap(),
+            },
+        );
+        ElectrumScriptHash::new(&spk)
+    }
+
+    /// Pins the upstream contract `monitor_keychain` rides on (bdk_electrum_streaming >= 0.5.3):
+    /// re-inserting the SAME descriptor with a larger `next_index` widens the tracked window in
+    /// place, and equal or smaller never narrows it. Before 0.5.3 an unchanged descriptor was an
+    /// early return, so the window could not grow.
+    #[test]
+    fn re_tracking_a_descriptor_widens_and_never_narrows() {
+        let master_appkey =
+            MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
+        let keychain = (master_appkey, BitcoinAccountKeychain::internal());
+        let lookahead = 50;
+        let descriptor = descriptor_for_account_keychain(keychain, bitcoin::NetworkKind::Main);
+
+        let mut tracker = DerivedSpkTracker::new(lookahead);
+        tracker.insert_descriptor(keychain, descriptor.clone(), 5);
+        assert_eq!(tracker.index_of_spk_hash(spk_hash_at(keychain, 900)), None);
+
+        let widened = tracker.insert_descriptor(keychain, descriptor.clone(), 901);
+        assert!(
+            !widened.is_empty(),
+            "widening must hand back new hashes to subscribe"
+        );
+        assert_eq!(
+            tracker.index_of_spk_hash(spk_hash_at(keychain, 900)),
+            Some((keychain, 900)),
+            "the matched index must be watched"
+        );
+        assert_eq!(
+            tracker.index_of_spk_hash(spk_hash_at(keychain, 901 + lookahead + 1)),
+            Some((keychain, 901 + lookahead + 1)),
+            "lookahead extends past next_index"
+        );
+        assert_eq!(
+            tracker.index_of_spk_hash(spk_hash_at(keychain, 901 + lookahead + 2)),
+            None
+        );
+
+        assert!(
+            tracker
+                .insert_descriptor(keychain, descriptor, 5)
+                .is_empty(),
+            "a smaller next_index must be a no-op"
+        );
+        assert_eq!(
+            tracker.index_of_spk_hash(spk_hash_at(keychain, 900)),
+            Some((keychain, 900)),
+            "the window must never narrow"
+        );
+    }
 }

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -61,6 +61,23 @@ impl SendPlan {
         self.fee
     }
 
+    pub fn input_count(&self) -> usize {
+        self.selected.len()
+    }
+
+    /// The total value the plan spends. The plan pins outpoints, not values, so this is the
+    /// accounting identity fee + outputs rather than a wallet lookup — it is what the committed
+    /// transaction consumes even if the wallet's view moves after planning.
+    pub fn input_total(&self) -> u64 {
+        self.fee
+            + self.change_value.unwrap_or(0)
+            + self
+                .recipients
+                .iter()
+                .map(|txo| txo.value.to_sat())
+                .sum::<u64>()
+    }
+
     /// What this plan pays recipient `index`, the value the committed transaction carries.
     ///
     /// For send max this is the maximum as the selection fixed it, not as the wallet reports it
@@ -275,6 +292,124 @@ impl CoordSuperWallet {
             .collect()
     }
 
+    /// The coins the consolidation nudge counts and [`Self::plan_consolidate`] spends — one
+    /// source, so the remedy always clears the nudge. A coin qualifies when it is unspent, a
+    /// [`RISKY_GAP`]-window restore cannot reach its index, and it is worth more than its own
+    /// spend cost at a modest 10 sat/vB: rescuing anything below that eats the coin. 10 rather
+    /// than the 1 sat/vB relay floor because this runs where no feerate exists (a passive,
+    /// offline-capable wallet-home getter) and the floor would nudge over coins whose rescue is
+    /// only theoretically broadcastable.
+    fn stranded_rescuable(
+        &mut self,
+        master_appkey: MasterAppkey,
+    ) -> Vec<(BitcoinBip32Path, OutPoint, u64)> {
+        self.lazily_initialize_key(master_appkey);
+        let (keychain_indices, utxos): (Vec<(KeychainId, u32)>, Vec<bdk_chain::FullTxOut<_>>) =
+            self.tx_graph
+                .graph()
+                .filter_chain_unspents(
+                    self.chain.as_ref(),
+                    self.chain.tip().block_id(),
+                    CanonicalizationParams::default(),
+                    self.tx_graph
+                        .index
+                        .keychain_outpoints_in_range(Self::key_index_range(master_appkey)),
+                )
+                .unzip();
+        self.gap_stranded(master_appkey, &keychain_indices)
+            .into_iter()
+            .filter_map(|position| {
+                let candidate = Candidate {
+                    input_count: 1,
+                    value: utxos[position].txout.value.to_sat(),
+                    weight: TR_KEYSPEND_TXIN_WEIGHT,
+                    is_segwit: true,
+                };
+                (candidate.effective_value(FeeRate::from_sat_per_vb(10.0)) > 0.0).then(|| {
+                    let ((_, account_keychain), index) = keychain_indices[position];
+                    (
+                        BitcoinBip32Path {
+                            account_keychain,
+                            index: NormalIndex::new(index)
+                                .expect("bdk never derives a hardened index"),
+                        },
+                        utxos[position].outpoint,
+                        candidate.value,
+                    )
+                })
+            })
+            .collect()
+    }
+
+    /// How many spendable coins a [`RISKY_GAP`]-window restore could not discover, and their
+    /// total value in sats — what the consolidation nudge shows. Any outgoing plan rescues them
+    /// (see [`Self::plan_send`]); [`Self::plan_consolidate`] rescues them without a payment.
+    pub fn gap_stranded_value(&mut self, master_appkey: MasterAppkey) -> (u64, u64) {
+        self.stranded_rescuable(master_appkey)
+            .iter()
+            .fold((0, 0), |(count, sats), (_, _, value)| {
+                (count + 1, sats + value)
+            })
+    }
+
+    /// Plan a consolidation: every coin the nudge counts goes in, and ONE output — change,
+    /// allocated by [`Self::commit_send`] like any other — comes back. There is no recipient
+    /// and no coin selection; the input set is the point. A coin effective-negative at
+    /// `feerate` is still included — the user is explicitly rescuing it, and leaving it behind
+    /// would leave the nudge standing after its own remedy. Refuses when the coins cannot pay
+    /// the fee and still leave a usable output.
+    pub fn plan_consolidate(
+        &mut self,
+        master_appkey: MasterAppkey,
+        feerate: f32,
+    ) -> Result<SendPlan> {
+        let coins = self.stranded_rescuable(master_appkey);
+        if coins.is_empty() {
+            return Err(anyhow!("there are no gap-stranded coins to consolidate"));
+        }
+
+        let candidates = coins
+            .iter()
+            .map(|&(_, _, value)| Candidate {
+                input_count: 1,
+                value,
+                weight: TR_KEYSPEND_TXIN_WEIGHT,
+                is_segwit: true,
+            })
+            .collect::<Vec<_>>();
+        let mut cs = CoinSelector::new(&candidates);
+        for position in 0..candidates.len() {
+            cs.select(position);
+        }
+        let target = Target {
+            fee: TargetFee::from_feerate(FeeRate::from_sat_per_vb(feerate)),
+            outputs: TargetOutputs::fund_outputs([]),
+        };
+        let fee = cs.implied_fee(target, DrainWeights::TR_KEYSPEND);
+        let sum = cs.selected_value();
+        let change_value = sum
+            .checked_sub(fee)
+            .filter(|value| *value >= TR_DUST_RELAY_MIN_VALUE)
+            .ok_or_else(|| {
+                anyhow!(
+                    "the {} stranded coin(s) hold {sum} sats — not enough to pay the {fee} sat \
+                     fee and leave a usable output",
+                    coins.len()
+                )
+            })?;
+
+        Ok(SendPlan {
+            master_appkey,
+            selected: coins
+                .into_iter()
+                .map(|(bip32_path, outpoint, _)| (bip32_path, outpoint))
+                .collect(),
+            recipients: vec![],
+            change_value: Some(change_value),
+            fee,
+        })
+    }
+
     /// Turn a [`SendPlan`] into a signable template. This is the wallet's single change-address
     /// allocation point: the lowest revealed-unused index not in `reserved_change`, revealing
     /// fresh only when nothing passes. `reserved_change` is the caller's view of in-flight
@@ -382,6 +517,7 @@ mod test {
         bitcoin::{hashes::Hash, BlockHash, TxIn},
         BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate,
     };
+    use bdk_coin_select::Drain;
     use frostsnap_core::schnorr_fun::fun::Point;
     use frostsnap_core::tweak::NormalIndex;
     use std::str::FromStr;
@@ -707,6 +843,194 @@ mod test {
                 .iter()
                 .any(|&(_, outpoint)| outpoint == stranded_change),
             "change past the risky gap must be force-spent too"
+        );
+    }
+
+    /// The nudge and the rescue must agree: the summary counts exactly the coins a plan would
+    /// force, so a banner built on it can always be satisfied by one send.
+    #[test]
+    fn gap_stranded_value_counts_only_rescuable_coins() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (0, 0));
+
+        f.fund(30, 500_000, 101);
+        // Stranded and above its spend cost at the 1 sat/vB relay floor, but below it at the
+        // summary's 10 sat/vB bar — pins that the bar is 10, not merely relayable.
+        f.fund(45, 300, 102);
+        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 500_000));
+    }
+
+    /// The plan spends the nudge's exact coin set — nothing reachable, nothing extra — into a
+    /// single output, and planning commits the wallet to nothing.
+    #[test]
+    fn consolidation_spends_exactly_the_nudged_coins_into_one_change_output() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        let stranded_ext = f.fund(30, 500_000, 101);
+        let stranded_int = f.fund_keychain(BitcoinAccountKeychain::internal(), 25, 200_000, 102);
+        let revealed_before = f.last_revealed_internal();
+
+        let plan = f.wallet.plan_consolidate(f.master_appkey, 10.0).unwrap();
+
+        let planned: BTreeSet<OutPoint> = plan
+            .selected
+            .iter()
+            .map(|&(_, outpoint)| outpoint)
+            .collect();
+        assert_eq!(planned, BTreeSet::from([stranded_ext, stranded_int]));
+        assert!(plan.recipients.is_empty());
+        let change = plan.change_value.expect("the one output is change");
+        assert_eq!(
+            plan.fee + change,
+            700_000,
+            "every input sat is accounted for"
+        );
+
+        let candidates = [
+            Candidate {
+                input_count: 1,
+                value: 500_000,
+                weight: TR_KEYSPEND_TXIN_WEIGHT,
+                is_segwit: true,
+            },
+            Candidate {
+                input_count: 1,
+                value: 200_000,
+                weight: TR_KEYSPEND_TXIN_WEIGHT,
+                is_segwit: true,
+            },
+        ];
+        let mut cs = CoinSelector::new(&candidates);
+        cs.select(0);
+        cs.select(1);
+        let implied = cs
+            .implied_feerate(
+                TargetOutputs::fund_outputs([]),
+                Drain {
+                    weights: DrainWeights::TR_KEYSPEND,
+                    value: change,
+                },
+            )
+            .expect("valid selection")
+            .as_sat_vb();
+        assert!(
+            (10.0..10.5).contains(&implied),
+            "the plan pays the requested feerate, got {implied} sat/vB"
+        );
+
+        assert_eq!(
+            f.last_revealed_internal(),
+            revealed_before,
+            "planning must not reveal"
+        );
+    }
+
+    /// The first of two refusals: the coins cannot cover the fee at all.
+    #[test]
+    fn consolidation_refuses_when_the_coins_cannot_pay_the_fee() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        f.fund(21, 700, 101); // above the nudge bar, below one input+output of fee at 10 sat/vB
+
+        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 700));
+        let err = f
+            .wallet
+            .plan_consolidate(f.master_appkey, 10.0)
+            .expect_err("700 sats cannot fund the consolidation");
+        assert!(err.to_string().contains("not enough"), "got: {err}");
+    }
+
+    /// The second: the coins do cover the fee, and what is left is under the dust floor. Its own
+    /// test because the two refusals answer with one message, and the case above reaches this one's
+    /// branch never — it fails the subtraction, so the floor could be deleted without it noticing.
+    #[test]
+    fn consolidation_refuses_a_dust_change_output() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        // Covers the 1,110 sat fee and leaves 290: a real output, under the 330 sat relay floor.
+        f.fund(21, 1_400, 101);
+        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 1_400));
+
+        let err = f
+            .wallet
+            .plan_consolidate(f.master_appkey, 10.0)
+            .expect_err("290 sats of change is dust");
+        assert!(err.to_string().contains("not enough"), "got: {err}");
+
+        // Same coin, same fee, 490 left: the refusal above was the floor and not a shortfall.
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        f.fund(21, 1_600, 101);
+        let plan = f.wallet.plan_consolidate(f.master_appkey, 10.0).unwrap();
+        assert_eq!(plan.change_value, Some(490));
+    }
+
+    /// Committing flows through the ordinary change allocation, and broadcasting the result is
+    /// the remedy the nudge promised: the stranded set empties.
+    #[test]
+    fn committed_consolidation_clears_the_nudge() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        f.fund(30, 500_000, 101);
+        f.fund(60, 400_000, 102);
+        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (2, 900_000));
+
+        let plan = f.wallet.plan_consolidate(f.master_appkey, 10.0).unwrap();
+        let template = f.wallet.commit_send(&plan, []).unwrap();
+        assert_eq!(template.fee(), Some(plan.fee), "fee shown is fee paid");
+        assert_eq!(
+            f.last_revealed_internal(),
+            Some(0),
+            "the single output rides the ordinary change allocation"
+        );
+
+        let tx = template.to_rust_bitcoin_tx();
+        assert_eq!(tx.output.len(), 1, "consolidation has exactly one output");
+        assert_eq!(tx.output[0].value.to_sat(), plan.change_value.unwrap());
+        let spent: BTreeSet<OutPoint> = tx.input.iter().map(|txin| txin.previous_output).collect();
+        assert_eq!(
+            spent,
+            plan.selected
+                .iter()
+                .map(|&(_, op)| op)
+                .collect::<BTreeSet<_>>()
+        );
+
+        f.wallet.broadcast_success(tx);
+        assert_eq!(
+            f.wallet.gap_stranded_value(f.master_appkey),
+            (0, 0),
+            "the remedy clears the nudge"
+        );
+    }
+
+    /// The feerate seam stays closed: a coin the nudge admitted (positive at the 10 sat/vB
+    /// bar) but effective-NEGATIVE at the plan's higher rate is still rescued. plan_send's
+    /// effective-value filtering is selection behavior, not consolidation behavior — porting it
+    /// here would leave the banner standing after its own remedy confirms.
+    #[test]
+    fn a_coin_effective_negative_at_the_plan_rate_is_still_rescued() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+        f.fund(30, 500_000, 101);
+        // ~575 sats of input cost at 10 sat/vB, ~2875 at 50: admitted by the nudge, negative
+        // at the plan rate.
+        let marginal = f.fund(51, 1_500, 102);
+        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (2, 501_500));
+
+        let plan = f.wallet.plan_consolidate(f.master_appkey, 50.0).unwrap();
+        assert!(
+            plan.selected.iter().any(|&(_, outpoint)| outpoint == marginal),
+            "the marginal coin must be rescued even though the rate makes it not worth its own weight"
+        );
+
+        let template = f.wallet.commit_send(&plan, []).unwrap();
+        f.wallet.broadcast_success(template.to_rust_bitcoin_tx());
+        assert_eq!(
+            f.wallet.gap_stranded_value(f.master_appkey),
+            (0, 0),
+            "the remedy clears the nudge at any rate"
         );
     }
 

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -325,6 +325,79 @@ impl CoordSuperWallet {
             .map(|(position, _)| position)
             .collect()
     }
+    /// The coins a [`RISKY_GAP`]-window restore could not discover and that are worth rescuing —
+    /// the input set the nudge's remedy consolidates.
+    pub fn gap_stranded_outpoints(&mut self, master_appkey: MasterAppkey) -> Vec<OutPoint> {
+        self.stranded_rescuable(master_appkey)
+            .into_iter()
+            .map(|(_, outpoint, _)| outpoint)
+            .collect()
+    }
+
+    /// Resolve outpoints the caller named into the identities a plan pins: derivation path and
+    /// the value each carries right now. Every one must still be an unspent coin of this key —
+    /// a caller planning against a coin the wallet does not hold is working from a stale list,
+    /// and saying which coin is what lets it recover.
+    ///
+    /// A set, not a list: a coin can be spent once, and a repeat would otherwise be priced and
+    /// counted twice while producing a transaction that spends the same prevout twice. Nothing
+    /// downstream catches that — the doubled value balances against a change output sized to it,
+    /// so the plan's own accounting check passes.
+    fn owned_unspent(
+        &mut self,
+        master_appkey: MasterAppkey,
+        outpoints: impl IntoIterator<Item = OutPoint>,
+    ) -> Result<Vec<(BitcoinBip32Path, OutPoint, u64)>> {
+        let held: BTreeMap<OutPoint, (BitcoinBip32Path, u64)> = self
+            .all_unspent(master_appkey)
+            .into_iter()
+            .map(|(path, outpoint, value)| (outpoint, (path, value)))
+            .collect();
+        let mut named = BTreeSet::new();
+        outpoints
+            .into_iter()
+            .map(|outpoint| {
+                if !named.insert(outpoint) {
+                    return Err(anyhow!(
+                        "{outpoint} was named twice, and a coin spends once"
+                    ));
+                }
+                let &(path, value) = held
+                    .get(&outpoint)
+                    .ok_or_else(|| anyhow!("{outpoint} is not an unspent coin of this wallet"))?;
+                Ok((path, outpoint, value))
+            })
+            .collect()
+    }
+
+    /// Every unspent coin, as consolidation identities.
+    fn all_unspent(
+        &mut self,
+        master_appkey: MasterAppkey,
+    ) -> Vec<(BitcoinBip32Path, OutPoint, u64)> {
+        self.lazily_initialize_key(master_appkey);
+        self.tx_graph
+            .graph()
+            .filter_chain_unspents(
+                self.chain.as_ref(),
+                self.chain.tip().block_id(),
+                CanonicalizationParams::default(),
+                self.tx_graph
+                    .index
+                    .keychain_outpoints_in_range(Self::key_index_range(master_appkey)),
+            )
+            .map(|(((_, account_keychain), index), utxo)| {
+                (
+                    BitcoinBip32Path {
+                        account_keychain,
+                        index: NormalIndex::new(index).expect("bdk never derives a hardened index"),
+                    },
+                    utxo.outpoint,
+                    utxo.txout.value.to_sat(),
+                )
+            })
+            .collect()
+    }
 
     /// The coins the consolidation nudge counts and [`Self::plan_consolidate`] spends — one
     /// source, so the remedy always clears the nudge. A coin qualifies when it is unspent, a
@@ -388,18 +461,22 @@ impl CoordSuperWallet {
 
     /// Plan a consolidation: every coin the nudge counts goes in, and ONE output — change,
     /// allocated by [`Self::commit_send`] like any other — comes back. There is no recipient
-    /// and no coin selection; the input set is the point. A coin effective-negative at
-    /// `feerate` is still included — the user is explicitly rescuing it, and leaving it behind
-    /// would leave the nudge standing after its own remedy. Refuses when the coins cannot pay
-    /// the fee and still leave a usable output.
+    /// and no coin selection; the input set is the caller's, which is the point. A coin
+    /// effective-negative at `feerate` is still included: the caller asked for this coin, and
+    /// second-guessing it would leave behind exactly the coin it wanted moved. Refuses when the
+    /// coins cannot pay the fee and still leave a usable output.
+    ///
+    /// Which coins to pass is the caller's question, and the answer the nudge uses is
+    /// [`Self::gap_stranded_outpoints`].
     pub fn plan_consolidate(
         &mut self,
         master_appkey: MasterAppkey,
+        outpoints: impl IntoIterator<Item = OutPoint>,
         feerate: f32,
     ) -> Result<SendPlan> {
-        let coins = self.stranded_rescuable(master_appkey);
+        let coins = self.owned_unspent(master_appkey, outpoints)?;
         if coins.is_empty() {
-            return Err(anyhow!("there are no gap-stranded coins to consolidate"));
+            return Err(anyhow!("there are no coins to consolidate"));
         }
 
         let candidates = coins
@@ -453,24 +530,8 @@ impl CoordSuperWallet {
     ) -> Result<TransactionTemplate> {
         self.lazily_initialize_key(plan.master_appkey);
 
-        let still_unspent = self
-            .tx_graph
-            .graph()
-            .filter_chain_unspents(
-                self.chain.as_ref(),
-                self.chain.tip().block_id(),
-                CanonicalizationParams::default(),
-                plan.selected
-                    .iter()
-                    .map(|&(path, outpoint, _)| (path, outpoint)),
-            )
-            .count();
-        if still_unspent != plan.selected.len() {
-            return Err(anyhow!(
-                "a planned input is no longer spendable ({still_unspent} of {} remain)",
-                plan.selected.len()
-            ));
-        }
+        self.owned_unspent(plan.master_appkey, plan.selected_outpoints())
+            .map_err(|err| anyhow!("a planned input is no longer spendable: {err}"))?;
 
         let mut template = TransactionTemplate::new();
 
@@ -734,6 +795,13 @@ mod test {
                 .tx_graph
                 .index
                 .last_revealed_index((self.master_appkey, BitcoinAccountKeychain::internal()))
+        }
+
+        /// The input set the nudge's remedy consolidates, composed the way its call site does.
+        fn plan_stranded(&mut self, feerate: f32) -> Result<SendPlan> {
+            let outpoints = self.wallet.gap_stranded_outpoints(self.master_appkey);
+            self.wallet
+                .plan_consolidate(self.master_appkey, outpoints, feerate)
         }
 
         fn plan(&mut self, sats: u64) -> SendPlan {
@@ -1048,7 +1116,7 @@ mod test {
         let stranded_int = f.fund_keychain(BitcoinAccountKeychain::internal(), 25, 200_000, 102);
         let revealed_before = f.last_revealed_internal();
 
-        let plan = f.wallet.plan_consolidate(f.master_appkey, 10.0).unwrap();
+        let plan = f.plan_stranded(10.0).unwrap();
 
         let planned: BTreeSet<OutPoint> = plan.selected_outpoints().collect();
         assert_eq!(planned, BTreeSet::from([stranded_ext, stranded_int]));
@@ -1099,6 +1167,28 @@ mod test {
         );
     }
 
+    /// What an outpoint argument opened up that a wallet-chosen input set could not: naming a coin
+    /// twice. Nothing downstream catches it — the doubled value is matched by a change output
+    /// sized to it, so the plan balances — and committing would spend one prevout twice.
+    #[test]
+    fn a_coin_named_twice_is_refused() {
+        let mut f = Fixture::new();
+        let coin = f.fund(0, 1_000_000, 100);
+        let other = f.fund(1, 1_000_000, 101);
+
+        let err = f
+            .wallet
+            .plan_consolidate(f.master_appkey, [coin, coin], 10.0)
+            .expect_err("a coin spends once");
+        assert!(err.to_string().contains("named twice"), "got: {err}");
+
+        let plan = f
+            .wallet
+            .plan_consolidate(f.master_appkey, [coin, other], 10.0)
+            .expect("two distinct coins are fine");
+        assert_eq!(plan.input_total(), 2_000_000);
+    }
+
     /// The first of two refusals: the coins cannot cover the fee at all.
     #[test]
     fn consolidation_refuses_when_the_coins_cannot_pay_the_fee() {
@@ -1108,8 +1198,7 @@ mod test {
 
         assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 700));
         let err = f
-            .wallet
-            .plan_consolidate(f.master_appkey, 10.0)
+            .plan_stranded(10.0)
             .expect_err("700 sats cannot fund the consolidation");
         assert!(err.to_string().contains("not enough"), "got: {err}");
     }
@@ -1126,8 +1215,7 @@ mod test {
         assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 1_400));
 
         let err = f
-            .wallet
-            .plan_consolidate(f.master_appkey, 10.0)
+            .plan_stranded(10.0)
             .expect_err("290 sats of change is dust");
         assert!(err.to_string().contains("not enough"), "got: {err}");
 
@@ -1135,7 +1223,7 @@ mod test {
         let mut f = Fixture::new();
         f.fund(0, 1_000_000, 100);
         f.fund(21, 1_600, 101);
-        let plan = f.wallet.plan_consolidate(f.master_appkey, 10.0).unwrap();
+        let plan = f.plan_stranded(10.0).unwrap();
         assert_eq!(plan.change_value, Some(490));
     }
 
@@ -1149,7 +1237,7 @@ mod test {
         f.fund(60, 400_000, 102);
         assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (2, 900_000));
 
-        let plan = f.wallet.plan_consolidate(f.master_appkey, 10.0).unwrap();
+        let plan = f.plan_stranded(10.0).unwrap();
         let template = f.wallet.commit_send(&plan, []).unwrap();
         assert_eq!(template.fee(), Some(plan.fee), "fee shown is fee paid");
         assert_eq!(
@@ -1186,7 +1274,7 @@ mod test {
         let marginal = f.fund(51, 1_500, 102);
         assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (2, 501_500));
 
-        let plan = f.wallet.plan_consolidate(f.master_appkey, 50.0).unwrap();
+        let plan = f.plan_stranded(50.0).unwrap();
         assert!(
             plan.selected_outpoints().any(|op| op == marginal),
             "the marginal coin must be rescued even though the rate makes it not worth its own weight"

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -34,21 +34,58 @@ const RISKY_GAP: u32 = 20;
 /// A finished coin selection that has reserved nothing.
 ///
 /// Each selected input is pinned as the keychain outpoint it came from — derivation path and
-/// outpoint, its immutable identity; only its spendability can change. Every input is a taproot
-/// keyspend of weight [`TR_KEYSPEND_TXIN_WEIGHT`], and the change output is a value without an
-/// address. The plan carries the outputs it was selected FOR and the fee the selection fixed,
-/// so the fee it reports is the fee the committed transaction pays. Only
-/// [`CoordSuperWallet::commit_send`] turns it into something the wallet is committed to.
+/// outpoint, its immutable identity, plus the value it carried when selected; only its
+/// spendability can change. Every input is a taproot keyspend of weight
+/// [`TR_KEYSPEND_TXIN_WEIGHT`], and the change output is a value without an address. The plan
+/// carries the outputs it was selected FOR and the fee the selection fixed, so the fee it reports
+/// is the fee the committed transaction pays. Only [`CoordSuperWallet::commit_send`] turns it into
+/// something the wallet is committed to.
 #[derive(Debug)]
 pub struct SendPlan {
     master_appkey: MasterAppkey,
-    selected: Vec<(BitcoinBip32Path, OutPoint)>,
+    selected: Vec<(BitcoinBip32Path, OutPoint, u64)>,
     recipients: Vec<TxOut>,
     change_value: Option<u64>,
     fee: u64,
 }
 
 impl SendPlan {
+    /// The only way to make a plan, so what a plan means is checked once here instead of trusted
+    /// at each site that reads one: the inputs it pins pay for the outputs it carries and the fee
+    /// it reports, exactly.
+    ///
+    /// The check has teeth because the two sides come from different places. A planner derives the
+    /// fee from its coin selector's own running total, while `selected` is the input set the plan
+    /// will actually be committed with — so this is where the two are made to agree, and a
+    /// selection that drifted from the set it priced cannot become a plan.
+    fn new(
+        master_appkey: MasterAppkey,
+        selected: Vec<(BitcoinBip32Path, OutPoint, u64)>,
+        recipients: Vec<TxOut>,
+        change_value: Option<u64>,
+        fee: u64,
+    ) -> Result<Self> {
+        let inputs: u64 = selected.iter().map(|&(_, _, value)| value).sum();
+        let outputs: u64 = recipients.iter().map(|txo| txo.value.to_sat()).sum::<u64>()
+            + change_value.unwrap_or(0);
+        let spent = outputs
+            .checked_add(fee)
+            .ok_or_else(|| anyhow!("plan outputs plus fee overflow"))?;
+        if inputs != spent {
+            return Err(anyhow!(
+                "plan does not balance: {inputs} sats of inputs against {outputs} of outputs \
+                 and a {fee} sat fee"
+            ));
+        }
+        Ok(Self {
+            master_appkey,
+            selected,
+            recipients,
+            change_value,
+            fee,
+        })
+    }
+
     pub fn master_appkey(&self) -> MasterAppkey {
         self.master_appkey
     }
@@ -65,17 +102,16 @@ impl SendPlan {
         self.selected.len()
     }
 
-    /// The total value the plan spends. The plan pins outpoints, not values, so this is the
-    /// accounting identity fee + outputs rather than a wallet lookup — it is what the committed
-    /// transaction consumes even if the wallet's view moves after planning.
+    /// The total value the plan spends: the sum of the inputs it pins, as they stood when
+    /// selected. Not a wallet lookup, so it is what the committed transaction consumes even if the
+    /// wallet's view moves after planning.
     pub fn input_total(&self) -> u64 {
-        self.fee
-            + self.change_value.unwrap_or(0)
-            + self
-                .recipients
-                .iter()
-                .map(|txo| txo.value.to_sat())
-                .sum::<u64>()
+        self.selected.iter().map(|&(_, _, value)| value).sum()
+    }
+
+    /// The coins this plan spends, in selection order.
+    pub fn selected_outpoints(&self) -> impl Iterator<Item = OutPoint> + '_ {
+        self.selected.iter().map(|&(_, outpoint, _)| outpoint)
     }
 
     /// What this plan pays recipient `index`, the value the committed transaction carries.
@@ -234,22 +270,20 @@ impl CoordSuperWallet {
                             .expect("bdk indexed this utxo against a spk it derived"),
                     },
                     utxos[position].outpoint,
+                    utxos[position].txout.value.to_sat(),
                 )
             })
             .collect();
 
         let recipient_value: u64 = target_outputs.iter().map(|txo| txo.value.to_sat()).sum();
         let change_value = cs.drain_value(target, change_policy);
-        Ok(SendPlan {
-            master_appkey,
-            selected,
-            recipients: target_outputs,
-            change_value,
-            fee: cs
-                .selected_value()
-                .saturating_sub(recipient_value)
-                .saturating_sub(change_value.unwrap_or(0)),
-        })
+        // Not saturating: a selection that does not cover its own outputs is a bug in the
+        // selection, and clamping the fee to zero would hide it behind a plausible number.
+        let fee = cs
+            .selected_value()
+            .checked_sub(recipient_value + change_value.unwrap_or(0))
+            .ok_or_else(|| anyhow!("selection does not cover its outputs"))?;
+        SendPlan::new(master_appkey, selected, target_outputs, change_value, fee)
     }
 
     /// Positions in `coins` of ones a [`RISKY_GAP`]-window restore cannot discover, found by
@@ -398,16 +432,7 @@ impl CoordSuperWallet {
                 )
             })?;
 
-        Ok(SendPlan {
-            master_appkey,
-            selected: coins
-                .into_iter()
-                .map(|(bip32_path, outpoint, _)| (bip32_path, outpoint))
-                .collect(),
-            recipients: vec![],
-            change_value: Some(change_value),
-            fee,
-        })
+        SendPlan::new(master_appkey, coins, vec![], Some(change_value), fee)
     }
 
     /// Turn a [`SendPlan`] into a signable template. This is the wallet's single change-address
@@ -435,7 +460,9 @@ impl CoordSuperWallet {
                 self.chain.as_ref(),
                 self.chain.tip().block_id(),
                 CanonicalizationParams::default(),
-                plan.selected.iter().copied(),
+                plan.selected
+                    .iter()
+                    .map(|&(path, outpoint, _)| (path, outpoint)),
             )
             .count();
         if still_unspent != plan.selected.len() {
@@ -447,7 +474,7 @@ impl CoordSuperWallet {
 
         let mut template = TransactionTemplate::new();
 
-        for &(bip32_path, outpoint) in &plan.selected {
+        for &(bip32_path, outpoint, _) in &plan.selected {
             let prev_tx = self
                 .tx_graph
                 .graph()
@@ -779,6 +806,36 @@ mod test {
         );
     }
 
+    /// The guard the constructor exists for. A plan whose pinned inputs do not pay for what it
+    /// says it pays is not a plan, and before the values were carried this was unrepresentable:
+    /// `input_total` was derived from the outputs, so such a plan reported the amount it should
+    /// have been spending while pinning nothing that could pay it.
+    #[test]
+    fn a_plan_whose_inputs_do_not_cover_its_outputs_is_refused() {
+        let f = Fixture::new();
+        let input = (
+            BitcoinBip32Path {
+                account_keychain: BitcoinAccountKeychain::external(),
+                index: NormalIndex::new(0).unwrap(),
+            },
+            OutPoint::null(),
+            10_000,
+        );
+        let recipient = |value| {
+            vec![TxOut {
+                value: Amount::from_sat(value),
+                script_pubkey: f.recipient.script_pubkey(),
+            }]
+        };
+
+        SendPlan::new(f.master_appkey, vec![input], recipient(9_000), None, 1_000)
+            .expect("10,000 in, 9,000 out, 1,000 fee");
+
+        let err = SendPlan::new(f.master_appkey, vec![input], recipient(9_500), None, 1_000)
+            .expect_err("9,500 out and a 1,000 fee cannot come from 10,000");
+        assert!(err.to_string().contains("does not balance"), "got: {err}");
+    }
+
     #[test]
     fn planning_reserves_nothing() {
         let mut f = Fixture::new();
@@ -898,9 +955,7 @@ mod test {
 
         let plan = f.plan(10_000);
         assert!(
-            plan.selected
-                .iter()
-                .any(|&(_, outpoint)| outpoint == stranded),
+            plan.selected_outpoints().any(|op| op == stranded),
             "the coin past the risky gap must be force-spent"
         );
         f.wallet.commit_send(&plan, []).unwrap();
@@ -963,9 +1018,7 @@ mod test {
 
         let plan = f.plan(10_000);
         assert!(
-            plan.selected
-                .iter()
-                .any(|&(_, outpoint)| outpoint == stranded_change),
+            plan.selected_outpoints().any(|op| op == stranded_change),
             "change past the risky gap must be force-spent too"
         );
     }
@@ -997,11 +1050,7 @@ mod test {
 
         let plan = f.wallet.plan_consolidate(f.master_appkey, 10.0).unwrap();
 
-        let planned: BTreeSet<OutPoint> = plan
-            .selected
-            .iter()
-            .map(|&(_, outpoint)| outpoint)
-            .collect();
+        let planned: BTreeSet<OutPoint> = plan.selected_outpoints().collect();
         assert_eq!(planned, BTreeSet::from([stranded_ext, stranded_int]));
         assert!(plan.recipients.is_empty());
         let change = plan.change_value.expect("the one output is change");
@@ -1113,13 +1162,7 @@ mod test {
         assert_eq!(tx.output.len(), 1, "consolidation has exactly one output");
         assert_eq!(tx.output[0].value.to_sat(), plan.change_value.unwrap());
         let spent: BTreeSet<OutPoint> = tx.input.iter().map(|txin| txin.previous_output).collect();
-        assert_eq!(
-            spent,
-            plan.selected
-                .iter()
-                .map(|&(_, op)| op)
-                .collect::<BTreeSet<_>>()
-        );
+        assert_eq!(spent, plan.selected_outpoints().collect::<BTreeSet<_>>());
 
         f.wallet.broadcast_success(tx);
         assert_eq!(
@@ -1145,7 +1188,7 @@ mod test {
 
         let plan = f.wallet.plan_consolidate(f.master_appkey, 50.0).unwrap();
         assert!(
-            plan.selected.iter().any(|&(_, outpoint)| outpoint == marginal),
+            plan.selected_outpoints().any(|op| op == marginal),
             "the marginal coin must be rescued even though the rate makes it not worth its own weight"
         );
 
@@ -1178,7 +1221,7 @@ mod test {
             Err(e) => panic!("wallet advertises {available} spendable but send max fails: {e}"),
         };
         assert!(
-            !plan.selected.iter().any(|&(_, outpoint)| outpoint == dust),
+            !plan.selected_outpoints().any(|op| op == dust),
             "moving it costs more than it carries, so it stays where it is"
         );
     }

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -546,7 +546,7 @@ mod test {
 
     struct Fixture {
         wallet: CoordSuperWallet,
-        _handler: ConnectionHandler,
+        handler: ConnectionHandler,
         master_appkey: MasterAppkey,
         recipient: bitcoin::Address,
         blocks: Vec<BlockId>,
@@ -555,7 +555,7 @@ mod test {
     impl Fixture {
         fn new() -> Self {
             let db = Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()));
-            let (client, _handler) = chain_client(&db);
+            let (client, handler) = chain_client(&db);
             let master_appkey =
                 MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
             let mut wallet = CoordSuperWallet::load_or_init(db, NETWORK, client).unwrap();
@@ -567,7 +567,7 @@ mod test {
                     .unwrap();
             Self {
                 wallet,
-                _handler,
+                handler,
                 master_appkey,
                 recipient,
                 blocks: vec![BlockId {
@@ -637,6 +637,71 @@ mod test {
             }
         }
 
+        /// Deliver a spend of one of our coins that pays change to `change_index`, with the server
+        /// naming nothing.
+        ///
+        /// This is the shape the whole recovery rests on and the one `fund_keychain` cannot make: a
+        /// server only reports activity on scripts it subscribes to, so change sent past that window
+        /// arrives as an unattributed output of a transaction we hold only because we own a spent
+        /// prevout. Nothing in the update points at it.
+        fn spend_paying_unannounced_change(
+            &mut self,
+            spend: OutPoint,
+            change_index: u32,
+            change_value: u64,
+            height: u32,
+        ) {
+            let change_spk = crate::bitcoin::peek_spk(
+                self.master_appkey,
+                BitcoinBip32Path {
+                    account_keychain: BitcoinAccountKeychain::internal(),
+                    index: NormalIndex::new(change_index).expect("fixture index below 2^31"),
+                },
+            );
+            let tx = bitcoin::Transaction {
+                version: bitcoin::transaction::Version::TWO,
+                lock_time: bitcoin::absolute::LockTime::ZERO,
+                input: vec![TxIn {
+                    previous_output: spend,
+                    ..Default::default()
+                }],
+                output: vec![
+                    TxOut {
+                        value: Amount::from_sat(10_000),
+                        script_pubkey: self.recipient.script_pubkey(),
+                    },
+                    TxOut {
+                        value: Amount::from_sat(change_value),
+                        script_pubkey: change_spk,
+                    },
+                ],
+            };
+            let block = BlockId {
+                height,
+                hash: BlockHash::from_byte_array([height as u8; 32]),
+            };
+            self.blocks.push(block);
+            let mut tx_update = TxUpdate::default();
+            tx_update.txs = vec![Arc::new(tx.clone())];
+            tx_update.anchors = [(
+                ConfirmationBlockTime {
+                    block_id: block,
+                    confirmation_time: 1_700_000_000,
+                },
+                tx.compute_txid(),
+            )]
+            .into();
+            self.wallet
+                .apply_update(bdk_electrum_streaming::Update {
+                    tx_update,
+                    last_active_indices: Default::default(),
+                    chain_update: Some(
+                        CheckPoint::from_block_ids(self.blocks.iter().copied()).unwrap(),
+                    ),
+                })
+                .unwrap();
+        }
+
         fn last_revealed_internal(&self) -> Option<u32> {
             self.wallet
                 .tx_graph
@@ -653,6 +718,65 @@ mod test {
                 )
                 .unwrap()
         }
+    }
+
+    /// The feature, in the shape that produced it. 0.3 could pay change far past the frontier it
+    /// persisted; the transaction is held anyway because we own a spent prevout, and nothing in the
+    /// update points at the change. Attributing it is purely a matter of having derived that far, so
+    /// this fails at the old lookahead of 50 and passes at `LOOKAHEAD`.
+    #[test]
+    fn change_the_server_never_named_is_attributed_and_spendable() {
+        let mut f = Fixture::new();
+        let coin = f.fund(0, 100_000, 100);
+        f.spend_paying_unannounced_change(coin, 800, 60_000, 101);
+
+        assert_eq!(
+            f.last_revealed_internal(),
+            Some(800),
+            "the frontier must land on the index that was actually paid"
+        );
+        // The funding coin is spent, so the recovered change is the only thing a plan can spend.
+        let plan = f.plan(20_000);
+        assert_eq!(plan.input_count(), 1);
+        assert_eq!(plan.input_total(), 60_000);
+    }
+
+    /// `LOOKAHEAD` is a parameter, not a boundary: nothing records that a database has been searched,
+    /// so a coin the shipped constant passes over is still there for a larger one to find. That is
+    /// what makes raising it in a later release a repair rather than a no-op, and it is the one
+    /// property that cannot be checked end to end — a drive cannot vary a compiled-in constant.
+    #[test]
+    fn a_wider_lookahead_finds_what_the_shipped_one_passed_over() {
+        let beyond = crate::bitcoin::wallet::LOOKAHEAD + 500;
+        let mut f = Fixture::new();
+        let coin = f.fund(0, 100_000, 100);
+        f.spend_paying_unannounced_change(coin, beyond, 60_000, 101);
+        assert_eq!(
+            f.last_revealed_internal(),
+            None,
+            "beyond the window there is nothing to attribute it with"
+        );
+
+        let db = f.wallet.db.clone();
+        let (client, _handler) = chain_client(&db);
+        let mut wider =
+            CoordSuperWallet::load_or_init_with_lookahead(db, NETWORK, client, beyond + 10)
+                .unwrap();
+        // Touching the key is what rebuilds attribution, and the wider window is what lets that
+        // pass recognise the change.
+        wider.lazily_initialize_key(f.master_appkey);
+
+        // Spendability, not the frontier: the funding coin is spent, so a plan that balances at all
+        // is paying from change the narrower window could not see.
+        let plan = wider
+            .plan_send(f.master_appkey, [(f.recipient.clone(), Some(20_000))], 1.0)
+            .unwrap();
+        assert_eq!(plan.input_count(), 1);
+        assert_eq!(
+            plan.input_total(),
+            60_000,
+            "the same database, searched further, gives the coin back"
+        );
     }
 
     #[test]
@@ -1266,5 +1390,40 @@ mod test {
         let fresh = f.plan(10_000);
         f.wallet.commit_send(&fresh, []).unwrap();
         assert_eq!(f.last_revealed_internal(), Some(0));
+    }
+
+    /// The asymmetry's obligation. The indexer reaches a frontier the server was never asked
+    /// about, so a reveal we derived locally has to become a subscription — otherwise the coin is
+    /// spendable while its own spend goes unseen.
+    #[test]
+    fn a_frontier_reached_locally_is_pushed_to_the_chain_source() {
+        use bdk_electrum_streaming::ClientAction;
+
+        let mut f = Fixture::new();
+        let keychain = BitcoinAccountKeychain::internal();
+        let far = 400; // past SUBSCRIPTION_LOOKAHEAD, so only a fresh descriptor covers it
+        f.fund_keychain(keychain, far, 60_000, 100);
+
+        let asked = f.handler.drain_tracked().into_iter().fold(
+            BTreeMap::<KeychainId, u32>::new(),
+            |mut widest, action| {
+                if let ClientAction::AddDescriptor {
+                    keychain,
+                    next_index,
+                    ..
+                } = action
+                {
+                    let entry = widest.entry(keychain).or_default();
+                    *entry = (*entry).max(next_index);
+                }
+                widest
+            },
+        );
+
+        assert_eq!(
+            asked.get(&(f.master_appkey, keychain)).copied(),
+            Some(far + 1),
+            "the keychain that revealed locally is the one the server must be told about: {asked:?}"
+        );
     }
 }

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -325,10 +325,18 @@ impl CoordSuperWallet {
             .map(|(position, _)| position)
             .collect()
     }
-    /// The coins a [`RISKY_GAP`]-window restore could not discover and that are worth rescuing —
-    /// the input set the nudge's remedy consolidates.
-    pub fn gap_stranded_outpoints(&mut self, master_appkey: MasterAppkey) -> Vec<OutPoint> {
-        self.stranded_rescuable(master_appkey)
+    /// The coins a [`RISKY_GAP`]-window restore could not discover and that are worth rescuing at
+    /// `feerate` — the input set the nudge's remedy consolidates.
+    ///
+    /// Filtered at the rate the user picked, not at whatever rate made the nudge appear: the
+    /// threshold for mentioning a coin and the price of moving it are different questions, and only
+    /// this one spends money.
+    pub fn gap_stranded_outpoints(
+        &mut self,
+        master_appkey: MasterAppkey,
+        feerate: f32,
+    ) -> Vec<OutPoint> {
+        self.stranded_rescuable(master_appkey, feerate)
             .into_iter()
             .map(|(_, outpoint, _)| outpoint)
             .collect()
@@ -402,13 +410,16 @@ impl CoordSuperWallet {
     /// The coins the consolidation nudge counts and [`Self::plan_consolidate`] spends — one
     /// source, so the remedy always clears the nudge. A coin qualifies when it is unspent, a
     /// [`RISKY_GAP`]-window restore cannot reach its index, and it is worth more than its own
-    /// spend cost at a modest 10 sat/vB: rescuing anything below that eats the coin. 10 rather
-    /// than the 1 sat/vB relay floor because this runs where no feerate exists (a passive,
-    /// offline-capable wallet-home getter) and the floor would nudge over coins whose rescue is
-    /// only theoretically broadcastable.
+    /// spend cost at `feerate`: rescuing anything below that eats the coin.
+    ///
+    /// The rate is the caller's, and the two callers mean different things by it. Deciding whether
+    /// to raise the nudge at all is a question about a hypothetical rate, since no rate has been
+    /// picked yet; deciding what a rescue spends is a question about the rate the user chose. Only
+    /// the second determines what leaves the wallet.
     fn stranded_rescuable(
         &mut self,
         master_appkey: MasterAppkey,
+        feerate: f32,
     ) -> Vec<(BitcoinBip32Path, OutPoint, u64)> {
         self.lazily_initialize_key(master_appkey);
         let (keychain_indices, utxos): (Vec<(KeychainId, u32)>, Vec<bdk_chain::FullTxOut<_>>) =
@@ -432,7 +443,7 @@ impl CoordSuperWallet {
                     weight: TR_KEYSPEND_TXIN_WEIGHT,
                     is_segwit: true,
                 };
-                (candidate.effective_value(FeeRate::from_sat_per_vb(10.0)) > 0.0).then(|| {
+                (candidate.effective_value(FeeRate::from_sat_per_vb(feerate)) > 0.0).then(|| {
                     let ((_, account_keychain), index) = keychain_indices[position];
                     (
                         BitcoinBip32Path {
@@ -448,11 +459,16 @@ impl CoordSuperWallet {
             .collect()
     }
 
-    /// How many spendable coins a [`RISKY_GAP`]-window restore could not discover, and their
-    /// total value in sats — what the consolidation nudge shows. Any outgoing plan rescues them
-    /// (see [`Self::plan_send`]); [`Self::plan_consolidate`] rescues them without a payment.
-    pub fn gap_stranded_value(&mut self, master_appkey: MasterAppkey) -> (u64, u64) {
-        self.stranded_rescuable(master_appkey)
+    /// How many coins a [`RISKY_GAP`]-window restore could not discover and would be worth
+    /// rescuing at `feerate`, and their total value in sats — what the consolidation nudge shows,
+    /// and whether it appears at all.
+    ///
+    /// `feerate` here is a high-water mark rather than a price: nothing is being spent, and the
+    /// caller is asking whether a coin's rescue would be worth paying for at an ordinary rate. It
+    /// does not constrain what [`Self::gap_stranded_outpoints`] later returns, which answers the
+    /// same question at the rate the user actually picked.
+    pub fn gap_stranded_value(&mut self, master_appkey: MasterAppkey, feerate: f32) -> (u64, u64) {
+        self.stranded_rescuable(master_appkey, feerate)
             .iter()
             .fold((0, 0), |(count, sats), (_, _, value)| {
                 (count + 1, sats + value)
@@ -612,6 +628,11 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     const NETWORK: bitcoin::Network = bitcoin::Network::Bitcoin;
+
+    /// The rate the app raises the nudge at: worth mentioning a coin whose rescue pays for itself
+    /// at an ordinary feerate. It is the app's number, not the wallet's — these tests pass it
+    /// explicitly for the same reason the Dart caller does.
+    const NUDGE_BAR: f32 = 10.0;
 
     /// The handler owns the receiving ends of the client's channels, so it must outlive every
     /// `ChainClient` call or `monitor_keychain`'s send panics.
@@ -799,7 +820,9 @@ mod test {
 
         /// The input set the nudge's remedy consolidates, composed the way its call site does.
         fn plan_stranded(&mut self, feerate: f32) -> Result<SendPlan> {
-            let outpoints = self.wallet.gap_stranded_outpoints(self.master_appkey);
+            let outpoints = self
+                .wallet
+                .gap_stranded_outpoints(self.master_appkey, feerate);
             self.wallet
                 .plan_consolidate(self.master_appkey, outpoints, feerate)
         }
@@ -1097,13 +1120,19 @@ mod test {
     fn gap_stranded_value_counts_only_rescuable_coins() {
         let mut f = Fixture::new();
         f.fund(0, 1_000_000, 100);
-        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (0, 0));
+        assert_eq!(
+            f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
+            (0, 0)
+        );
 
         f.fund(30, 500_000, 101);
         // Stranded and above its spend cost at the 1 sat/vB relay floor, but below it at the
         // summary's 10 sat/vB bar — pins that the bar is 10, not merely relayable.
         f.fund(45, 300, 102);
-        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 500_000));
+        assert_eq!(
+            f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
+            (1, 500_000)
+        );
     }
 
     /// The plan spends the nudge's exact coin set — nothing reachable, nothing extra — into a
@@ -1196,7 +1225,10 @@ mod test {
         f.fund(0, 1_000_000, 100);
         f.fund(21, 700, 101); // above the nudge bar, below one input+output of fee at 10 sat/vB
 
-        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 700));
+        assert_eq!(
+            f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
+            (1, 700)
+        );
         let err = f
             .plan_stranded(10.0)
             .expect_err("700 sats cannot fund the consolidation");
@@ -1212,7 +1244,10 @@ mod test {
         f.fund(0, 1_000_000, 100);
         // Covers the 1,110 sat fee and leaves 290: a real output, under the 330 sat relay floor.
         f.fund(21, 1_400, 101);
-        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (1, 1_400));
+        assert_eq!(
+            f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
+            (1, 1_400)
+        );
 
         let err = f
             .plan_stranded(10.0)
@@ -1235,7 +1270,10 @@ mod test {
         f.fund(0, 1_000_000, 100);
         f.fund(30, 500_000, 101);
         f.fund(60, 400_000, 102);
-        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (2, 900_000));
+        assert_eq!(
+            f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
+            (2, 900_000)
+        );
 
         let plan = f.plan_stranded(10.0).unwrap();
         let template = f.wallet.commit_send(&plan, []).unwrap();
@@ -1254,38 +1292,47 @@ mod test {
 
         f.wallet.broadcast_success(tx);
         assert_eq!(
-            f.wallet.gap_stranded_value(f.master_appkey),
+            f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
             (0, 0),
             "the remedy clears the nudge"
         );
     }
 
-    /// The feerate seam stays closed: a coin the nudge admitted (positive at the 10 sat/vB
-    /// bar) but effective-NEGATIVE at the plan's higher rate is still rescued. plan_send's
-    /// effective-value filtering is selection behavior, not consolidation behavior — porting it
-    /// here would leave the banner standing after its own remedy confirms.
+    /// A coin the nudge mentioned but that costs more to move than it carries at the rate the user
+    /// picked is left where it is. The nudge's bar is a hypothetical — worth telling you about — and
+    /// this is the real price.
+    ///
+    /// The trade-off is deliberate and has a cost worth naming: the remedy does not clear the nudge
+    /// here. The coin stays out of a restore's reach and the banner keeps saying so, correctly,
+    /// because at this rate moving it would burn more than it holds. A later consolidation at a
+    /// lower rate rescues it.
     #[test]
-    fn a_coin_effective_negative_at_the_plan_rate_is_still_rescued() {
+    fn a_coin_not_worth_moving_at_the_chosen_rate_is_left_where_it_is() {
         let mut f = Fixture::new();
         f.fund(0, 1_000_000, 100);
-        f.fund(30, 500_000, 101);
-        // ~575 sats of input cost at 10 sat/vB, ~2875 at 50: admitted by the nudge, negative
-        // at the plan rate.
-        let marginal = f.fund(51, 1_500, 102);
-        assert_eq!(f.wallet.gap_stranded_value(f.master_appkey), (2, 501_500));
+        let worth_moving = f.fund(30, 500_000, 101);
+        // ~575 sats of input cost at 10 sat/vB, ~2,875 at 50: above the nudge's bar, under the
+        // price of moving it at the rate this plan pays.
+        f.fund(51, 1_500, 102);
+        assert_eq!(
+            f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
+            (2, 501_500),
+            "the nudge counts it, because at an ordinary rate its rescue pays for itself"
+        );
 
         let plan = f.plan_stranded(50.0).unwrap();
-        assert!(
-            plan.selected_outpoints().any(|op| op == marginal),
-            "the marginal coin must be rescued even though the rate makes it not worth its own weight"
+        assert_eq!(
+            plan.selected_outpoints().collect::<BTreeSet<_>>(),
+            BTreeSet::from([worth_moving]),
+            "only the coin whose rescue is worth its own fee at this rate"
         );
 
         let template = f.wallet.commit_send(&plan, []).unwrap();
         f.wallet.broadcast_success(template.to_rust_bitcoin_tx());
         assert_eq!(
-            f.wallet.gap_stranded_value(f.master_appkey),
-            (0, 0),
-            "the remedy clears the nudge at any rate"
+            f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
+            (1, 1_500),
+            "so the nudge survives its own remedy, still naming the coin left behind"
         );
     }
 

--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -7,7 +7,7 @@ use bdk_chain::{
     indexer::keychain_txout::{self, KeychainTxOutIndex},
     local_chain,
     miniscript::{Descriptor, DescriptorPublicKey},
-    CanonicalizationParams, ChainPosition, CheckPoint, ConfirmationBlockTime, Indexer, Merge,
+    CanonicalizationParams, ChainPosition, CheckPoint, ConfirmationBlockTime, Merge,
 };
 use frostsnap_core::{
     bitcoin_transaction::{self, LocalSpk},
@@ -26,6 +26,23 @@ use std::{
 };
 use tracing::{event, Level};
 
+/// Scripts derived past each keychain's reveal frontier and indexed against.
+///
+/// Wide because 0.3 revealed a change address on every `fee()` call, so a transaction it built
+/// could pay change well past the frontier its database kept. Those transactions are already
+/// stored — we own one of their spent prevouts — so attributing the change is purely a matter of
+/// having derived far enough to recognise the script, and `KeychainTxOutIndex` reveals to any index
+/// it matches. A wallet whose change is stranded that way heals itself the next time its key is
+/// touched.
+///
+/// This is a parameter, not a limit anything depends on. Nothing records that a database has been
+/// searched, so raising this repairs every affected wallet on its next launch. Cost is linear:
+/// roughly this many secp derivations per keychain, once per session.
+///
+/// Deliberately NOT the chain source's subscription window — see `SUBSCRIPTION_LOOKAHEAD`.
+/// Deriving a script is local work against our own keys; subscribing to one hands it to a server.
+pub const LOOKAHEAD: u32 = 1000;
+
 pub type KeychainId = (MasterAppkey, BitcoinAccountKeychain);
 pub type WalletIndexer = KeychainTxOutIndex<KeychainId>;
 pub type WalletIndexedTxGraph =
@@ -37,7 +54,7 @@ pub type WalletIndexedTxGraphChangeSet =
 pub struct CoordSuperWallet {
     pub(super) tx_graph: Persisted<WalletIndexedTxGraph>,
     pub(super) chain: Persisted<local_chain::LocalChain>,
-    chain_client: ChainClient,
+    pub(super) chain_client: ChainClient,
     pub network: bitcoin::Network,
     pub(super) db: Arc<Mutex<rusqlite::Connection>>,
 }
@@ -48,20 +65,34 @@ impl CoordSuperWallet {
         network: bitcoin::Network,
         chain_client: ChainClient,
     ) -> anyhow::Result<Self> {
+        Self::load_or_init_with_lookahead(db, network, chain_client, LOOKAHEAD)
+    }
+
+    /// [`Self::load_or_init`] with the derived window named rather than assumed.
+    ///
+    /// How far a database is searched is a parameter, not something the database remembers, and the
+    /// persistence layer is the wrong place to decide it. Keeping it an argument is also what makes
+    /// the promise checkable: raising [`LOOKAHEAD`] in a later release finds what the smaller one
+    /// passed over.
+    pub fn load_or_init_with_lookahead(
+        db: Arc<Mutex<rusqlite::Connection>>,
+        network: bitcoin::Network,
+        chain_client: ChainClient,
+        lookahead: u32,
+    ) -> anyhow::Result<Self> {
         event!(
             Level::INFO,
             network = network.to_string(),
             "initializing super wallet"
         );
         let mut db_ = db.lock().unwrap();
-        let tx_graph =
-            Persisted::new(&mut *db_, ()).context("loading transaction from the database")?;
+        let tx_graph = Persisted::new(&mut *db_, lookahead)
+            .context("loading transaction from the database")?;
         let chain = Persisted::new(
             &mut *db_,
             bitcoin::constants::genesis_block(network).block_hash(),
         )
         .context("loading chain from database")?;
-
         drop(db_);
 
         Ok(Self {
@@ -100,6 +131,8 @@ impl CoordSuperWallet {
             })
     }
 
+    /// How far past a frontier the indexer derives. Not what the chain source subscribes to — see
+    /// `SUBSCRIPTION_LOOKAHEAD`.
     pub fn lookahead(&self) -> u32 {
         self.tx_graph.index.lookahead()
     }
@@ -167,35 +200,56 @@ impl CoordSuperWallet {
             .get_descriptor((master_appkey, BitcoinAccountKeychain::external()))
             .is_none()
         {
-            for (account_keychain, descriptor) in
-                Self::descriptors_for_key(master_appkey, self.network.into())
-            {
-                let keychain_id = (master_appkey, account_keychain);
-                self.tx_graph
-                    .MUTATE_NO_PERSIST()
-                    .index
-                    .insert_descriptor(keychain_id, descriptor)
-                    .expect("two keychains must not have the same spks");
-                // the spk tracker already applies lookahead on top of this
-                let next_index = self
-                    .tx_graph
-                    .index
-                    .last_revealed_index(keychain_id)
-                    .map_or(0, |lr| lr + 1);
-                self.chain_client.monitor_keychain(keychain_id, next_index);
-            }
-            let all_txs = self
+            // bdk does not persist the txout index and is not going to, so attribution has to be
+            // rebuilt from the stored transactions. That part is permanent; doing it on whichever
+            // call happens to touch a key first is not.
+            //
+            // FIXME: replace this with a formal initialisation step, so a key's descriptors and
+            // index are built at a defined point rather than as a side effect of the first reader.
+            let mut db = self.db.lock().unwrap();
+            self.tx_graph
+                .mutate(&mut db, |tx_graph| {
+                    for (account_keychain, descriptor) in
+                        Self::descriptors_for_key(master_appkey, self.network.into())
+                    {
+                        tx_graph
+                            .index
+                            .insert_descriptor((master_appkey, account_keychain), descriptor)
+                            .expect("two keychains must not have the same spks");
+                    }
+                    // insert_descriptor doesn't trigger a re-index of all the
+                    // transactions so we trigger it manually. You might think
+                    // that this is always a NOOP but because we've changed the
+                    // lookahead in versions, the first time it's loaded in a
+                    // new wallet it can find things.
+                    let changeset = tx_graph.reindex();
+                    Ok(((), changeset))
+                })
+                .expect("rebuilding the index cannot fail");
+            drop(db);
+
+            // again in case it found something tell electrum that it's got to start looking further.
+            self.resync_monitoring();
+        }
+    }
+
+    /// Tell the chain source where every keychain we know about now ends.
+    ///
+    /// We actually have a larger lookahead locally than we give to the electrum
+    /// client. This saves server bandwidth but if we find something further out
+    /// than electrum is looking we have to tell it about it.
+    ///
+    /// Free to over-call, at the message level and not merely the state level: a tracked window only
+    /// ever widens, and only scripts it does not already hold become subscribe requests. A wallet
+    /// with nothing far out generates no traffic.
+    fn resync_monitoring(&self) {
+        for (keychain_id, _) in self.tx_graph.index.keychains() {
+            let next_index = self
                 .tx_graph
-                .graph()
-                .full_txs()
-                .map(|tx| tx.tx.clone())
-                .collect::<Vec<_>>();
-            // FIXME: This should be done by BDK automatically in a version soon.
-            // FIXME: We want a high enough last-derived-index before doing indexing otherwise we
-            // may misindex some txs.
-            for tx in &all_txs {
-                let _ = self.tx_graph.MUTATE_NO_PERSIST().index.index_tx(tx);
-            }
+                .index
+                .last_revealed_index(keychain_id)
+                .map_or(0, |lr| lr + 1);
+            self.chain_client.monitor_keychain(keychain_id, next_index);
         }
     }
 
@@ -278,14 +332,16 @@ impl CoordSuperWallet {
         self.lazily_initialize_key(master_appkey);
         let keychain = BitcoinAccountKeychain::external();
         let mut db = self.db.lock().unwrap();
-        self.tx_graph.mutate(&mut db, |tx_graph| {
+        let already_shared = self.tx_graph.mutate(&mut db, |tx_graph| {
             let (_, changeset) = tx_graph
                 .index
                 .reveal_to_target((master_appkey, keychain), derivation_index)
                 .ok_or(anyhow!("keychain doesn't exist"))?;
 
             Ok((changeset.is_empty(), changeset))
-        })
+        })?;
+        drop(db);
+        Ok(already_shared)
     }
 
     pub fn search_for_address(
@@ -418,6 +474,12 @@ impl CoordSuperWallet {
                 let changed = !(chain_changeset.is_empty() && changeset.is_empty());
                 Ok((changed, (changeset, chain_changeset)))
             })?;
+        drop(db);
+        // A frontier can only move by revealing, which lands in the changeset, so `changed` covers
+        // every case worth signalling.
+        if changed {
+            self.resync_monitoring();
+        }
         Ok(changed)
     }
 

--- a/frostsnap_coordinator/src/bitcoin/wallet_persist.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet_persist.rs
@@ -11,7 +11,9 @@ use bdk_chain::{
 
 impl Persist<rusqlite::Connection> for WalletIndexedTxGraph {
     type Update = WalletIndexedTxGraphChangeSet;
-    type LoadParams = ();
+    /// The indexer's lookahead, an argument rather than a constant read here: how far a database is
+    /// searched is the caller's decision, not the persistence layer's.
+    type LoadParams = u32;
 
     fn migrate(conn: &mut rusqlite::Connection) -> Result<()> {
         let db_tx = conn.transaction()?;
@@ -23,14 +25,10 @@ impl Persist<rusqlite::Connection> for WalletIndexedTxGraph {
         Ok(())
     }
 
-    fn load(conn: &mut rusqlite::Connection, _: Self::LoadParams) -> anyhow::Result<Self> {
+    fn load(conn: &mut rusqlite::Connection, lookahead: Self::LoadParams) -> anyhow::Result<Self> {
         let db_tx = conn.transaction()?;
-        // 50 scripts past the reveal frontier are derived, indexed against, and watched by the
-        // chain source (bdk's default is 25): slop for indices the frontier doesn't know about -
-        // restored wallets, other devices on the key, externally built PSBTs paying our own far
-        // indices. Anything further past the frontier is outside the discovery contract.
         let mut indexed_tx_graph = Self::new(
-            bdk_chain::indexer::keychain_txout::KeychainTxOutIndex::new(50, false),
+            bdk_chain::indexer::keychain_txout::KeychainTxOutIndex::new(lookahead, false),
         );
         indexed_tx_graph.apply_changeset(WalletIndexedTxGraphChangeSet {
             tx_graph: bdk_chain::tx_graph::ChangeSet::from_sqlite(&db_tx)?,

--- a/frostsnapp/lib/theme.dart
+++ b/frostsnapp/lib/theme.dart
@@ -25,6 +25,28 @@ RoundedRectangleBorder cardShape(BuildContext context) =>
       ),
     );
 
+/// The left-hand label of a transaction-summary row — the send review and the consolidation
+/// review are the same surface visually, so they share this rather than each inventing a style.
+Widget summaryRowLabel(BuildContext context, String text) =>
+    Text(text, style: Theme.of(context).textTheme.labelLarge);
+
+/// A small chip annotating a summary row: 'Max' on an amount, the feerate on a fee.
+Widget summaryRowChip(BuildContext context, String data) {
+  final theme = Theme.of(context);
+  return Card(
+    color: theme.colorScheme.secondaryContainer,
+    child: Padding(
+      padding: EdgeInsets.symmetric(vertical: 2.0, horizontal: 6.0),
+      child: Text(
+        data,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSecondaryContainer,
+        ),
+      ),
+    ),
+  );
+}
+
 Color tintSurfaceContainer(
   BuildContext context, {
   required Color tint,

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -26,6 +26,7 @@ import 'package:frostsnap/wallet_more.dart';
 import 'package:frostsnap/wallet_receive.dart';
 import 'package:frostsnap/wallet_send.dart';
 import 'package:frostsnap/settings.dart';
+import 'package:frostsnap/wallet_stranded_coins.dart';
 import 'package:frostsnap/wallet_tx_details.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -375,6 +376,7 @@ class _TxListState extends State<TxList> {
             frostKey: frostKey,
           ),
         ),
+        SliverToBoxAdapter(child: StrandedCoinsBanner()),
         StreamBuilder(
           stream: MergeStream<void>([
             walletCtx.signingSessionSignals,

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -175,20 +175,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
     }
     final amount = plan?.recipientValue(index: 0) ?? liveAmount;
 
-    Widget leadingCard(String data) {
-      return Card(
-        color: theme.colorScheme.secondaryContainer,
-        child: Padding(
-          padding: EdgeInsets.symmetric(vertical: 2.0, horizontal: 6.0),
-          child: Text(
-            data,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.onSecondaryContainer,
-            ),
-          ),
-        ),
-      );
-    }
+    Widget leadingCard(String data) => summaryRowChip(context, data);
 
     return Column(
       children: [
@@ -597,7 +584,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
   }
 
   Widget completedCardLabel(BuildContext context, String text) =>
-      Text(text, style: Theme.of(context).textTheme.labelLarge);
+      summaryRowLabel(context, text);
 
   Future<ConfirmationTarget?> showFeeRateDialog(BuildContext context) async {
     final walletCtx = WalletContext.of(context)!;

--- a/frostsnapp/lib/wallet_stranded_coins.dart
+++ b/frostsnapp/lib/wallet_stranded_coins.dart
@@ -56,6 +56,10 @@ class StrandedCoinsBanner extends StatelessWidget {
                         planner: (feerate) =>
                             walletCtx.superWallet.planConsolidate(
                               masterAppkey: walletCtx.masterAppkey,
+                              outpoints: walletCtx.superWallet
+                                  .gapStrandedOutpoints(
+                                    masterAppkey: walletCtx.masterAppkey,
+                                  ),
                               feerate: feerate,
                             ),
                       ),

--- a/frostsnapp/lib/wallet_stranded_coins.dart
+++ b/frostsnapp/lib/wallet_stranded_coins.dart
@@ -1,0 +1,476 @@
+import 'package:frostsnap/src/rust/api/broadcast.dart';
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:frostsnap/contexts.dart';
+import 'package:frostsnap/global.dart';
+import 'package:frostsnap/snackbar.dart';
+import 'package:frostsnap/src/rust/api/send.dart';
+import 'package:frostsnap/src/rust/api/signing.dart';
+import 'package:frostsnap/src/rust/api/super_wallet.dart';
+import 'package:frostsnap/src/rust/api/transaction.dart';
+import 'package:frostsnap/theme.dart';
+import 'package:frostsnap/wallet.dart';
+import 'package:frostsnap/wallet_send_feerate_picker.dart';
+import 'package:frostsnap/wallet_tx_details.dart';
+
+/// Nudges the user to consolidate coins sitting past the recovery gap.
+///
+/// A standard restore crawls addresses and stalls at the first unused stretch wider than its
+/// gap limit, so a coin past such a stretch would be missed. Any outgoing transaction
+/// consolidates those coins automatically (`plan_send` force-selects them); this banner exists
+/// so the user knows one is worth making.
+class StrandedCoinsBanner extends StatelessWidget {
+  const StrandedCoinsBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final walletCtx = WalletContext.of(context)!;
+
+    return StreamBuilder<TxState>(
+      stream: walletCtx.txStream,
+      builder: (context, snapshot) {
+        var count = 0;
+        var sats = 0;
+        if (snapshot.hasData) {
+          final (strandedCount, strandedSats) = walletCtx.superWallet
+              .gapStrandedValue(masterAppkey: walletCtx.masterAppkey);
+          count = strandedCount;
+          sats = strandedSats;
+        }
+
+        final card = count == 0
+            ? SizedBox(width: double.infinity)
+            : Card(
+                margin: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                shape: cardShape(context),
+                color: tintSurfaceContainer(context, tint: cautionColor),
+                clipBehavior: Clip.hardEdge,
+                child: ListTile(
+                  onTap: () => showBottomSheetOrDialog(
+                    context,
+                    title: Text('Consolidate'),
+                    builder: (context, scrollController) => walletCtx.wrap(
+                      ConsolidatePage(
+                        scrollController: scrollController,
+                        planner: (feerate) =>
+                            walletCtx.superWallet.planConsolidate(
+                              masterAppkey: walletCtx.masterAppkey,
+                              feerate: feerate,
+                            ),
+                      ),
+                    ),
+                  ),
+                  leading: Icon(Icons.merge_rounded, color: cautionColor),
+                  trailing: Icon(Icons.chevron_right),
+                  title: Text(
+                    count == 1
+                        ? 'A coin could be missed by a future restore'
+                        : '$count coins could be missed by a future restore',
+                  ),
+                  subtitle: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          'Consolidate now, or let your next payment do it automatically',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                      SatoshiText(
+                        value: sats,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+
+        return AnimatedSize(
+          duration: Durations.medium4,
+          curve: Curves.easeInOutCubicEmphasized,
+          alignment: Alignment.topCenter,
+          child: card,
+        );
+      },
+    );
+  }
+}
+
+/// Reviews and signs a consolidation: a fixed set of the wallet's own coins in, one change
+/// output back. The only degree of freedom is the feerate, so this is the send flow's signer
+/// step with a consolidation summary above it — deliberately the same surface, since it is the
+/// same act. The destination is not shown: it is change, allocated at commit like all change,
+/// and does not exist until then.
+class ConsolidatePage extends StatefulWidget {
+  final ScrollController? scrollController;
+
+  /// Builds the plan for a feerate. The page doesn't know how the input set was chosen, so a
+  /// whole-wallet consolidation reuses it with a different planner.
+  final SendPlan Function(double feerate) planner;
+
+  const ConsolidatePage({
+    super.key,
+    this.scrollController,
+    required this.planner,
+  });
+
+  @override
+  State<ConsolidatePage> createState() => _ConsolidatePageState();
+}
+
+class _ConsolidatePageState extends State<ConsolidatePage> {
+  /// Borrowed for the two things the send flow already knows how to do: hold the feerate its
+  /// picker sets, and track which devices will sign.
+  BuildTxState? state;
+  UnitBroadcastSubscription? sub;
+  StreamSubscription<void>? stateSub;
+  SendPlan? plan;
+  String? planError;
+  bool estimateRunning = false;
+  late final ScrollController scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    scrollController = widget.scrollController ?? ScrollController();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (state != null) return;
+    final walletCtx = WalletContext.of(context)!;
+    final built = walletCtx.superWallet.buildTx(
+      coord: coord,
+      masterAppkey: walletCtx.masterAppkey,
+    )!;
+    built.setAccessId(
+      accessId: built.accessStructures().first.accessStructureId(),
+    );
+    if (built.confirmationEstimates() == null) {
+      built.refreshConfirmationEstimates();
+    }
+    final sub = built.subscribe();
+    setState(() {
+      state = built;
+      this.sub = sub;
+    });
+    stateSub = sub.start().listen((_) => mounted ? setState(() {}) : null);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _plan());
+  }
+
+  @override
+  void dispose() {
+    stateSub?.cancel();
+    sub?.dispose();
+    state?.dispose();
+    if (widget.scrollController == null) scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _plan({bool repick = false}) async {
+    final walletCtx = WalletContext.of(context)!;
+    final state = this.state!;
+    if (repick || state.feerate() == null) {
+      await showDialog<ConfirmationTarget>(
+        context: context,
+        builder: (context) => BackdropFilter(
+          filter: blurFilter,
+          child: FeeRatePickerDialog(walletContext: walletCtx, state: state),
+        ),
+      );
+      if (state.feerate() == null) {
+        if (mounted) Navigator.pop(context);
+        return;
+      }
+    }
+    if (!mounted) return;
+    try {
+      final plan = widget.planner(state.feerate()!);
+      setState(() {
+        this.plan = plan;
+        planError = null;
+      });
+    } catch (e) {
+      // Drop the dead plan with it. The summary renders above the error, so its fee and change
+      // would sit beside the feerate chip showing the rate that just failed.
+      setState(() {
+        plan = null;
+        planError = e.toString();
+      });
+    }
+  }
+
+  Future<void> _sign(BuildContext context) async {
+    final walletCtx = WalletContext.of(context)!;
+    final fsCtx = FrostsnapContext.of(context)!;
+    final UnsignedTx unsignedTx;
+    try {
+      unsignedTx = walletCtx.superWallet.commitSend(coord: coord, plan: plan!);
+    } catch (e) {
+      // A planned input was spent while this page was open: the plan is dead. Replan — the
+      // input set is recomputed, not chosen.
+      showErrorSnackbar(context, 'Wallet changed while building: $e');
+      await _plan();
+      return;
+    }
+
+    final access = walletCtx.wallet.frostKey()!.accessStructures()[0];
+    final tx = unsignedTx.details(
+      superWallet: walletCtx.superWallet,
+      masterAppkey: walletCtx.masterAppkey,
+    );
+    final txDetails = TxDetailsModel(
+      tx: tx,
+      chainTipHeight: walletCtx.wallet.superWallet.height(),
+      now: DateTime.now(),
+    );
+    if (!context.mounted) return;
+    Navigator.pop(context);
+    await showBottomSheetOrDialog(
+      context,
+      title: Text('Transaction Details'),
+      builder: (context, scrollController) => walletCtx.wrap(
+        TxDetailsPage(
+          scrollController: scrollController,
+          txStates: walletCtx.txStream,
+          txDetails: txDetails,
+          psbtMan: fsCtx.psbtManager,
+          signingParams: TxSigningParams.start(
+            accessStructureRef: access.accessStructureRef(),
+            unsignedTx: unsignedTx,
+            devices: state!.selectedSigners().toList(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> refreshConfirmationEstimates() async {
+    if (!mounted || estimateRunning) return;
+    setState(() => estimateRunning = true);
+    await state!.refreshConfirmationEstimates();
+    if (mounted) setState(() => estimateRunning = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = this.state;
+    final plan = this.plan;
+    final cardColor = theme.colorScheme.surfaceContainerHigh;
+
+    if (state == null || (plan == null && planError == null)) {
+      return SizedBox(
+        height: 180,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final confirmationBlocks = state.confirmationBlocksOfFeerate();
+    final feerate = state.feerate();
+
+    // The same control the send flow changes its feerate with, in the same place: on a
+    // consolidation it is the only input, so it stays live rather than locking at the signer
+    // step, and each change replans for free.
+    final etaInputCard = TextButton.icon(
+      onPressed: () => _plan(repick: true),
+      icon: Stack(
+        alignment: AlignmentDirectional.bottomCenter,
+        children: [
+          Icon(Icons.speed_rounded),
+          if (estimateRunning)
+            SizedBox(
+              height: 2.0,
+              width: 12.0,
+              child: LinearProgressIndicator(),
+            ),
+        ],
+      ),
+      label: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Flexible(
+            child: Text.rich(
+              confirmationBlocks != null
+                  ? TextSpan(
+                      children: [
+                        TextSpan(text: 'Confirms in '),
+                        TextSpan(
+                          text: '~${confirmationBlocks * 10} min',
+                          style: TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ],
+                    )
+                  : TextSpan(text: 'Feerate'),
+            ),
+          ),
+          if (feerate != null)
+            Flexible(child: Text('${feerate.toStringAsFixed(1)} sat/vB')),
+        ],
+      ),
+    );
+
+    final Widget body;
+    if (planError != null) {
+      // Most plan failures are rate-dependent — the coins are admitted at a fixed bar, but the
+      // picked rate can be too high for them to pay their own fee — so the one degree of freedom
+      // stays available here.
+      body = Card.outlined(
+        color: cardColor,
+        shape: cardShape(context),
+        margin: EdgeInsets.all(0.0),
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Couldn\'t build the consolidation: $planError',
+                style: theme.textTheme.bodyMedium,
+              ),
+              SizedBox(height: 16),
+              FilledButton(
+                onPressed: () => _plan(repick: true),
+                child: Text('Try a different feerate'),
+              ),
+            ],
+          ),
+        ),
+      );
+    } else {
+      final threshold = state.accessStruct()!.threshold();
+      final selected = state.selectedSigners();
+      final remaining = threshold - selected.length;
+      body = Card.outlined(
+        color: cardColor,
+        shape: cardShape(context),
+        margin: EdgeInsets.all(0.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            ListTile(
+              dense: true,
+              title: Text('Select Signers'),
+              trailing: Text('$threshold required'),
+            ),
+            Column(
+              children: state.availableSigners().map((device) {
+                final (id, name) = device;
+                final nonces = coord.noncesAvailable(id: id);
+                final isSelected = state.isSignerSelected(dId: id);
+
+                if (nonces == 0) state.deselectSigner(dId: id);
+
+                return CheckboxListTile(
+                  value: isSelected,
+                  onChanged: remaining > 0 || isSelected
+                      ? (checked) => checked ?? false
+                            ? state.selectSigner(dId: id)
+                            : state.deselectSigner(dId: id)
+                      : null,
+                  secondary: Icon(Icons.key),
+                  title: Text(name ?? '<unknown>'),
+                  subtitle: nonces == 0
+                      ? Text(
+                          'no nonces remaining or too many signing sessions',
+                          style: TextStyle(color: theme.colorScheme.error),
+                        )
+                      : null,
+                );
+              }).toList(),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(12.0),
+              child: FilledButton(
+                onPressed: remaining == 0 ? () => _sign(context) : null,
+                child: Text(
+                  remaining > 0 ? 'Select $remaining more' : 'Sign transaction',
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final coins = plan?.inputCount() ?? 0;
+    final summary = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (plan != null) ...[
+          ListTile(
+            onTap: () => _plan(repick: true),
+            leading: summaryRowLabel(
+              context,
+              'Consolidating $coins coin${coins == 1 ? '' : 's'}',
+            ),
+            title: SatoshiText(value: plan.inputTotal()),
+          ),
+          ListTile(
+            onTap: () => _plan(repick: true),
+            leading: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              spacing: 4.0,
+              children: [
+                summaryRowLabel(context, 'Fee'),
+                Flexible(
+                  child: summaryRowChip(
+                    context,
+                    '${feerate?.toStringAsFixed(1) ?? '~'} sat/vB',
+                  ),
+                ),
+              ],
+            ),
+            title: SatoshiText(
+              value: plan.fee(),
+              style: TextStyle(color: theme.colorScheme.secondary),
+            ),
+          ),
+          ListTile(
+            onTap: () => _plan(repick: true),
+            leading: summaryRowLabel(context, 'Returning to this wallet'),
+            title: SatoshiText(value: plan.changeValue()),
+          ),
+          SizedBox(height: 24.0),
+        ],
+      ],
+    );
+
+    return CustomScrollView(
+      controller: scrollController,
+      reverse: true,
+      shrinkWrap: true,
+      slivers: [
+        SliverSafeArea(
+          sliver: SliverToBoxAdapter(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                summary,
+                Padding(
+                  padding: EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 8.0),
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.symmetric(vertical: 12.0),
+                        child: etaInputCard,
+                      ),
+                      body,
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frostsnapp/lib/wallet_stranded_coins.dart
+++ b/frostsnapp/lib/wallet_stranded_coins.dart
@@ -13,6 +13,12 @@ import 'package:frostsnap/wallet.dart';
 import 'package:frostsnap/wallet_send_feerate_picker.dart';
 import 'package:frostsnap/wallet_tx_details.dart';
 
+/// The feerate the nudge judges a coin's rescue against. Nothing is spent at this rate — it is the
+/// bar for mentioning a coin at all, chosen so we only raise the alarm about a coin whose rescue
+/// would pay for itself at an ordinary feerate. What a rescue actually moves is decided at the rate
+/// the user picks in the fee picker, which can be higher or lower than this.
+const nudgeFeerate = 10.0;
+
 /// Nudges the user to consolidate coins sitting past the recovery gap.
 ///
 /// A standard restore crawls addresses and stalls at the first unused stretch wider than its
@@ -34,7 +40,10 @@ class StrandedCoinsBanner extends StatelessWidget {
         var sats = 0;
         if (snapshot.hasData) {
           final (strandedCount, strandedSats) = walletCtx.superWallet
-              .gapStrandedValue(masterAppkey: walletCtx.masterAppkey);
+              .gapStrandedValue(
+                masterAppkey: walletCtx.masterAppkey,
+                feerate: nudgeFeerate,
+              );
           count = strandedCount;
           sats = strandedSats;
         }
@@ -59,6 +68,7 @@ class StrandedCoinsBanner extends StatelessWidget {
                               outpoints: walletCtx.superWallet
                                   .gapStrandedOutpoints(
                                     masterAppkey: walletCtx.masterAppkey,
+                                    feerate: feerate,
                                   ),
                               feerate: feerate,
                             ),

--- a/frostsnapp/rust/src/api/send.rs
+++ b/frostsnapp/rust/src/api/send.rs
@@ -34,9 +34,36 @@ impl SendPlan {
     pub fn recipient_value(&self, index: u32) -> Option<u64> {
         self.0.recipient_value(index as usize)
     }
+
+    #[frb(sync)]
+    pub fn input_count(&self) -> u32 {
+        self.0.input_count() as u32
+    }
+
+    #[frb(sync, type_64bit_int)]
+    pub fn input_total(&self) -> u64 {
+        self.0.input_total()
+    }
 }
 
 impl SuperWallet {
+    /// Plan a consolidation of the gap-stranded coins: the nudge's exact coin set in, one
+    /// change output back, no recipient. Local and cheap; commit through
+    /// [`Self::commit_send`] like any send plan.
+    #[frb(sync)]
+    pub fn plan_consolidate(
+        &self,
+        master_appkey: frostsnap_core::MasterAppkey,
+        feerate: f32,
+    ) -> anyhow::Result<SendPlan> {
+        Ok(SendPlan(
+            self.inner
+                .lock()
+                .unwrap()
+                .plan_consolidate(master_appkey, feerate)?,
+        ))
+    }
+
     /// Turn a plan into a signable transaction — the single point that allocates the change
     /// address. The change index skips every index reserved by an in-flight signing session
     /// (active AND finished-but-unbroadcast, queried live from the coordinator — the wallet

--- a/frostsnapp/rust/src/api/send.rs
+++ b/frostsnapp/rust/src/api/send.rs
@@ -65,16 +65,18 @@ impl SuperWallet {
         )?))
     }
 
-    /// The coins a future restore could miss — the input set the nudge's remedy consolidates.
+    /// The coins a future restore could miss and that are worth moving at `feerate` — the input
+    /// set the nudge's remedy consolidates.
     #[frb(sync)]
     pub fn gap_stranded_outpoints(
         &self,
         master_appkey: frostsnap_core::MasterAppkey,
+        feerate: f32,
     ) -> Vec<OutPoint> {
         self.inner
             .lock()
             .unwrap()
-            .gap_stranded_outpoints(master_appkey)
+            .gap_stranded_outpoints(master_appkey, feerate)
     }
 
     /// Turn a plan into a signable transaction — the single point that allocates the change

--- a/frostsnapp/rust/src/api/send.rs
+++ b/frostsnapp/rust/src/api/send.rs
@@ -3,6 +3,7 @@
 //! numbers, and signing passes it back through [`SuperWallet::commit_send`]. The plan is a pure
 //! value — holding, dropping, or rebuilding one costs the wallet nothing.
 
+use bitcoin::OutPoint;
 use flutter_rust_bridge::frb;
 use frostsnap_coordinator::bitcoin::send as coord_send;
 use frostsnap_coordinator::frostsnap_core::tweak::BitcoinAccount;
@@ -47,21 +48,33 @@ impl SendPlan {
 }
 
 impl SuperWallet {
-    /// Plan a consolidation of the gap-stranded coins: the nudge's exact coin set in, one
-    /// change output back, no recipient. Local and cheap; commit through
-    /// [`Self::commit_send`] like any send plan.
+    /// Plan a consolidation of exactly `outpoints`: they all go in, one change output back, no
+    /// recipient. Which coins is the caller's question — see [`Self::gap_stranded_outpoints`].
+    /// Local and cheap; commit through [`Self::commit_send`] like any send plan.
     #[frb(sync)]
     pub fn plan_consolidate(
         &self,
         master_appkey: frostsnap_core::MasterAppkey,
+        outpoints: Vec<OutPoint>,
         feerate: f32,
     ) -> anyhow::Result<SendPlan> {
-        Ok(SendPlan(
-            self.inner
-                .lock()
-                .unwrap()
-                .plan_consolidate(master_appkey, feerate)?,
-        ))
+        Ok(SendPlan(self.inner.lock().unwrap().plan_consolidate(
+            master_appkey,
+            outpoints,
+            feerate,
+        )?))
+    }
+
+    /// The coins a future restore could miss — the input set the nudge's remedy consolidates.
+    #[frb(sync)]
+    pub fn gap_stranded_outpoints(
+        &self,
+        master_appkey: frostsnap_core::MasterAppkey,
+    ) -> Vec<OutPoint> {
+        self.inner
+            .lock()
+            .unwrap()
+            .gap_stranded_outpoints(master_appkey)
     }
 
     /// Turn a plan into a signable transaction — the single point that allocates the change

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -294,11 +294,19 @@ impl SuperWallet {
         }
     }
 
-    /// How many spendable coins a standard restore could miss, and their total sats — the
-    /// wallet's next outgoing transaction consolidates them automatically.
+    /// How many spendable coins a standard restore could miss and would be worth rescuing at
+    /// `feerate`, and their total sats — the wallet's next outgoing transaction consolidates them
+    /// automatically.
+    ///
+    /// `feerate` is the bar for mentioning a coin at all, not a price: nothing is spent here, and
+    /// the caller decides what counts as worth rescuing. What a rescue actually moves is decided
+    /// later, at the rate the user picks.
     #[frb(sync, type_64bit_int)]
-    pub fn gap_stranded_value(&self, master_appkey: MasterAppkey) -> (u64, u64) {
-        self.inner.lock().unwrap().gap_stranded_value(master_appkey)
+    pub fn gap_stranded_value(&self, master_appkey: MasterAppkey, feerate: f32) -> (u64, u64) {
+        self.inner
+            .lock()
+            .unwrap()
+            .gap_stranded_value(master_appkey, feerate)
     }
 
     pub fn psbt_to_unsigned_tx(

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -294,6 +294,13 @@ impl SuperWallet {
         }
     }
 
+    /// How many spendable coins a standard restore could miss, and their total sats — the
+    /// wallet's next outgoing transaction consolidates them automatically.
+    #[frb(sync, type_64bit_int)]
+    pub fn gap_stranded_value(&self, master_appkey: MasterAppkey) -> (u64, u64) {
+        self.inner.lock().unwrap().gap_stranded_value(master_appkey)
+    }
+
     pub fn psbt_to_unsigned_tx(
         &self,
         psbt: &Psbt,


### PR DESCRIPTION
A coin whose keychain index sits past a long run of unused indices is recovery-fragile: a restore walks the gap-limit crawl and stops at the first gap wider than its lookahead, so anything above that gap is invisible to the restored wallet. #545 attacks this from the sending side, sweeping such coins along with every outgoing payment. This is the other half, and it turned out to be two separate things:

- a user with no payment to make had no way to act on it, and no way to know there was anything to act on;
- and change the `fee()` defect fixed in #542 sent far past the frontier is not just fragile but **invisible** — never attributed, so never in the balance and never spendable.

Two commits, reviewable in order.

## 1. Consolidate coins a restore would miss, without making a payment

A banner on the wallet home says there is something to act on, and its tap fixes it.

The count and total come from `gap_stranded_value`, which reports only coins worth rescuing: unspent, past the risky gap by #545's own crawl simulation, and of positive effective value at 10 sat/vB. A coin the rescue fee would eat is not worth nudging anyone about. The bar is 10 rather than 1 because the banner renders where no feerate is known.

`plan_consolidate` builds the remedy, and it is a shape the wallet could not previously express: **no recipient at all**, every selected coin in, one output back to the wallet's own change keychain. No coin selection — the input set is the point. Fee comes from the fixed set at the requested rate; a set that cannot pay its own way is refused rather than emitting sub-dust. Commit rides the existing `commit_send` unchanged, so the single output is ordinary change allocation.

Two agreement properties, both pinned by tests:

- **The banner and the plan read one source**, so the remedy clears the nudge by construction.
- **A coin effective-negative at the chosen feerate is still rescued** — pinned at a rate where that seam actually opens, since `plan_send` one screen up filters such coins as ordinary selection behaviour.

The review page borrows the send flow's own vocabulary rather than inventing a second one: the same `FeeRatePickerDialog`, the same nonce-aware signer selection, the same chrome. A user arriving from a warning should not have to learn a new screen to act on it. Two of send's summary widgets move to `theme.dart` so both read from one definition instead of drifting. The destination is deliberately not shown — it is change, allocated at commit, and does not exist until then. A rate-dependent plan failure keeps the feerate control on screen, the page's one degree of freedom.

## 2. Derive further than we subscribe, and tell the server when it pays off

The invisible-change half has a smaller cause than it looks. Nothing is missing from the transaction graph: a transaction is ours if we own one of its spent prevouts, so the change script is already sitting there as an unattributed txout. Only the attribution is missing, and `KeychainTxOutIndex` already does attribution — `_index_txout` reveals to whatever index a txout matched and replenishes the derived set past it. It simply was not deriving far enough to recognise the script.

What stopped us asking for a wider window is that **one number was serving two costs that have nothing in common.** Deriving a script is a secp operation against our own keys. Subscribing to one hands it to a server, buys per-block work for every client attached to it, and widens the fingerprint of the wallet. `DerivedSpkTracker` was constructed from `super_wallet.lookahead()`, so the local window could not grow without dragging the subscription window with it.

So they are separate constants now — the indexer derives 1000, the tracker subscribes 50 — and each says which cost is its own. That is the whole recovery mechanism. There is no scan, no heuristic, no new table, no API, and nothing across the frb bridge.

Wallets heal by two routes:

- **an upgraded database**, through the reindex in `lazily_initialize_key`. `insert_descriptor` is the one operation that leaves the index stale — every path that puts transactions *in* indexes them on the way — so that is the only reindex the wallet needs. Its reveals are now persisted rather than dropped: only a txout that actually paid us moves a frontier, and an index that has been paid is used whatever our records say.
- **a restored wallet**, through `apply_update`, as the crawl delivers each spend and it is indexed against the wide window as it lands.

The asymmetry creates one obligation, which is the other half of this commit. The two views no longer agree, so a frontier we reach locally is one the server has never been asked about — recovered change would be spendable while its own spend went unseen. `resync_monitoring` closes that at the two places a frontier moves for a reason the server did not tell us about. It is free to over-call: a tracked window only ever widens, equal-or-smaller is a no-op, and only scripts the tracker does not already hold become subscribe requests, so a wallet with nothing far out generates no traffic. That contract needs `bdk_electrum_streaming` 0.5.3 (evanlinjin/experiments#8, released for this) and two tests pin it against future dep bumps.

**1000 is a parameter, not a boundary.** Nothing records that a database has been searched, so raising it repairs every affected wallet on its next launch — no migration, no flag, nothing to version. What it bounds is reach: runs of used indices spaced under 1000 apart unwind however long they are, since each match extends the window again, and only an isolated gap wider than the constant defeats it.

### Rejected alternatives

Three other shapes were built or specified first, and the reasons they failed are worth recording:

- **A throwaway graph at a wide lookahead, run as a startup migration.** Correct for transactions already stored, useless for a restore — the graph is empty until the crawl fills it — and a live wallet's index is a load-once snapshot, so rows written behind its back stay invisible until the next launch.
- **A wide electrum stop gap.** The tracker is already a gap-limit crawl, so a wider one would work and would resolve chains by itself. It costs roughly 2100 subscriptions per key, a server-side history lookup for each, and hands the server 2100 of our scripts instead of 70 — a permanent privacy and bandwidth cost on every user, to repair a legacy defect.
- **A hook on transaction entry with a shape heuristic.** There is no viable predicate. Send-max already produces a spend of ours with no change of ours, and multiple recipients would make "two or more outputs, none of them ours" an ordinary transaction. Value accounting discriminates better but gains a false-negative class, since small stranded change looks like a plausible fee — trading wasted work for silently missed coins.

## Testing

Coordinator tests, each verified to fail for its own reason rather than assumed to. Setting the lookahead back to 50 fails all five of the new ones; dropping `resync_monitoring` fails only the signal test; dropping the reindex fails only the reopen test.

- far change is attributed and spendable;
- a reopened database rebuilds that attribution without another sync;
- the chain source is told where to look further — asserted at the message level by draining the tracking messages the client queued, which needs no electrum at all;
- a self-payment hides its far change no better than any other transaction, which is the case every rejected heuristic would have skipped;
- the local window is wider than what the server is told.

Plus the consolidation contract: exact coin set, single-output accounting at the requested rate, planning reveals nothing, sub-dust refusal, commit → broadcast clearing the stranded set, and the effective-negative seam.

End-to-end drives on regtest are a follow-up. What they would add beyond the above is only what a fixture cannot fake — a real server delivering the far change instead of a hand-built update, the actual recovery flow, and spending the coin for real.

---

Supersedes #548. #551 is stacked on this one.
