### PR TITLE
[coord] Fix master: the restart test still builds a bip32 path from a u32

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -383,6 +383,7 @@ mod test {
         BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate,
     };
     use frostsnap_core::schnorr_fun::fun::Point;
+    use frostsnap_core::tweak::NormalIndex;
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
 
@@ -834,7 +835,8 @@ mod test {
                         master_appkey,
                         BitcoinBip32Path {
                             account_keychain: BitcoinAccountKeychain::external(),
-                            index: far,
+                            index: NormalIndex::new(far)
+                                .expect("far is lookahead + 10, well inside the normal range"),
                         },
                     ),
                 }],


### PR DESCRIPTION
`master` does not compile. `cargo test -p frostsnap_coordinator --lib` fails with:

```
error[E0308]: mismatched types
   --> frostsnap_coordinator/src/bitcoin/send.rs:837:36
    |
837 |                             index: far,
    |                                    ^^^ expected `NormalIndex`, found `u32`
```

Wrapping `far` is the whole fix. It is `lookahead + 10`, so the `expect` says that rather than asserting a general invariant.

## How it got in, since neither PR was wrong

#547 was branched from a master where `BitcoinBip32Path::index` was still a `u32`, and its checks stayed green against that base — correctly, for that tree. #540 then retyped the field to `NormalIndex`. #547 merged without being rebased onto it, so a `u32` landed in a struct that no longer takes one.

There was no textual conflict, so nothing surfaced it: the two changes touch different lines of different files. **The first build of the two together was on `master` itself**, which is the one place a red build costs everyone.

Confirmed by bisecting the merges: `bcd102eb` (#547's own merge commit) already fails, before #559 existed.

## After this

`cargo test -p frostsnap_coordinator --lib` → `36 passed; 0 failed; 2 ignored`.