### PR TITLE
Inline the revealed_index expects at their call sites

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -4,7 +4,7 @@
 //! re-plan) as often as it likes — a fee display bound to a plan cannot move the wallet's
 //! keychain indices.
 
-use super::wallet::{revealed_index, CoordSuperWallet, KeychainId};
+use super::wallet::{CoordSuperWallet, KeychainId};
 use anyhow::{anyhow, Result};
 use bdk_chain::{
     bitcoin::{self, Amount, OutPoint, TxOut},
@@ -17,7 +17,7 @@ use bdk_coin_select::{
 };
 use frostsnap_core::{
     bitcoin_transaction::{LocalSpk, PushInput, TransactionTemplate},
-    tweak::{BitcoinAccountKeychain, BitcoinBip32Path},
+    tweak::{BitcoinAccountKeychain, BitcoinBip32Path, NormalIndex},
     MasterAppkey,
 };
 use std::collections::{BTreeMap, BTreeSet};
@@ -213,7 +213,8 @@ impl CoordSuperWallet {
                 (
                     BitcoinBip32Path {
                         account_keychain,
-                        index: revealed_index(index),
+                        index: NormalIndex::new(index)
+                            .expect("bdk indexed this utxo against a spk it derived"),
                     },
                     utxos[position].outpoint,
                 )
@@ -356,7 +357,8 @@ impl CoordSuperWallet {
                     master_appkey: plan.master_appkey,
                     bip32_path: BitcoinBip32Path {
                         account_keychain: BitcoinAccountKeychain::internal(),
-                        index: revealed_index(index),
+                        index: NormalIndex::new(index)
+                            .expect("bdk never reveals a change spk past BIP32_MAX_INDEX"),
                     },
                 },
             );
@@ -381,7 +383,6 @@ mod test {
         BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate,
     };
     use frostsnap_core::schnorr_fun::fun::Point;
-    use frostsnap_core::tweak::NormalIndex;
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
 

--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -205,7 +205,9 @@ impl CoordSuperWallet {
                     master_appkey,
                     BitcoinBip32Path {
                         account_keychain: keychain,
-                        index: revealed_index(i),
+                        index: NormalIndex::new(i).expect(
+                            "i is bounded by next_index, which bdk saturates at BIP32_MAX_INDEX",
+                        ),
                     },
                 )
             })
@@ -253,7 +255,8 @@ impl CoordSuperWallet {
             master_appkey,
             BitcoinBip32Path {
                 account_keychain: keychain,
-                index: revealed_index(index),
+                index: NormalIndex::new(index)
+                    .expect("bdk saturates next_index at BIP32_MAX_INDEX"),
             },
         )
     }
@@ -626,7 +629,9 @@ impl CoordSuperWallet {
                         master_appkey,
                         bip32_path: BitcoinBip32Path {
                             account_keychain,
-                            index: revealed_index(index),
+                            index: NormalIndex::new(index).expect(
+                                "bdk derived this spk from our descriptor so its index is normal",
+                            ),
                         },
                     },
                 ),
@@ -709,11 +714,6 @@ impl std::fmt::Display for PsbtValidationError {
     }
 }
 impl std::error::Error for PsbtValidationError {}
-
-/// bdk stops revealing at `BIP32_MAX_INDEX`, so any index it hands back is a normal child.
-pub(super) fn revealed_index(index: u32) -> NormalIndex {
-    NormalIndex::new(index).expect("bdk never reveals past BIP32_MAX_INDEX")
-}
 
 #[derive(Clone, Debug)]
 pub struct AddressInfo {


### PR DESCRIPTION
`revealed_index` was a function whose whole body was an `expect`, which hides the assumption behind a name.

The five call sites did not share one assumption, so the single blanket message said nothing true about either group:

- Three hold an index bdk revealed or was about to reveal (`next_index`, `unused_keychain_spks`/`reveal_next_spk`). There the claim is that bdk stops at `BIP32_MAX_INDEX`.
- Two hold an index bdk handed back for a script it had derived itself (`index_of_spk`, `keychain_outpoints_in_range`). There the claim is about that spk's provenance, not about any revealing bound.

Each site now states the justification that actually holds there. The panics and their conditions are unchanged.