### PR TITLE
Only treat a PSBT output as ours if our key owns it

### DIFF
--- a/frostsnap_coordinator/src/bitcoin.rs
+++ b/frostsnap_coordinator/src/bitcoin.rs
@@ -83,6 +83,34 @@ fn peek_spk(approot: MasterAppkey, path: BitcoinBip32Path) -> ScriptBuf {
         .script_pubkey()
 }
 
+/// A wallet on an in-memory database. The handler owns the receiving ends of the chain
+/// client's channels, so it has to outlive the wallet.
+#[cfg(test)]
+pub(crate) fn test_wallet(
+    network: bitcoin::Network,
+) -> (wallet::CoordSuperWallet, chain_sync::ConnectionHandler) {
+    use std::sync::{Arc, Mutex};
+    let db = Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()));
+    let trusted = {
+        let mut conn = db.lock().unwrap();
+        crate::persist::Persisted::new(&mut *conn, network).unwrap()
+    };
+    let (client, handler) = chain_sync::ChainClient::new(
+        bitcoin::constants::genesis_block(network).block_hash(),
+        chain_sync::ElectrumConfig {
+            enabled: crate::settings::ElectrumEnabled::None,
+            primary: String::new(),
+            backup: String::new(),
+        },
+        trusted,
+        db.clone(),
+    );
+    (
+        wallet::CoordSuperWallet::load_or_init(db, network, client).unwrap(),
+        handler,
+    )
+}
+
 #[cfg(test)]
 mod test {
     use bitcoin::Network;

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -372,38 +372,18 @@ impl CoordSuperWallet {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::bitcoin::chain_sync::{ChainClient, ConnectionHandler, ElectrumConfig};
+    use crate::bitcoin::chain_sync::ConnectionHandler;
+    use crate::bitcoin::test_wallet;
     use crate::bitcoin::wallet::CoordSuperWallet;
-    use crate::persist::Persisted;
-    use crate::settings::ElectrumEnabled;
     use bdk_chain::{
         bitcoin::{hashes::Hash, BlockHash, TxIn},
         BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate,
     };
     use frostsnap_core::schnorr_fun::fun::Point;
     use std::str::FromStr;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     const NETWORK: bitcoin::Network = bitcoin::Network::Bitcoin;
-
-    /// The handler owns the receiving ends of the client's channels, so it must outlive every
-    /// `ChainClient` call or `monitor_keychain`'s send panics.
-    fn chain_client(db: &Arc<Mutex<rusqlite::Connection>>) -> (ChainClient, ConnectionHandler) {
-        let trusted = {
-            let mut conn = db.lock().unwrap();
-            Persisted::new(&mut *conn, NETWORK).unwrap()
-        };
-        ChainClient::new(
-            bitcoin::constants::genesis_block(NETWORK).block_hash(),
-            ElectrumConfig {
-                enabled: ElectrumEnabled::None,
-                primary: String::new(),
-                backup: String::new(),
-            },
-            trusted,
-            db.clone(),
-        )
-    }
 
     struct Fixture {
         wallet: CoordSuperWallet,
@@ -415,11 +395,9 @@ mod test {
 
     impl Fixture {
         fn new() -> Self {
-            let db = Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()));
-            let (client, _handler) = chain_client(&db);
+            let (mut wallet, _handler) = test_wallet(NETWORK);
             let master_appkey =
                 MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
-            let mut wallet = CoordSuperWallet::load_or_init(db, NETWORK, client).unwrap();
             wallet.list_addresses(master_appkey);
             let recipient =
                 bitcoin::Address::from_str("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")

--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -612,24 +612,26 @@ impl CoordSuperWallet {
             owned_count += 1;
         }
 
-        for (i, _) in psbt.outputs.iter().enumerate() {
-            let txout = &rust_bitcoin_tx.output[i];
+        for txout in &rust_bitcoin_tx.output {
+            // An owned output keeps a derivation path, not the script, and the template
+            // re-derives it: our appkey on another wallet's address repoints the payment at us.
             match self
                 .tx_graph
                 .index
                 .index_of_spk(txout.script_pubkey.clone())
             {
-                Some(&((_, account_keychain), index)) => template.push_owned_output(
-                    txout.value,
-                    LocalSpk {
-                        master_appkey,
-                        bip32_path: BitcoinBip32Path {
-                            account_keychain,
-                            index,
+                Some(&((owner, account_keychain), index)) if owner == master_appkey => template
+                    .push_owned_output(
+                        txout.value,
+                        LocalSpk {
+                            master_appkey,
+                            bip32_path: BitcoinBip32Path {
+                                account_keychain,
+                                index,
+                            },
                         },
-                    },
-                ),
-                None => {
+                    ),
+                _ => {
                     template.push_foreign_output(txout.clone());
                 }
             }
@@ -741,8 +743,72 @@ pub struct ConfirmationTime {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::bitcoin::{peek_spk, test_wallet};
     use bitcoin::key::{Secp256k1, TweakedPublicKey};
-    use frostsnap_core::{schnorr_fun::fun::Point, tweak::AppTweak};
+    use frostsnap_core::{
+        schnorr_fun::fun::Point,
+        tweak::{AppTweak, DerivationPathExt},
+    };
+
+    fn appkey() -> MasterAppkey {
+        MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()))
+    }
+
+    #[test]
+    fn a_psbt_output_paying_another_loaded_wallet_stays_foreign() {
+        let (mut wallet, _handler) = test_wallet(bitcoin::Network::Bitcoin);
+        let (signer, other) = (appkey(), appkey());
+        wallet.lazily_initialize_key(signer);
+        wallet.lazily_initialize_key(other);
+
+        let path = BitcoinBip32Path::external(0);
+        let unsigned_tx = bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![bitcoin::TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::from_sat(90_000),
+                script_pubkey: peek_spk(other, path),
+            }],
+        };
+        let mut psbt = bitcoin::Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+
+        // The input classifier only reads the key origin, so the internal key itself can be
+        // any valid point.
+        let internal_key = bitcoin::secp256k1::XOnlyPublicKey::from_str(
+            "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        )
+        .unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: peek_spk(signer, path),
+        });
+        psbt.inputs[0].tap_internal_key = Some(internal_key);
+        psbt.inputs[0].tap_key_origins.insert(
+            internal_key,
+            (
+                vec![],
+                (
+                    signer.derive_appkey(AppTweakKind::Bitcoin).fingerprint(),
+                    bip32::DerivationPath::from_normal_path_segments(
+                        path.path_segments_from_bitcoin_appkey(),
+                    ),
+                ),
+            ),
+        );
+
+        let template = wallet.psbt_to_tx_template(&psbt, signer).unwrap();
+
+        assert_eq!(
+            template.to_rust_bitcoin_tx().output,
+            psbt.unsigned_tx.output,
+            "the signed transaction must still pay the address the PSBT named"
+        );
+        assert!(
+            template.outputs()[0].local_owner().is_none(),
+            "another wallet's address is not our own change"
+        );
+    }
 
     #[test]
     fn wallet_descriptors_match_our_tweaking() {


### PR DESCRIPTION
`index_of_spk` looks a script up across every wallet loaded in the app and tells you which one derives it. The PSBT output loop threw that answer away and stamped the signing wallet's key on it instead.

So with two wallets open, signing a PSBT that pays wallet B's address produced a transaction paying wallet A at the same index. Nothing is stealable here, but the transaction signed isn't the one the PSBT asked for.
 
Two commits: the first shares the test wallet fixture send.rs already had inline; the second is the fix, one file plus the first tests over `psbt_to_tx_template`. The test asserts that the signed transaction's outputs still equal the PSBT's, rather than how the output gets labelled -- remove the guard and it fails on exactly that.