### PR TITLE
Consolidate (n): whole-wallet consolidation from More Actions

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -342,6 +342,47 @@ impl CoordSuperWallet {
             .collect()
     }
 
+    /// The coins a whole-wallet consolidation spends: every one the wallet holds that is worth more
+    /// than it costs to move at `feerate`.
+    ///
+    /// A coin below its own spend cost is left where it is, because moving it destroys value —
+    /// 300 sats carried against roughly 575 of input cost at 10 sat/vB — and forfeits spending it
+    /// later at a rate where it does pay. That is the same coin [`Self::plan_send`] declines to
+    /// force and [`Self::calculate_avaliable_value`] leaves out of the spendable figure, so
+    /// including it here would spend value the wallet does not count as spendable.
+    ///
+    /// Filtered at the rate the user picked rather than a nominal one: a manual consolidation runs
+    /// behind the ordinary feerate picker, so the caller holds the real rate when it composes the
+    /// set, and coins enter and leave it as that rate moves.
+    pub fn all_unspent_outpoints(
+        &mut self,
+        master_appkey: MasterAppkey,
+        feerate: f32,
+    ) -> Vec<OutPoint> {
+        let rate = FeeRate::from_sat_per_vb(feerate);
+        self.all_unspent(master_appkey)
+            .into_iter()
+            .filter(|&(_, _, value)| {
+                Candidate {
+                    input_count: 1,
+                    value,
+                    weight: TR_KEYSPEND_TXIN_WEIGHT,
+                    is_segwit: true,
+                }
+                .effective_value(rate)
+                    > 0.0
+            })
+            .map(|(_, outpoint, _)| outpoint)
+            .collect()
+    }
+
+    /// How many coins the wallet holds — what the "Consolidate (n)" menu action shows and gates on
+    /// (one coin into one coin is a pure fee burn). A plain count: which of them a consolidation
+    /// actually spends depends on the rate the user has not picked yet.
+    pub fn utxo_count(&mut self, master_appkey: MasterAppkey) -> usize {
+        self.all_unspent(master_appkey).len()
+    }
+
     /// Resolve outpoints the caller named into the identities a plan pins: derivation path and
     /// the value each carries right now. Every one must still be an unspent coin of this key —
     /// a caller planning against a coin the wallet does not hold is working from a stale list,
@@ -519,7 +560,7 @@ impl CoordSuperWallet {
             .filter(|value| *value >= TR_DUST_RELAY_MIN_VALUE)
             .ok_or_else(|| {
                 anyhow!(
-                    "the {} stranded coin(s) hold {sum} sats — not enough to pay the {fee} sat \
+                    "the {} coin(s) hold {sum} sats — not enough to pay the {fee} sat \
                      fee and leave a usable output",
                     coins.len()
                 )
@@ -816,6 +857,14 @@ mod test {
                 .tx_graph
                 .index
                 .last_revealed_index((self.master_appkey, BitcoinAccountKeychain::internal()))
+        }
+
+        fn plan_all(&mut self, feerate: f32) -> Result<SendPlan> {
+            let outpoints = self
+                .wallet
+                .all_unspent_outpoints(self.master_appkey, feerate);
+            self.wallet
+                .plan_consolidate(self.master_appkey, outpoints, feerate)
         }
 
         /// The input set the nudge's remedy consolidates, composed the way its call site does.
@@ -1334,6 +1383,79 @@ mod test {
             f.wallet.gap_stranded_value(f.master_appkey, NUDGE_BAR),
             (1, 1_500),
             "so the nudge survives its own remedy, still naming the coin left behind"
+        );
+    }
+
+    /// Whole-wallet consolidation: every coin worth moving at the chosen rate goes into one
+    /// output, and one that is not stays where it is. Cleaning up should not cost more than the
+    /// mess — a coin carrying less than its own input cost makes the user poorer by merging it, and
+    /// forfeits spending it later at a rate where it pays.
+    #[test]
+    fn all_scope_leaves_behind_what_costs_more_than_it_carries() {
+        let mut f = Fixture::new();
+        let reachable = f.fund(0, 1_000_000, 100);
+        let stranded = f.fund(30, 500_000, 101);
+        let dust = f.fund(1, 1_500, 102); // ~2,875 sats of input cost at the plan rate
+        assert_eq!(f.wallet.utxo_count(f.master_appkey), 3);
+        let revealed_before = f.last_revealed_internal();
+
+        let plan = f.plan_all(50.0).unwrap();
+        assert_eq!(
+            f.last_revealed_internal(),
+            revealed_before,
+            "planning must not reveal"
+        );
+        let planned: BTreeSet<OutPoint> = plan.selected_outpoints().collect();
+        assert_eq!(planned, BTreeSet::from([reachable, stranded]));
+        assert!(
+            !planned.contains(&dust),
+            "merging it would cost more than it carries"
+        );
+        assert!(plan.recipients.is_empty());
+        assert_eq!(
+            plan.fee + plan.change_value.unwrap(),
+            1_500_000,
+            "every input sat is accounted for"
+        );
+    }
+
+    /// The planner prices the set it is given and forms no opinion about it. Moving one coin into
+    /// one coin is a pure fee burn for a coin already within reach and the entire point for one a
+    /// restore would miss — a difference only the caller knows it is making, and both callers gate
+    /// on it themselves: the menu hides the action below two coins, and the banner appears only
+    /// when something is stranded.
+    #[test]
+    fn a_single_coin_is_planned_because_the_caller_asked_for_it() {
+        let mut f = Fixture::new();
+        f.fund(0, 500_000, 100); // reachable: pointless to move, and planned anyway
+        assert_eq!(f.wallet.utxo_count(f.master_appkey), 1);
+        let plan = f.plan_all(10.0).expect("the planner does what it is told");
+        assert_eq!(plan.input_count(), 1);
+
+        let mut f = Fixture::new();
+        f.fund(30, 500_000, 100); // past RISKY_GAP, so a restore would miss it
+        f.plan_all(10.0)
+            .expect("and the same for the coin where moving it is the point");
+        f.plan_stranded(10.0)
+            .expect("both paths plan the same lone coin");
+    }
+
+    /// The shortfall guard is scope-independent, and says so without calling reachable coins
+    /// stranded.
+    #[test]
+    fn all_scope_refuses_when_the_coins_cannot_pay_the_fee() {
+        let mut f = Fixture::new();
+        // 700 each: above the ~575 sat cost of its own input at this rate, so both survive into
+        // the set, and 1,400 together is still under the ~1,685 sat fee for two inputs.
+        f.fund(0, 700, 100);
+        f.fund(1, 700, 101);
+        let err = f
+            .plan_all(10.0)
+            .expect_err("1,400 sats cannot fund two inputs and an output");
+        assert!(err.to_string().contains("not enough"), "got: {err}");
+        assert!(
+            !err.to_string().contains("stranded"),
+            "reachable coins must not be described as stranded: {err}"
         );
     }
 

--- a/frostsnapp/lib/wallet_more.dart
+++ b/frostsnapp/lib/wallet_more.dart
@@ -73,47 +73,95 @@ class _WalletMoreState extends State<WalletMore> {
     final isDeveloperMode =
         SettingsContext.of(context)?.settings.isInDeveloperMode() ?? false;
 
-    final signColumn = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        spacing: 2,
-        children: [
-          ListTile(
-            contentPadding: contentPadding,
-            tileColor: tileColor,
-            shape: isDeveloperMode ? tileShapeTop : tileShapeSingle,
-            title: Text('PSBT'),
-            subtitle: Text('Sign a partially signed bitcoin transaction'),
-            leading: Icon(Icons.edit_document),
-            onTap: () async {
-              await MaybeFullscreenDialog.show(
-                context: context,
-                child: walletCtx.wrap(LoadPsbtPage(wallet: walletCtx.wallet)),
-              );
-            },
+    final signColumn = StreamBuilder(
+      stream: walletCtx.txStream,
+      builder: (context, _) {
+        final utxos = walletCtx.superWallet.utxoCount(
+          masterAppkey: walletCtx.masterAppkey,
+        );
+        // One coin into one coin is a pure fee burn, so the action only exists past that.
+        final showConsolidate = utxos > 1;
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 2,
+            children: [
+              ListTile(
+                contentPadding: contentPadding,
+                tileColor: tileColor,
+                shape: showConsolidate || isDeveloperMode
+                    ? tileShapeTop
+                    : tileShapeSingle,
+                title: Text('PSBT'),
+                subtitle: Text('Sign a partially signed bitcoin transaction'),
+                leading: Icon(Icons.edit_document),
+                onTap: () async {
+                  await MaybeFullscreenDialog.show(
+                    context: context,
+                    child: walletCtx.wrap(
+                      LoadPsbtPage(wallet: walletCtx.wallet),
+                    ),
+                  );
+                },
+              ),
+              if (showConsolidate)
+                ListTile(
+                  contentPadding: contentPadding,
+                  tileColor: tileColor,
+                  shape: isDeveloperMode ? tileShape : tileShapeEnd,
+                  title: Text('Consolidate ($utxos)'),
+                  subtitle: Text(
+                    'Merge all coins into one — this links them together on-chain',
+                  ),
+                  leading: Icon(Icons.merge_rounded),
+                  onTap: () => showBottomSheetOrDialog(
+                    context,
+                    title: Text('Consolidate'),
+                    builder: (context, scrollController) => walletCtx.wrap(
+                      ConsolidatePage(
+                        scrollController: scrollController,
+                        description:
+                            'Merges all of this wallet\'s coins into one. This '
+                            'links your coins together on-chain; everything '
+                            'returns to this wallet, minus the fee.',
+                        planner: (feerate) =>
+                            walletCtx.superWallet.planConsolidate(
+                              masterAppkey: walletCtx.masterAppkey,
+                              outpoints: walletCtx.superWallet
+                                  .allUnspentOutpoints(
+                                    masterAppkey: walletCtx.masterAppkey,
+                                    feerate: feerate,
+                                  ),
+                              feerate: feerate,
+                            ),
+                      ),
+                    ),
+                  ),
+                ),
+              if (isDeveloperMode)
+                ListTile(
+                  contentPadding: contentPadding,
+                  tileColor: tileColor,
+                  shape: tileShapeEnd,
+                  title: Text('Message'),
+                  subtitle: Text('Sign an arbitrary message'),
+                  leading: Icon(Icons.edit_note),
+                  onTap: frostKey == null
+                      ? null
+                      : () async {
+                          await MaybeFullscreenDialog.show(
+                            context: context,
+                            child: walletCtx.wrap(
+                              SignMessagePage(frostKey: frostKey),
+                            ),
+                          );
+                        },
+                ),
+            ],
           ),
-          if (isDeveloperMode)
-            ListTile(
-              contentPadding: contentPadding,
-              tileColor: tileColor,
-              shape: tileShapeEnd,
-              title: Text('Message'),
-              subtitle: Text('Sign an arbitrary message'),
-              leading: Icon(Icons.edit_note),
-              onTap: frostKey == null
-                  ? null
-                  : () async {
-                      await MaybeFullscreenDialog.show(
-                        context: context,
-                        child: walletCtx.wrap(
-                          SignMessagePage(frostKey: frostKey),
-                        ),
-                      );
-                    },
-            ),
-        ],
-      ),
+        );
+      },
     );
 
     final manageColumn = Padding(
@@ -175,49 +223,6 @@ class _WalletMoreState extends State<WalletMore> {
               );
             },
           ),
-          StreamBuilder(
-            stream: walletCtx.txStream,
-            builder: (context, _) {
-              final utxos = walletCtx.superWallet.utxoCount(
-                masterAppkey: walletCtx.masterAppkey,
-              );
-              // One coin into one coin is a pure fee burn, so the action only exists past that.
-              if (utxos <= 1) return SizedBox.shrink();
-              return ListTile(
-                contentPadding: contentPadding,
-                tileColor: tileColor,
-                shape: tileShape,
-                title: Text('Consolidate ($utxos)'),
-                subtitle: Text(
-                  'Merge all coins into one — this links them together on-chain',
-                ),
-                leading: Icon(Icons.merge_rounded),
-                onTap: () => showBottomSheetOrDialog(
-                  context,
-                  title: Text('Consolidate'),
-                  builder: (context, scrollController) => walletCtx.wrap(
-                    ConsolidatePage(
-                      scrollController: scrollController,
-                      description:
-                          'Merges all of this wallet\'s coins into one. This '
-                          'links your coins together on-chain; everything '
-                          'returns to this wallet, minus the fee.',
-                      planner: (feerate) =>
-                          walletCtx.superWallet.planConsolidate(
-                            masterAppkey: walletCtx.masterAppkey,
-                            outpoints: walletCtx.superWallet
-                                .allUnspentOutpoints(
-                                  masterAppkey: walletCtx.masterAppkey,
-                                  feerate: feerate,
-                                ),
-                            feerate: feerate,
-                          ),
-                    ),
-                  ),
-                ),
-              );
-            },
-          ),
           ListTile(
             contentPadding: contentPadding,
             tileColor: tileColor,
@@ -256,7 +261,7 @@ class _WalletMoreState extends State<WalletMore> {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        makeTitle(context, title: Text('Sign data')),
+        makeTitle(context, title: Text('Sign')),
         signColumn,
         makeTitle(context, title: Text('Manage wallet')),
         manageColumn,

--- a/frostsnapp/lib/wallet_more.dart
+++ b/frostsnapp/lib/wallet_more.dart
@@ -9,6 +9,7 @@ import 'package:frostsnap/psbt.dart';
 import 'package:frostsnap/settings.dart';
 import 'package:frostsnap/sign_message.dart';
 import 'package:frostsnap/theme.dart';
+import 'package:frostsnap/wallet_stranded_coins.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';
 
 class WalletMore extends StatefulWidget {
@@ -171,6 +172,49 @@ class _WalletMoreState extends State<WalletMore> {
               await MaybeFullscreenDialog.show(
                 context: context,
                 child: walletCtx.wrap(CheckAddressPage()),
+              );
+            },
+          ),
+          StreamBuilder(
+            stream: walletCtx.txStream,
+            builder: (context, _) {
+              final utxos = walletCtx.superWallet.utxoCount(
+                masterAppkey: walletCtx.masterAppkey,
+              );
+              // One coin into one coin is a pure fee burn, so the action only exists past that.
+              if (utxos <= 1) return SizedBox.shrink();
+              return ListTile(
+                contentPadding: contentPadding,
+                tileColor: tileColor,
+                shape: tileShape,
+                title: Text('Consolidate ($utxos)'),
+                subtitle: Text(
+                  'Merge all coins into one — this links them together on-chain',
+                ),
+                leading: Icon(Icons.merge_rounded),
+                onTap: () => showBottomSheetOrDialog(
+                  context,
+                  title: Text('Consolidate'),
+                  builder: (context, scrollController) => walletCtx.wrap(
+                    ConsolidatePage(
+                      scrollController: scrollController,
+                      description:
+                          'Merges all of this wallet\'s coins into one. This '
+                          'links your coins together on-chain; everything '
+                          'returns to this wallet, minus the fee.',
+                      planner: (feerate) =>
+                          walletCtx.superWallet.planConsolidate(
+                            masterAppkey: walletCtx.masterAppkey,
+                            outpoints: walletCtx.superWallet
+                                .allUnspentOutpoints(
+                                  masterAppkey: walletCtx.masterAppkey,
+                                  feerate: feerate,
+                                ),
+                            feerate: feerate,
+                          ),
+                    ),
+                  ),
+                ),
               );
             },
           ),

--- a/frostsnapp/lib/wallet_stranded_coins.dart
+++ b/frostsnapp/lib/wallet_stranded_coins.dart
@@ -126,10 +126,15 @@ class ConsolidatePage extends StatefulWidget {
   /// whole-wallet consolidation reuses it with a different planner.
   final SendPlan Function(double feerate) planner;
 
+  /// An optional line above the summary, for entry points that need to say something the rows
+  /// cannot (whole-wallet consolidation links every coin on-chain).
+  final String? description;
+
   const ConsolidatePage({
     super.key,
     this.scrollController,
     required this.planner,
+    this.description,
   });
 
   @override
@@ -409,10 +414,21 @@ class _ConsolidatePageState extends State<ConsolidatePage> {
       );
     }
 
+    final description = widget.description;
     final coins = plan?.inputCount() ?? 0;
     final summary = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        if (description != null)
+          Padding(
+            padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
+            child: Text(
+              description,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
         if (plan != null) ...[
           ListTile(
             onTap: () => _plan(repick: true),

--- a/frostsnapp/rust/src/api/send.rs
+++ b/frostsnapp/rust/src/api/send.rs
@@ -49,7 +49,8 @@ impl SendPlan {
 
 impl SuperWallet {
     /// Plan a consolidation of exactly `outpoints`: they all go in, one change output back, no
-    /// recipient. Which coins is the caller's question — see [`Self::gap_stranded_outpoints`].
+    /// recipient. Which coins is the caller's question — see [`Self::gap_stranded_outpoints`]
+    /// and [`Self::all_unspent_outpoints`].
     /// Local and cheap; commit through [`Self::commit_send`] like any send plan.
     #[frb(sync)]
     pub fn plan_consolidate(
@@ -77,6 +78,26 @@ impl SuperWallet {
             .lock()
             .unwrap()
             .gap_stranded_outpoints(master_appkey, feerate)
+    }
+
+    /// Every coin worth moving at `feerate` — the input set a whole-wallet consolidation spends.
+    /// A coin carrying less than its own input cost is left alone rather than merged at a loss.
+    #[frb(sync)]
+    pub fn all_unspent_outpoints(
+        &self,
+        master_appkey: frostsnap_core::MasterAppkey,
+        feerate: f32,
+    ) -> Vec<OutPoint> {
+        self.inner
+            .lock()
+            .unwrap()
+            .all_unspent_outpoints(master_appkey, feerate)
+    }
+
+    /// How many coins the wallet holds — the "Consolidate (n)" menu action's badge and gate.
+    #[frb(sync)]
+    pub fn utxo_count(&self, master_appkey: frostsnap_core::MasterAppkey) -> u32 {
+        self.inner.lock().unwrap().utxo_count(master_appkey) as u32
     }
 
     /// Turn a plan into a signable transaction — the single point that allocates the change


### PR DESCRIPTION
Stacked on #550 (review the tip commit).

#550 gives the stranded-coins nudge a remedy: merge the coins a restore would miss into one, with no payment involved. This generalises it to the obvious user request — **merge everything** — because nothing downstream of choosing the input set cares why the coins were chosen.

## Change

- `plan_consolidate` takes a `ConsolidationScope`: `Stranded` (the nudge's set, behaviour unchanged) or `All` (every unspent coin). The fee arithmetic, sub-dust refusal, commit boundary and review page are shared verbatim.
- `utxo_count` for the menu's badge and its gate.
- **"Consolidate (n)" in More Actions**, visible only past one coin, opening the same `ConsolidatePage` the banner opens — the page already took its input set as a planner closure, so this needed no page changes beyond an optional description line.

Two policy decisions, both deliberate and pinned by tests:

- **`All` includes coins effective-negative at the chosen rate.** The user asked to clean the wallet; leaving dust behind defeats that. The total-level fee/dust guard remains the safety boundary.
- **`All` refuses a single coin** — merging one coin into one coin only pays a fee — enforced in the wallet, not the menu, so a direct call or a tap racing a spend can't build it. `Stranded` stays unbounded there: moving one stranded coin back within a restore's reach is exactly the point.

Whole-wallet consolidation links every coin on-chain, so both surfaces say so rather than leaving it implied.

## Screenshots

The menu entry counting three coins, with the linking note:

![menu entry](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-551/04-menu-entry.png)

The shared review page — the send flow's own vocabulary (row labels, fee chip, ETA feerate button, signer card): 1.5 BTC in, 226 sat fee at 1.0 sat/vB, 1.49999774 returning:

![review](https://raw.githubusercontent.com/LLFourn/frostsnap-artifacts/main/pr-551/03-review.png)

## Testing

- Coordinator: `All` plans every coin (reachable, stranded, and dust not worth its own weight at the rate) into one output with the accounting identity holding and planning revealing nothing; the whole-wallet remedy also clears the stranded nudge and leaves exactly one coin; the single-coin refusal alongside `Stranded` still rescuing one; the sub-dust refusal is scope-independent and its wording no longer calls reachable coins "stranded".
- End-to-end on regtest (real bitcoind + electrs, device-signed): the action is absent at one coin, present as "Consolidate (3)", opens the shared page, signs, and after one confirmation the action gates itself off again while `scantxoutset` over the wallet's own exported descriptor sees exactly one unspent output. Both stranded-path scenarios still pass unchanged.
