### PR TITLE
[widgets] Settle hold progress before a touch flips `holding`

### DIFF
--- a/frostsnap_widgets/src/hold_to_confirm.rs
+++ b/frostsnap_widgets/src/hold_to_confirm.rs
@@ -218,7 +218,10 @@ where
         current_time: crate::Instant,
         is_release: bool,
     ) -> Option<crate::KeyTouch> {
-        // Handle touch on the border (which will pass it to content)
+        // This touch is about to flip `holding`, and elapsed time is accounted
+        // differently either side of that flip, so settle progress against the
+        // state that has actually been in effect since the last draw.
+        self.update_progress(current_time);
         self.content.handle_touch(point, current_time, is_release)
     }
 
@@ -243,9 +246,7 @@ where
     where
         D: DrawTarget<Color = Self::Color>,
     {
-        if self.is_holding() || self.content.get_progress() > Frac::ZERO {
-            self.update_progress(current_time);
-        }
+        self.update_progress(current_time);
 
         // Draw the border (which includes the content)
         self.content.draw(target, current_time)?;


### PR DESCRIPTION
## The bug

Tapping a hold-to-confirm button and pressing it again later confirms
instantly, with no hold.

`HoldToConfirm` keeps one timestamp, `last_update`, and spends the interval
since it either as hold credit or as decay depending on `is_holding()`. Nothing
settles that interval when `holding` changes, because `holding` only changes in
`handle_touch`, which never touched the timer. A press therefore charges the
whole gap since the last draw — time the user spent *not* holding — to the new
hold.

The reported tap is the extreme case. A tap spanning a single draw frame seeds
`last_update` without accruing progress, and `draw`'s guard
(`is_holding() || progress > ZERO`) is the exact complement of
`update_progress`'s early exit (`!holding && progress == ZERO`), so the branch
that would clear the stale timer is unreachable from `draw`. The timestamp then
survives indefinitely and the next press saturates progress on its first frame.

There is a second reachable case the tap does not show: progress accrued before
a release survives a stalled draw loop and is topped up by the stalled interval
on the next press. `frosty_ui::poll` processes touch events every pass but
rate-limits `draw`, so touch events genuinely do arrive with no draw between
them.

Affects every hold-to-confirm screen: sign, erase, firmware upgrade, keygen,
backup.

## The fix

Settle progress at the top of `handle_touch`, before the touch can flip
`holding`. That is exactly what `update_progress` already does, so there is no
new arithmetic — just the call at the boundary that was missing it, which
closes both cases. The `draw` guard goes with it: it duplicates the early exit
it guards, and the two having to stay in exact agreement is what the bug
depended on.

+5/−4 in `frostsnap_widgets/src/hold_to_confirm.rs`.

---

Supersedes #554 — same defect, smaller fix.

I left out #554's 250 ms per-frame accrual clamp. It bounds the symptom rather
than the cause, and it costs a real hold: once the draw interval exceeds 250 ms
a genuine hold is credited 250 ms per frame no matter how long the frame
actually took, so the hold the user must perform is multiplied by
`frame_interval / 250`. At 2 fps the erase-device confirmation needs a
12-second hold instead of 6; at 1 fps, 24 seconds — with nothing telling the
user the requirement changed.
