### PR TITLE
[coord] Don't panic on a signature share for an unknown session

### DIFF
--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -871,10 +871,12 @@ impl FrostCoordinator {
                     ref replenish_nonces,
                 },
             ) => {
-                let active_sign_session = self
-                    .active_signing_sessions
-                    .get(&session_id)
-                    .expect("inavariant");
+                let active_sign_session = self.active_signing_sessions.get(&session_id).ok_or(
+                    Error::coordinator_invalid_message(
+                        message_kind,
+                        "got signature shares for a signing session we don't have",
+                    ),
+                )?;
                 let sessions = &active_sign_session.progress;
                 let n_signatures = sessions.len();
                 let access_structure_ref = active_sign_session.access_structure_ref();


### PR DESCRIPTION
The session lookup for an incoming SignatureShare was an unguarded `.expect()` on a session_id the device chooses. The id is checked after framing and decode but before any crypto verification, so nothing authenticates it: any connected device can panic the coordinator process by naming a session the coordinator doesn't hold. It is also reachable benignly, when the coordinator has forgotten a session and the device sends its share anyway.

Return `Error::coordinator_invalid_message`, as the neighbouring arms of the same match already do for a device sending something that doesn't fit the coordinator's state. The only production caller logs and continues, so a device losing this race isn't disconnected.