### PR TITLE
[widgets,device] Show the firmware version on the standby screens

### DIFF
--- a/device/firmware_version.rs
+++ b/device/firmware_version.rs
@@ -1,0 +1,4 @@
+// Included verbatim by device/src/lib.rs and by frostsnap_widgets' demos, which
+// cannot depend on this riscv32-only crate. See FIRMWARE_VERSION in
+// device/src/lib.rs for why the version is a literal at all.
+(0, 4, 0)

--- a/device/src/frosty_ui.rs
+++ b/device/src/frosty_ui.rs
@@ -62,7 +62,10 @@ impl<'a> FrostyUi<'a> {
         use embedded_graphics::geometry::Size;
         use frostsnap_widgets::debug::EnabledDebug;
 
-        let root_widget = RootWidget::new(WidgetTree::Standby(Box::new(Standby::new())), 200);
+        let root_widget = RootWidget::new(
+            WidgetTree::Standby(Box::new(Standby::new(crate::FIRMWARE_VERSION))),
+            200,
+        );
         let debug_config = EnabledDebug {
             logs: cfg!(feature = "debug_log"),
             memory: cfg!(feature = "debug_mem"),
@@ -182,9 +185,11 @@ impl<'a> UserInteraction for FrostyUi<'a> {
 
         // Convert workflow to widget tree
         let new_page = match workflow {
-            Workflow::Startup => WidgetTree::Standby(Box::new(Standby::new())),
+            Workflow::Startup => {
+                WidgetTree::Standby(Box::new(Standby::new(crate::FIRMWARE_VERSION)))
+            }
             Workflow::None => {
-                let mut standby = Standby::new();
+                let mut standby = Standby::new(crate::FIRMWARE_VERSION);
                 standby.set_welcome();
                 WidgetTree::Standby(Box::new(standby))
             }
@@ -192,7 +197,7 @@ impl<'a> UserInteraction for FrostyUi<'a> {
                 device_name,
                 held_share,
             } => {
-                let mut standby = Standby::new();
+                let mut standby = Standby::new(crate::FIRMWARE_VERSION);
                 standby.set_key(device_name.to_string(), held_share);
                 WidgetTree::Standby(Box::new(standby))
             }

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -1,12 +1,36 @@
 #![no_std]
 
 use alloc::{collections::VecDeque, string::ToString};
-use frostsnap_comms::{DeviceSendBody, DeviceSendMessage, WireDeviceSendBody};
+use frostsnap_comms::{
+    firmware_version::{self, VersionNumber},
+    DeviceSendBody, DeviceSendMessage, WireDeviceSendBody,
+};
 use frostsnap_core::DeviceId;
 use ui::UserInteraction;
 
 #[macro_use]
 extern crate alloc;
+
+/// The version of the firmware built from this tree.
+///
+/// A literal because an image can never contain its own digest, so running
+/// firmware cannot look itself up in the released-version table. It is accurate
+/// because exactly one binary is ever signed as a given release. From v0.5.0 the
+/// version is embedded in the image at build time and this goes away.
+pub const FIRMWARE_VERSION: VersionNumber = {
+    let (major, minor, patch) = include!("../firmware_version.rs");
+    VersionNumber::new(major, minor, patch)
+};
+
+const _: () = {
+    const fn ordered(v: VersionNumber) -> u32 {
+        (v.major as u32) << 16 | (v.minor as u32) << 8 | v.patch as u32
+    }
+    assert!(
+        ordered(firmware_version::EARLIEST_ACCEPTABLE) <= ordered(FIRMWARE_VERSION),
+        "a release bump moved the downgrade floor past the version this tree builds"
+    );
+};
 
 /// Display refresh frequency in milliseconds (25ms = 40 FPS)
 pub const DISPLAY_REFRESH_MS: u64 = 25;

--- a/device/src/widget_tree.rs
+++ b/device/src/widget_tree.rs
@@ -152,7 +152,7 @@ impl WidgetTree {
                 }
             }
             SignTask::Nostr { .. } => {
-                let mut standby = Standby::new();
+                let mut standby = Standby::new(crate::FIRMWARE_VERSION);
                 standby.set_welcome();
                 Self::Standby(Box::new(standby))
             }
@@ -219,6 +219,6 @@ impl WidgetTree {
 
 impl Default for WidgetTree {
     fn default() -> Self {
-        WidgetTree::Standby(Box::new(Standby::new()))
+        WidgetTree::Standby(Box::new(Standby::new(crate::FIRMWARE_VERSION)))
     }
 }

--- a/frostsnap_widgets/src/demo_widget.rs
+++ b/frostsnap_widgets/src/demo_widget.rs
@@ -1,3 +1,10 @@
+/// The one release literal, shared with the device by inclusion because a host
+/// crate cannot depend on the riscv32-only device crate.
+pub fn firmware_version() -> alloc::string::String {
+    let (major, minor, patch): (u8, u8, u8) = include!("../../device/firmware_version.rs");
+    alloc::format!("{}.{}.{}", major, minor, patch)
+}
+
 /// Macro for selecting and running demo widgets
 #[macro_export]
 macro_rules! demo_widget {
@@ -137,7 +144,7 @@ macro_rules! demo_widget {
             }
             "welcome" => {
                 use $crate::Standby;
-                let mut widget = Standby::new();
+                let mut widget = Standby::new($crate::demo_widget::firmware_version());
                 widget.set_welcome();
                 $run_macro!(widget);
             }
@@ -986,7 +993,7 @@ macro_rules! demo_widget {
                 };
 
                 let device_name = "Alice";
-                let mut widget = Standby::new();
+                let mut widget = Standby::new($crate::demo_widget::firmware_version());
                 widget.set_key(device_name, held_share);
                 $run_macro!(widget);
             }
@@ -1013,7 +1020,7 @@ macro_rules! demo_widget {
                 };
 
                 let device_name = "Alice";
-                let mut widget = Standby::new();
+                let mut widget = Standby::new($crate::demo_widget::firmware_version());
                 widget.set_key(device_name, held_share);
                 $run_macro!(widget);
             }
@@ -1155,7 +1162,7 @@ macro_rules! demo_widget {
                 impl StandbyTransitionsDemo {
                     fn new() -> Self {
                         Self {
-                            widget: Standby::new(),
+                            widget: Standby::new($crate::demo_widget::firmware_version()),
                             last_switch_time: None,
                             state_index: 0,
                         }

--- a/frostsnap_widgets/src/standby.rs
+++ b/frostsnap_widgets/src/standby.rs
@@ -16,6 +16,16 @@ const WARNING_ICON_DATA: &[u8] = include_bytes!("../assets/warning-icon-24x24.bm
 
 type Image = crate::Image<GrayToAlpha<Bmp<'static, Gray8>, Rgb565>>;
 
+fn version_text(firmware_version: impl core::fmt::Display) -> Padding<Text> {
+    let text = Text::new(
+        format!("v{}", firmware_version),
+        DefaultTextStyle::new(crate::FONT_SMALL, PALETTE.text_secondary),
+    );
+    // The panel's corners are round (r=42, per hold_to_confirm_border): a corner inset (d, d)
+    // from the screen corner clears the arc only for d >= r * (1 - 1/sqrt(2)) ~= 12.3.
+    Padding::only(text).top(13).right(13).build()
+}
+
 /// Blank standby content - shows welcome message
 #[derive(frostsnap_macros::Widget)]
 pub struct StandbyBlank {
@@ -113,23 +123,20 @@ impl StandbyHasKey {
 #[derive(frostsnap_macros::Widget)]
 pub struct Standby {
     #[widget_delegate]
-    content: Center<
-        Column<(
-            Padding<Image>,
-            Delay<FadeSwitcher<Option<AnyOf<(StandbyBlank, StandbyHasKey)>>>>,
-        )>,
-    >,
-}
-
-impl Default for Standby {
-    fn default() -> Self {
-        Self::new()
-    }
+    content: Stack<(
+        Center<
+            Column<(
+                Padding<Image>,
+                Delay<FadeSwitcher<Option<AnyOf<(StandbyBlank, StandbyHasKey)>>>>,
+            )>,
+        >,
+        Padding<Text>,
+    )>,
 }
 
 impl Standby {
     /// Create a new Standby widget in startup mode (just logo, empty body)
-    pub fn new() -> Self {
+    pub fn new(firmware_version: impl core::fmt::Display) -> Self {
         let logo_bmp = Bmp::<Gray8>::from_slice(LOGO_DATA).expect("Failed to load BMP");
         let logo = Image::new(GrayToAlpha::new(logo_bmp, PALETTE.logo));
         let padded_logo = Padding::only(logo).top(30).bottom(20).build();
@@ -143,35 +150,32 @@ impl Standby {
             .push(delayed_fade)
             .with_cross_axis_alignment(crate::CrossAxisAlignment::Center);
 
-        let content = Center::new(column);
+        let content = Stack::builder().push(Center::new(column)).push_aligned(
+            version_text(firmware_version),
+            crate::layout::Alignment::TopRight,
+        );
 
         Self { content }
     }
 
     /// Clear content (back to startup mode - just logo)
     pub fn clear_content(&mut self) {
-        self.content.child.children.1.child.switch_to(None);
+        self.body().switch_to(None);
     }
 
     /// Set to welcome mode (blank with welcome message)
     pub fn set_welcome(&mut self) {
         let blank_content = StandbyBlank::new();
-        self.content
-            .child
-            .children
-            .1
-            .child
-            .switch_to(Some(AnyOf::new(blank_content)));
+        self.body().switch_to(Some(AnyOf::new(blank_content)));
     }
 
     /// Set to has-key mode with key information
     pub fn set_key(&mut self, device_name: impl Into<String>, held_share: HeldShare2) {
         let has_key_content = StandbyHasKey::new(device_name, held_share);
-        self.content
-            .child
-            .children
-            .1
-            .child
-            .switch_to(Some(AnyOf::new(has_key_content)));
+        self.body().switch_to(Some(AnyOf::new(has_key_content)));
+    }
+
+    fn body(&mut self) -> &mut FadeSwitcher<Option<AnyOf<(StandbyBlank, StandbyHasKey)>>> {
+        &mut self.content.children.0.child.children.1.child
     }
 }


### PR DESCRIPTION
A device could not tell you which firmware it was running. This puts the version
on the standby screens.

## Where the constant lives

An image can never contain its own digest, so the running version is not
recoverable from `KNOWN_FIRMWARE_VERSIONS` and has to be a literal until v0.5.0
embeds it at build time.

`FIRMWARE_VERSION` lives in the device crate — the running version is not a
protocol fact, so the coordinator and app never need it. A const assertion ties
it to `EARLIEST_ACCEPTABLE` so a release bump cannot move the downgrade floor
past the version this tree builds; it is checked at firmware build time because a
no_std riscv32 crate has nowhere to run a host test.

The literal itself sits in `device/firmware_version.rs` and is included verbatim
by both the device and the widget demos. `frostsnap_widgets` cannot depend on the
device crate — device depends on widgets — so inclusion is what lets the
simulator render the real version rather than keeping a second literal that would
drift at the next release. `Standby` takes the version to display rather than
reading a constant, so the widget stays a display layer.

## Before / after

Before on the left, after on the right.

**Welcome**

![welcome](https://raw.githubusercontent.com/LLFourn/frostsnap/standby-captures/compare_welcome.png)

**Has key**

![has key](https://raw.githubusercontent.com/LLFourn/frostsnap/standby-captures/compare_standby.png)

**Recovery**

![recovery](https://raw.githubusercontent.com/LLFourn/frostsnap/standby-captures/compare_standby_recovery.png)

## Why the corner, not the column

The version first went at the foot of each content column. On the recovery
screen — warning row + key name + `Key #N` + device name + version — that
overflowed 280px and clipped the version against the bottom edge. As a top-right
overlay on `Standby` it fits every state, leaves both content columns exactly as
they were, and lives in one place rather than two.

It is `FONT_SMALL` in `text_secondary`, the same treatment `Key #N` gets, so it
reads as provenance rather than competing with the key name or the URL. Because
it hangs off `Standby` rather than the `FadeSwitcher`, it is also visible during
the startup state.

## Verification

- `frostsnap_widgets/tests/standby.rs` renders all four states and asserts the
  version corner is painted and that no state touches the bottom edge. Both were
  checked against mutations: removing the overlay fails the first, and moving the
  version into the content columns fails both, clipping on recovery.
- The const assertion was checked by setting `FIRMWARE_VERSION` below
  `EARLIEST_ACCEPTABLE`, which fails the firmware build as intended.
- The shared literal was checked by setting `device/firmware_version.rs` to
  `(9, 9, 9)` and confirming the widgets side renders `9.9.9`.
- riscv32 firmware builds from this branch: `cd device && cargo build --release --bin frontier`.
- `cargo test -p frostsnap_comms` (11) and `cargo test -p frostsnap_widgets` (34) pass.

Captures were taken with `tools/widget_simulator`, whose `screenshot` stdin
command already existed; they are hosted on a throwaway `standby-captures` branch
on my fork purely so they render here.
