### PR TITLE
Delete the unused bip32 path to DerivationPath conversion

### DIFF
--- a/frostsnap_core/src/tweak.rs
+++ b/frostsnap_core/src/tweak.rs
@@ -160,18 +160,6 @@ impl BitcoinBip32Path {
     }
 }
 
-impl From<BitcoinBip32Path> for DerivationPath {
-    fn from(bip32_path: BitcoinBip32Path) -> Self {
-        DerivationPath::from_normal_path_segments(
-            bip32_path
-                .account_keychain
-                .account
-                .path_segments_from_bitcoin_appkey()
-                .chain(core::iter::once(bip32_path.index.to_u32())),
-        )
-    }
-}
-
 #[derive(
     Clone, Copy, Debug, PartialEq, bincode::Encode, bincode::Decode, Eq, Hash, PartialOrd, Ord,
 )]


### PR DESCRIPTION
`From<BitcoinBip32Path> for DerivationPath` reached through to the account, so it emitted three segments and dropped the keychain. Receive `#7` and change `#7` converted to the same path, and neither round-tripped through `from_u32_slice`.

This PR originally fixed it. Deleting is better.
