### PR TITLE
Make a transaction template's key scope a type

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -599,6 +599,7 @@ mod test {
         let plan = f.plan(10_000);
         let template = f.wallet.commit_send(&plan, [0]).unwrap();
         let change_index = template
+            .as_seen_by(plan.master_appkey)
             .iter_locally_owned_outputs()
             .map(|(_, _, spk)| spk.bip32_path.index.to_u32())
             .next()

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -600,7 +600,7 @@ mod test {
         let template = f.wallet.commit_send(&plan, [0]).unwrap();
         let change_index = template
             .as_seen_by(plan.master_appkey)
-            .iter_locally_owned_outputs()
+            .iter_our_outputs()
             .map(|(_, _, spk)| spk.bip32_path.index.to_u32())
             .next()
             .expect("send has a change output");

--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -117,10 +117,6 @@ impl CoordSuperWallet {
             .collect()
     }
 
-    pub fn is_spk_mine(&self, master_appkey: MasterAppkey, spk: ScriptBuf) -> bool {
-        self.spk_path(master_appkey, spk).is_some()
-    }
-
     /// The derivation this wallet reaches `spk` by, or `None` if it does not reach it.
     /// The keychain is half the answer: receive #5 and change #5 are different scripts,
     /// and an index alone cannot say which one was found.

--- a/frostsnap_coordinator/tests/real_psbts.rs
+++ b/frostsnap_coordinator/tests/real_psbts.rs
@@ -51,7 +51,7 @@ fn core_self_send_recognises_both_the_payment_and_the_change() {
         Amount::from_btc(1.5).unwrap().to_sat()
     );
     assert!(
-        template.net_value().values().all(|delta| *delta > -10_000),
+        template.as_seen_by(key).our_net_value() > -10_000,
         "a self-send moves nothing out beyond the fee"
     );
 }

--- a/frostsnap_coordinator/tests/real_psbts.rs
+++ b/frostsnap_coordinator/tests/real_psbts.rs
@@ -32,7 +32,7 @@ fn core_self_send_recognises_both_the_payment_and_the_change() {
     let key = wallet_key();
     let psbt = Psbt::deserialize(include_bytes!("fixtures/core_selfsend.psbt")).unwrap();
 
-    let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+    let template = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap();
 
     assert_eq!(template.inputs().len(), 1);
     assert!(template.inputs()[0].owner().local_owner().is_some());
@@ -61,7 +61,7 @@ fn core_payment_to_a_stranger_leaves_their_output_foreign() {
     let key = wallet_key();
     let psbt = Psbt::deserialize(include_bytes!("fixtures/core_stranger.psbt")).unwrap();
 
-    let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+    let template = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap();
 
     let recipient_spk = psbt.unsigned_tx.output[0].script_pubkey.clone();
     assert_eq!(
@@ -84,7 +84,7 @@ fn core_payment_to_our_own_change_address_owns_both_outputs() {
     let key = wallet_key();
     let psbt = Psbt::deserialize(include_bytes!("fixtures/core_to_internal.psbt")).unwrap();
 
-    let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+    let template = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap();
 
     assert_eq!(
         template.outputs()[0].owner().local_owner().cloned(),
@@ -114,7 +114,7 @@ fn our_derivation_agrees_with_bitcoin_core() {
         include_bytes!("fixtures/core_to_internal.psbt").as_slice(),
     ] {
         let psbt = Psbt::deserialize(bytes).unwrap();
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap();
 
         assert_eq!(
             template.to_rust_bitcoin_tx().output,
@@ -138,7 +138,7 @@ fn a_template_from_a_real_psbt_carries_every_prevout() {
         include_bytes!("fixtures/core_to_internal.psbt").as_slice(),
     ] {
         let psbt = Psbt::deserialize(bytes).unwrap();
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap();
 
         assert_eq!(
             template.inputs().len(),

--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -14,8 +14,22 @@ use crate::{
     MasterAppkey,
 };
 
-/// Invalid state free representation of a transaction
-/// The scope a [`TransactionTemplate`] is in.
+/// Marks a template that has not been narrowed to any one key: the form that travels.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, bincode::Encode, bincode::Decode)]
+pub struct Unscoped;
+
+/// Marks a template narrowed to one key by [`TransactionTemplate::as_seen_by`], where
+/// `Local` can only mean that key.
+///
+/// Deliberately not `bincode::Encode`/`Decode`: a scoped template is a local conclusion, and
+/// making it unserializable means the form that goes over the wire is the general one by
+/// construction rather than by discipline.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct ScopedTo(pub MasterAppkey);
+
+/// Invalid state free representation of a transaction.
+///
+/// The type parameter is the scope: which key's transaction this is.
 ///
 /// An ownership question — which inputs are ours, which recipients are foreign — has no
 /// answer until the template names a key, so those readers exist only on
@@ -40,19 +54,6 @@ use crate::{
 /// There is deliberately no way back either: scoping erases another key's ownership, so a
 /// widened template would carry less than the one it came from. Anything that must send
 /// holds the unscoped form and narrows to read.
-/// Marks a template that has not been narrowed to any one key: the form that travels.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, bincode::Encode, bincode::Decode)]
-pub struct Unscoped;
-
-/// Marks a template narrowed to one key by [`TransactionTemplate::as_seen_by`], where
-/// `Local` can only mean that key.
-///
-/// Deliberately not `bincode::Encode`/`Decode`: a scoped template is a local conclusion, and
-/// making it unserializable means the form that goes over the wire is the general one by
-/// construction rather than by discipline.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct ScopedTo(pub MasterAppkey);
-
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, Eq, PartialEq, Hash)]
 pub struct TransactionTemplate<S = Unscoped> {
     scope: S,

--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -182,22 +182,6 @@ impl<S> TransactionTemplate<S> {
             .sum::<u64>()
             .checked_sub(self.outputs.iter().map(|output| output.value).sum())
     }
-
-    pub fn net_value(&self) -> BTreeMap<RootOwner, i64> {
-        let mut spk_to_value: BTreeMap<RootOwner, i64> = Default::default();
-
-        for input in &self.inputs {
-            let value = spk_to_value.entry(input.owner.root_owner()).or_default();
-            *value -= i64::try_from(input.value).expect("input ridiciously large");
-        }
-
-        for output in &self.outputs {
-            let value = spk_to_value.entry(output.owner.root_owner()).or_default();
-            *value += i64::try_from(output.value).expect("input ridiciously large");
-        }
-
-        spk_to_value
-    }
 }
 
 impl TransactionTemplate<Unscoped> {
@@ -311,9 +295,9 @@ impl TransactionTemplate<Unscoped> {
         self.push_owned_output(txout.value, owner);
         Ok(())
     }
-}
 
-impl TransactionTemplate<Unscoped> {
+    /// This transaction as `master_appkey` sees it: another key's scripts become foreign,
+    /// because they are not ours to sign and its outputs are money leaving.
     pub fn as_seen_by(&self, master_appkey: MasterAppkey) -> TransactionTemplate<ScopedTo> {
         let foreign_to_us = |owner: &SpkOwner| match owner {
             SpkOwner::Local(local) if local.master_appkey != master_appkey => {
@@ -449,6 +433,49 @@ impl TransactionTemplate<ScopedTo> {
             .any(|input| input.owner.local_owner().is_some())
     }
 
+    /// What this transaction does to the balance of the key it is scoped to.
+    pub fn our_net_value(&self) -> i64 {
+        let ours = |owner: &SpkOwner, value: u64| match owner {
+            SpkOwner::Local(_) => i64::try_from(value).expect("value ridiculously large"),
+            SpkOwner::Foreign(_) => 0,
+        };
+
+        self.outputs
+            .iter()
+            .map(|output| ours(&output.owner, output.value))
+            .sum::<i64>()
+            - self
+                .inputs
+                .iter()
+                .map(|input| ours(&input.owner, input.value))
+                .sum::<i64>()
+    }
+
+    /// Net value flowing to each script that is not ours, negative where a foreign party
+    /// spends into this transaction.
+    ///
+    /// Distinct from [`Self::foreign_recipients`], which reports what an output pays
+    /// regardless of what its owner also spends.
+    pub fn foreign_net_values(&self) -> BTreeMap<ScriptBuf, i64> {
+        let mut net: BTreeMap<ScriptBuf, i64> = Default::default();
+
+        for input in &self.inputs {
+            if let SpkOwner::Foreign(spk) = &input.owner {
+                *net.entry(spk.clone()).or_default() -=
+                    i64::try_from(input.value).expect("value ridiculously large");
+            }
+        }
+
+        for output in &self.outputs {
+            if let SpkOwner::Foreign(spk) = &output.owner {
+                *net.entry(spk.clone()).or_default() +=
+                    i64::try_from(output.value).expect("value ridiculously large");
+            }
+        }
+
+        net
+    }
+
     pub fn foreign_recipients(&self) -> impl Iterator<Item = (&Script, u64)> {
         self.outputs
             .iter()
@@ -565,12 +592,6 @@ impl PromptSignBitcoinTx {
             .sum();
         (foreign > bitcoin::Amount::ZERO).then_some(foreign)
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub enum RootOwner {
-    Local(MasterAppkey),
-    Foreign(ScriptBuf),
 }
 
 /// A signature was produced for every input of ours; a different count means the list did
@@ -698,12 +719,6 @@ pub enum SpkOwner {
 }
 
 impl SpkOwner {
-    pub fn root_owner(&self) -> RootOwner {
-        match self {
-            SpkOwner::Foreign(spk) => RootOwner::Foreign(spk.clone()),
-            SpkOwner::Local(local) => RootOwner::Local(local.master_appkey),
-        }
-    }
     pub fn spk(&self) -> ScriptBuf {
         match self {
             SpkOwner::Foreign(spk) => spk.clone(),

--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -65,6 +65,7 @@ pub struct TransactionTemplate<S = Unscoped> {
     outputs: Vec<Output>,
 }
 
+#[derive(Clone, Copy)]
 pub struct PushInput<'a> {
     pub prev_txout: PrevTxOut<'a>,
     pub sequence: bitcoin::Sequence,

--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -15,8 +15,47 @@ use crate::{
 };
 
 /// Invalid state free representation of a transaction
+/// The scope a [`TransactionTemplate`] is in.
+///
+/// An ownership question — which inputs are ours, which recipients are foreign — has no
+/// answer until the template names a key, so those readers exist only on
+/// `TransactionTemplate<ScopedTo>`. [`TransactionTemplate::as_seen_by`] is the only way
+/// across, and it is what firmware's `WireSignTask::check` calls.
+///
+/// ```compile_fail,E0599
+/// # use frostsnap_core::bitcoin_transaction::TransactionTemplate;
+/// let template = TransactionTemplate::new();
+/// // Whose inputs? The unscoped template cannot say, so this does not compile.
+/// template.iter_locally_owned_inputs();
+/// ```
+///
+/// ```compile_fail,E0277
+/// # use frostsnap_core::{bitcoin_transaction::TransactionTemplate, MasterAppkey};
+/// # fn key() -> MasterAppkey { unimplemented!() }
+/// let scoped = TransactionTemplate::new().as_seen_by(key());
+/// // A scoped template is a local conclusion and must not go over the wire.
+/// bincode::encode_to_vec(scoped, bincode::config::standard()).unwrap();
+/// ```
+///
+/// There is deliberately no way back either: scoping erases another key's ownership, so a
+/// widened template would carry less than the one it came from. Anything that must send
+/// holds the unscoped form and narrows to read.
+/// Marks a template that has not been narrowed to any one key: the form that travels.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, bincode::Encode, bincode::Decode)]
+pub struct Unscoped;
+
+/// Marks a template narrowed to one key by [`TransactionTemplate::as_seen_by`], where
+/// `Local` can only mean that key.
+///
+/// Deliberately not `bincode::Encode`/`Decode`: a scoped template is a local conclusion, and
+/// making it unserializable means the form that goes over the wire is the general one by
+/// construction rather than by discipline.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct ScopedTo(pub MasterAppkey);
+
 #[derive(Clone, Debug, bincode::Encode, bincode::Decode, Eq, PartialEq, Hash)]
-pub struct TransactionTemplate {
+pub struct TransactionTemplate<S = Unscoped> {
+    scope: S,
     #[bincode(with_serde)]
     version: bitcoin::blockdata::transaction::Version,
     #[bincode(with_serde)]
@@ -88,9 +127,82 @@ impl Default for TransactionTemplate {
     }
 }
 
-impl TransactionTemplate {
+/// Facts that do not depend on whose transaction it is.
+impl<S> TransactionTemplate<S> {
+    pub fn txid(&self) -> Txid {
+        self.to_rust_bitcoin_tx().compute_txid()
+    }
+
+    pub fn to_rust_bitcoin_tx(&self) -> bitcoin::Transaction {
+        bitcoin::Transaction {
+            version: self.version,
+            lock_time: self.lock_time,
+            input: self
+                .inputs
+                .iter()
+                .map(|input| bitcoin::TxIn {
+                    previous_output: input.outpoint,
+                    sequence: input.sequence,
+                    ..Default::default()
+                })
+                .collect(),
+            output: self.outputs.iter().map(|output| output.txout()).collect(),
+        }
+    }
+
+    pub fn inputs(&self) -> &[Input] {
+        &self.inputs
+    }
+
+    pub fn outputs(&self) -> &[Output] {
+        &self.outputs
+    }
+
+    pub fn iter_sighash(&self) -> impl Iterator<Item = TapSighash> {
+        let tx = self.to_rust_bitcoin_tx();
+        let mut sighash_cache = SighashCache::new(tx);
+        let schnorr_sighashty = bitcoin::sighash::TapSighashType::Default;
+        let prevouts = self.inputs.iter().map(Input::txout).collect::<Vec<_>>();
+        (0..self.inputs.len()).map(move |i| {
+            sighash_cache
+                .taproot_key_spend_signature_hash(
+                    i,
+                    &bitcoin::sighash::Prevouts::All(&prevouts),
+                    schnorr_sighashty,
+                )
+                .expect("inputs are right length")
+        })
+    }
+
+    pub fn fee(&self) -> Option<u64> {
+        self.inputs
+            .iter()
+            .map(|input| input.value)
+            .sum::<u64>()
+            .checked_sub(self.outputs.iter().map(|output| output.value).sum())
+    }
+
+    pub fn net_value(&self) -> BTreeMap<RootOwner, i64> {
+        let mut spk_to_value: BTreeMap<RootOwner, i64> = Default::default();
+
+        for input in &self.inputs {
+            let value = spk_to_value.entry(input.owner.root_owner()).or_default();
+            *value -= i64::try_from(input.value).expect("input ridiciously large");
+        }
+
+        for output in &self.outputs {
+            let value = spk_to_value.entry(output.owner.root_owner()).or_default();
+            *value += i64::try_from(output.value).expect("input ridiciously large");
+        }
+
+        spk_to_value
+    }
+}
+
+impl TransactionTemplate<Unscoped> {
     pub fn new() -> Self {
         Self {
+            scope: Unscoped,
             version: bitcoin::blockdata::transaction::Version::TWO,
             lock_time: bitcoin::absolute::LockTime::ZERO,
             inputs: Default::default(),
@@ -104,10 +216,6 @@ impl TransactionTemplate {
 
     pub fn set_lock_time(&mut self, lock_time: bitcoin::absolute::LockTime) {
         self.lock_time = lock_time;
-    }
-
-    pub fn txid(&self) -> Txid {
-        self.to_rust_bitcoin_tx().compute_txid()
     }
 
     pub fn push_foreign_input(&mut self, input: PushInput) {
@@ -202,54 +310,45 @@ impl TransactionTemplate {
         self.push_owned_output(txout.value, owner);
         Ok(())
     }
+}
 
-    pub fn to_rust_bitcoin_tx(&self) -> bitcoin::Transaction {
-        bitcoin::Transaction {
+impl TransactionTemplate<Unscoped> {
+    pub fn as_seen_by(&self, master_appkey: MasterAppkey) -> TransactionTemplate<ScopedTo> {
+        let foreign_to_us = |owner: &SpkOwner| match owner {
+            SpkOwner::Local(local) if local.master_appkey != master_appkey => {
+                SpkOwner::Foreign(local.spk())
+            }
+            owner => owner.clone(),
+        };
+
+        TransactionTemplate {
+            scope: ScopedTo(master_appkey),
             version: self.version,
             lock_time: self.lock_time,
-            input: self
+            inputs: self
                 .inputs
                 .iter()
-                .map(|input| bitcoin::TxIn {
-                    previous_output: input.outpoint,
-                    sequence: input.sequence,
-                    ..Default::default()
+                .map(|input| Input {
+                    owner: foreign_to_us(&input.owner),
+                    ..input.clone()
                 })
                 .collect(),
-            output: self.outputs.iter().map(|output| output.txout()).collect(),
+            outputs: self
+                .outputs
+                .iter()
+                .map(|output| Output {
+                    owner: foreign_to_us(&output.owner),
+                    value: output.value,
+                })
+                .collect(),
         }
     }
+}
 
-    pub fn inputs(&self) -> &[Input] {
-        &self.inputs
-    }
-
-    pub fn outputs(&self) -> &[Output] {
-        &self.outputs
-    }
-
-    pub fn iter_sighash(&self) -> impl Iterator<Item = TapSighash> {
-        let tx = self.to_rust_bitcoin_tx();
-        let mut sighash_cache = SighashCache::new(tx);
-        let schnorr_sighashty = bitcoin::sighash::TapSighashType::Default;
-        let prevouts = self.inputs.iter().map(Input::txout).collect::<Vec<_>>();
-        (0..self.inputs.len()).map(move |i| {
-            sighash_cache
-                .taproot_key_spend_signature_hash(
-                    i,
-                    &bitcoin::sighash::Prevouts::All(&prevouts),
-                    schnorr_sighashty,
-                )
-                .expect("inputs are right length")
-        })
-    }
-
-    pub fn fee(&self) -> Option<u64> {
-        self.inputs
-            .iter()
-            .map(|input| input.value)
-            .sum::<u64>()
-            .checked_sub(self.outputs.iter().map(|output| output.value).sum())
+/// Answers that only make sense once the template has been narrowed to one key.
+impl TransactionTemplate<ScopedTo> {
+    pub fn master_appkey(&self) -> MasterAppkey {
+        self.scope.0
     }
 
     pub fn feerate(&self) -> Option<f64> {
@@ -265,22 +364,6 @@ impl TransactionTemplate {
 
         let vbytes = tx.weight().to_vbytes_ceil() as f64;
         Some(self.fee()? as f64 / vbytes)
-    }
-
-    pub fn net_value(&self) -> BTreeMap<RootOwner, i64> {
-        let mut spk_to_value: BTreeMap<RootOwner, i64> = Default::default();
-
-        for input in &self.inputs {
-            let value = spk_to_value.entry(input.owner.root_owner()).or_default();
-            *value -= i64::try_from(input.value).expect("input ridiciously large");
-        }
-
-        for output in &self.outputs {
-            let value = spk_to_value.entry(output.owner.root_owner()).or_default();
-            *value += i64::try_from(output.value).expect("input ridiciously large");
-        }
-
-        spk_to_value
     }
 
     pub fn iter_sighashes_of_locally_owned_inputs(
@@ -430,42 +513,6 @@ impl TransactionTemplate {
             recipients,
             fee,
             fee_rate_sats_per_vbyte,
-        }
-    }
-    /// This transaction as `master_appkey` sees it: anything owned by another key becomes a
-    /// foreign script.
-    ///
-    /// Ownership is relative to a key, and every reader below says "local" without naming one.
-    /// Normalising once here means they cannot be wrong: a sibling key's output is money
-    /// leaving, and a sibling key's input is one we cannot sign, which is exactly what
-    /// `Foreign` already means to them.
-    pub fn as_seen_by(&self, master_appkey: MasterAppkey) -> Self {
-        let foreign_to_us = |owner: &SpkOwner| match owner {
-            SpkOwner::Local(local) if local.master_appkey != master_appkey => {
-                SpkOwner::Foreign(local.spk())
-            }
-            owner => owner.clone(),
-        };
-
-        Self {
-            version: self.version,
-            lock_time: self.lock_time,
-            inputs: self
-                .inputs
-                .iter()
-                .map(|input| Input {
-                    owner: foreign_to_us(&input.owner),
-                    ..input.clone()
-                })
-                .collect(),
-            outputs: self
-                .outputs
-                .iter()
-                .map(|output| Output {
-                    owner: foreign_to_us(&output.owner),
-                    value: output.value,
-                })
-                .collect(),
         }
     }
 }

--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -40,7 +40,7 @@ pub struct ScopedTo(pub MasterAppkey);
 /// # use frostsnap_core::bitcoin_transaction::TransactionTemplate;
 /// let template = TransactionTemplate::new();
 /// // Whose inputs? The unscoped template cannot say, so this does not compile.
-/// template.iter_locally_owned_inputs();
+/// template.iter_our_inputs();
 /// ```
 ///
 /// ```compile_fail,E0277
@@ -367,9 +367,7 @@ impl TransactionTemplate<ScopedTo> {
         Some(self.fee()? as f64 / vbytes)
     }
 
-    pub fn iter_sighashes_of_locally_owned_inputs(
-        &self,
-    ) -> impl Iterator<Item = (LocalSpk, TapSighash)> + '_ {
+    pub fn iter_our_input_sighashes(&self) -> impl Iterator<Item = (LocalSpk, TapSighash)> + '_ {
         self.inputs
             .iter()
             .zip(self.iter_sighash())
@@ -379,25 +377,23 @@ impl TransactionTemplate<ScopedTo> {
             })
     }
 
-    pub fn iter_locally_owned_inputs(&self) -> impl Iterator<Item = (usize, &Input, &LocalSpk)> {
+    pub fn iter_our_inputs(&self) -> impl Iterator<Item = (usize, &Input, &LocalSpk)> {
         self.inputs
             .iter()
             .enumerate()
             .filter_map(|(i, input)| Some((i, input, input.owner.local_owner()?)))
     }
 
-    /// Every script this transaction owns, on either side, with the path that derives it.
+    /// Every script this key owns in this transaction, on either side, with the path that
+    /// derives it.
     ///
-    /// A bare path is safe to return because a template reaching a reader has been normalised
-    /// by [`Self::as_seen_by`], so "owned" can only mean one key.
-    ///
-    /// The template is the authority on what is ours; asking a wallet index instead answers a
-    /// different question, and one bounded by whatever it has derived so far.
-    pub fn owned_spks(&self) -> BTreeMap<ScriptBuf, BitcoinBip32Path> {
-        self.iter_locally_owned_inputs()
+    /// The template is the authority on what is ours; asking a wallet index instead answers
+    /// a different question and is bounded by whatever it has derived so far.
+    pub fn our_spks(&self) -> BTreeMap<ScriptBuf, BitcoinBip32Path> {
+        self.iter_our_inputs()
             .map(|(_, _, owner)| (owner.spk(), owner.bip32_path))
             .chain(
-                self.iter_locally_owned_outputs()
+                self.iter_our_outputs()
                     .map(|(_, _, owner)| (owner.spk(), owner.bip32_path)),
             )
             .collect()
@@ -405,14 +401,14 @@ impl TransactionTemplate<ScopedTo> {
 
     /// Pairs each signature with the index of the input it was produced for.
     ///
-    /// Signatures arrive in the order [`Self::iter_sighashes_of_locally_owned_inputs`] produced
-    /// their sighashes, which skips foreign inputs. Their positions are therefore *not* input
+    /// Signatures arrive in the order [`Self::iter_our_input_sighashes`] produced their
+    /// sighashes, which skips foreign inputs. Their positions are therefore *not* input
     /// indices, and pairing them positionally against every input silently signs the wrong one.
     pub fn signatures_by_input_index<'a>(
         &self,
         signatures: &'a [EncodedSignature],
     ) -> Result<Vec<(usize, &'a EncodedSignature)>, SignatureCountMismatch> {
-        let expected = self.iter_locally_owned_inputs().count();
+        let expected = self.iter_our_inputs().count();
         if signatures.len() != expected {
             return Err(SignatureCountMismatch {
                 expected,
@@ -421,7 +417,7 @@ impl TransactionTemplate<ScopedTo> {
         }
 
         Ok(self
-            .iter_locally_owned_inputs()
+            .iter_our_inputs()
             .map(|(i, _, _)| i)
             .zip(signatures)
             .collect())
@@ -439,7 +435,7 @@ impl TransactionTemplate<ScopedTo> {
         Ok(tx)
     }
 
-    pub fn iter_locally_owned_outputs(&self) -> impl Iterator<Item = (usize, &Output, &LocalSpk)> {
+    pub fn iter_our_outputs(&self) -> impl Iterator<Item = (usize, &Output, &LocalSpk)> {
         self.outputs
             .iter()
             .enumerate()
@@ -475,7 +471,7 @@ impl TransactionTemplate<ScopedTo> {
             .iter()
             .any(|output| matches!(output.owner, SpkOwner::Foreign(_)));
         let internal_count = self
-            .iter_locally_owned_outputs()
+            .iter_our_outputs()
             .filter(|(_, _, local)| {
                 local.bip32_path.account_keychain.keychain == Keychain::Internal
             })
@@ -577,8 +573,8 @@ pub enum RootOwner {
     Foreign(ScriptBuf),
 }
 
-/// A signature was produced for every locally owned input; a different count means the list
-/// did not come from this template.
+/// A signature was produced for every input of ours; a different count means the list did
+/// not come from this template.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SignatureCountMismatch {
     pub expected: usize,

--- a/frostsnap_core/src/psbt.rs
+++ b/frostsnap_core/src/psbt.rs
@@ -21,21 +21,34 @@ use bitcoin::{
 use tracing::{event, Level};
 
 impl TransactionTemplate {
-    /// Reads a PSBT as a transaction `master_appkey` is being asked to sign.
+    /// Reads a PSBT as a transaction `master_appkeys` are being asked to sign.
     ///
     /// Ownership is taken from the PSBT's own key origins on both sides, and every claimed
-    /// path is derived from `master_appkey` and matched against the actual script before it
+    /// path is derived from the key it names and matched against the actual script before it
     /// counts, so a PSBT cannot make us attribute a script to a key that does not produce it.
     ///
-    /// Anything this key does not own is recorded as foreign rather than rejected — a PSBT is
-    /// only refused outright when it is malformed, or when nothing in it is ours to sign.
+    /// The result is unscoped and stays that way honestly: with several keys given, `Local`
+    /// means one of them and records which, and [`TransactionTemplate::as_seen_by`] narrows it
+    /// to whichever is signing. Anything none of the keys owns is recorded as foreign rather
+    /// than rejected — a PSBT is only refused outright when it is malformed, or when nothing
+    /// in it is ours to sign.
     pub fn from_psbt(
         psbt: &Psbt,
-        master_appkey: MasterAppkey,
+        master_appkeys: &[MasterAppkey],
     ) -> Result<TransactionTemplate, PsbtValidationError> {
-        let our_fingerprint = master_appkey
-            .derive_appkey(AppTweakKind::Bitcoin)
-            .fingerprint();
+        // A fingerprint is four bytes, so two of our own keys can share one. Holding every
+        // candidate and letting the script decide means a collision cannot hide the real owner.
+        let mut ours_by_fingerprint: BTreeMap<Fingerprint, Vec<MasterAppkey>> = BTreeMap::new();
+        for &master_appkey in master_appkeys {
+            let fingerprint = master_appkey
+                .derive_appkey(AppTweakKind::Bitcoin)
+                .fingerprint();
+            ours_by_fingerprint
+                .entry(fingerprint)
+                .or_default()
+                .push(master_appkey);
+        }
+
         let mut template = TransactionTemplate::new();
         let unsigned_tx = &psbt.unsigned_tx;
         template.set_version(unsigned_tx.version);
@@ -86,12 +99,12 @@ impl TransactionTemplate {
                 );
             }
 
-            let bip32_path = match claimed_path(
+            let (bip32_path, candidates) = match claimed_path(
                 input.tap_internal_key.as_ref(),
                 &input.tap_key_origins,
-                our_fingerprint,
+                &ours_by_fingerprint,
             ) {
-                Ok(bip32_path) => bip32_path,
+                Ok(claim) => claim,
                 // Refusing outright rather than skipping: an input claiming our fingerprint at a
                 // path we cannot derive is a PSBT we do not understand, not someone else's coin.
                 Err(NotOurs::Hardened) => {
@@ -102,13 +115,9 @@ impl TransactionTemplate {
                 Err(reason) => bail!(foreign_count, reason.to_string()),
             };
 
-            template.push_owned_input(
-                input_push,
-                LocalSpk {
-                    master_appkey,
-                    bip32_path,
-                },
-            )?;
+            push_owned(candidates, bip32_path, |owner| {
+                template.push_owned_input(input_push, owner)
+            })?;
             owned_count += 1;
         }
 
@@ -117,19 +126,15 @@ impl TransactionTemplate {
                 Some(output) => claimed_path(
                     output.tap_internal_key.as_ref(),
                     &output.tap_key_origins,
-                    our_fingerprint,
+                    &ours_by_fingerprint,
                 ),
                 None => Err(NotOurs::NoOrigin),
             };
 
             match claim {
-                Ok(bip32_path) => template.push_owned_output_checked(
-                    txout,
-                    LocalSpk {
-                        master_appkey,
-                        bip32_path,
-                    },
-                )?,
+                Ok((bip32_path, candidates)) => push_owned(candidates, bip32_path, |owner| {
+                    template.push_owned_output_checked(txout, owner)
+                })?,
                 Err(reason) => {
                     event!(Level::INFO, "PSBT output {i} isn't ours because {reason}");
                     template.push_foreign_output(txout.clone());
@@ -232,24 +237,27 @@ impl core::fmt::Display for NotOurs {
     }
 }
 
-/// The path a PSBT claims derives `tap_internal_key`, if it claims one under our fingerprint.
+/// The path a PSBT claims for `tap_internal_key`, and every key of ours whose fingerprint it
+/// claimed.
 ///
 /// Shared by both loops so inputs and outputs cannot drift apart on what counts as ours.
-/// The claim is unproven here — the caller matches it against the actual script.
-fn claimed_path(
+///
+/// Which candidate it really is cannot be decided here: only deriving the path and comparing
+/// the result against the actual script settles it, and that is [`push_owned`]'s job.
+fn claimed_path<'a>(
     tap_internal_key: Option<&XOnlyPublicKey>,
     tap_key_origins: &BTreeMap<XOnlyPublicKey, (Vec<taproot::TapLeafHash>, bip32::KeySource)>,
-    our_fingerprint: Fingerprint,
-) -> Result<BitcoinBip32Path, NotOurs> {
+    ours_by_fingerprint: &'a BTreeMap<Fingerprint, Vec<MasterAppkey>>,
+) -> Result<(BitcoinBip32Path, &'a [MasterAppkey]), NotOurs> {
     let tap_internal_key = tap_internal_key.ok_or(NotOurs::NoInternalKey)?;
     let (fingerprint, derivation_path) = tap_key_origins
         .get(tap_internal_key)
         .map(|(_, key_source)| key_source)
         .ok_or(NotOurs::NoOrigin)?;
 
-    if *fingerprint != our_fingerprint {
-        return Err(NotOurs::ForeignFingerprint);
-    }
+    let candidates = ours_by_fingerprint
+        .get(fingerprint)
+        .ok_or(NotOurs::ForeignFingerprint)?;
 
     let path = derivation_path
         .into_iter()
@@ -259,14 +267,40 @@ fn claimed_path(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    BitcoinBip32Path::from_u32_slice(&path).ok_or_else(|| {
+    let bip32_path = BitcoinBip32Path::from_u32_slice(&path).ok_or_else(|| {
         NotOurs::UnusualPath(
             path.iter()
                 .map(|n| n.to_string())
                 .collect::<Vec<String>>()
                 .join("/"),
         )
-    })
+    })?;
+
+    Ok((bip32_path, candidates))
+}
+
+/// Pushes the script under whichever candidate key actually derives it.
+///
+/// A fingerprint match with no script match is a PSBT claiming one of our keys over a script
+/// that key does not produce, so the last mismatch is returned rather than the script being
+/// recorded as foreign — silently demoting it would let a PSBT lie about us without saying so.
+fn push_owned(
+    candidates: &[MasterAppkey],
+    bip32_path: BitcoinBip32Path,
+    mut push: impl FnMut(LocalSpk) -> Result<(), Box<SpkDoesntMatchPathError>>,
+) -> Result<(), Box<SpkDoesntMatchPathError>> {
+    let mut last_mismatch = None;
+    for &master_appkey in candidates {
+        match push(LocalSpk {
+            master_appkey,
+            bip32_path,
+        }) {
+            Ok(()) => return Ok(()),
+            Err(mismatch) => last_mismatch = Some(mismatch),
+        }
+    }
+
+    Err(last_mismatch.expect("a fingerprint is only in the map because a key produced it"))
 }
 
 #[derive(Debug, Clone)]
@@ -474,7 +508,7 @@ mod test {
             vec![foreign_txout(90_000)],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -495,7 +529,7 @@ mod test {
         signed.final_script_witness = Some(Witness::from_slice(&[[3u8; 64].as_slice()]));
 
         let psbt = psbt_of(vec![signed], vec![foreign_txout(90_000)]);
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         match err {
             PsbtValidationError::NothingToSign {
@@ -520,7 +554,7 @@ mod test {
         input.tap_internal_key = None;
 
         let psbt = psbt_of(vec![input], vec![foreign_txout(90_000)]);
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         match err {
             PsbtValidationError::NothingToSign { foreign_count, .. } => {
@@ -538,7 +572,7 @@ mod test {
         input.tap_key_origins.clear();
 
         let psbt = psbt_of(vec![input], vec![foreign_txout(90_000)]);
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         match err {
             PsbtValidationError::NothingToSign { foreign_count, .. } => {
@@ -560,11 +594,106 @@ mod test {
         );
 
         let psbt = psbt_of(vec![input], vec![foreign_txout(90_000)]);
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         match err {
             PsbtValidationError::NothingToSign { foreign_count, .. } => {
                 assert_eq!(foreign_count, 1)
+            }
+            other => panic!("expected NothingToSign, got {other:?}"),
+        }
+    }
+
+    /// Why the result is unscoped rather than scoped to the key that was passed: given two of
+    /// our keys, `Local` records *which* one, and only `as_seen_by` collapses that to "ours".
+    #[test]
+    fn each_of_our_keys_owns_its_own_input() {
+        let ours = our_key();
+        let sibling = sibling_key();
+        let our_path = BitcoinBip32Path::external(idx(0));
+        let their_path = BitcoinBip32Path::external(idx(1));
+
+        let psbt = psbt_of(
+            vec![
+                owned_input(ours, our_path, 100_000),
+                owned_input(sibling, their_path, 100_000),
+            ],
+            vec![foreign_txout(150_000)],
+        );
+
+        let template = TransactionTemplate::from_psbt(&psbt, &[ours, sibling]).unwrap();
+
+        let owner_of = |i: usize| {
+            template.inputs()[i]
+                .owner()
+                .local_owner()
+                .map(|local| local.master_appkey)
+        };
+        assert_eq!(owner_of(0), Some(ours));
+        assert_eq!(owner_of(1), Some(sibling));
+
+        assert_eq!(
+            template
+                .as_seen_by(ours)
+                .iter_our_inputs()
+                .map(|(i, _, _)| i)
+                .collect::<Vec<_>>(),
+            vec![0]
+        );
+        assert_eq!(
+            template
+                .as_seen_by(sibling)
+                .iter_our_inputs()
+                .map(|(i, _, _)| i)
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+    }
+
+    /// The key list decides what is ours, not the PSBT's annotations: the same bytes read for
+    /// one key leave the other key's input foreign.
+    #[test]
+    fn a_key_left_out_of_the_list_is_foreign() {
+        let ours = our_key();
+        let sibling = sibling_key();
+        let our_path = BitcoinBip32Path::external(idx(0));
+        let their_path = BitcoinBip32Path::external(idx(1));
+
+        let psbt = psbt_of(
+            vec![
+                owned_input(ours, our_path, 100_000),
+                owned_input(sibling, their_path, 100_000),
+            ],
+            vec![foreign_txout(150_000)],
+        );
+
+        let template = TransactionTemplate::from_psbt(&psbt, &[ours]).unwrap();
+
+        assert!(template.inputs()[0].owner().local_owner().is_some());
+        assert!(matches!(template.inputs()[1].owner(), SpkOwner::Foreign(_)));
+    }
+
+    #[test]
+    fn nothing_to_sign_when_no_key_in_the_list_owns_an_input() {
+        let stranger = MasterAppkey::derive_from_rootkey(g!(5 * G).normalize());
+        let path = BitcoinBip32Path::external(idx(0));
+
+        let psbt = psbt_of(
+            vec![owned_input(stranger, path, 100_000)],
+            vec![foreign_txout(90_000)],
+        );
+        let err = TransactionTemplate::from_psbt(&psbt, &[our_key(), sibling_key()]).unwrap_err();
+
+        match err {
+            PsbtValidationError::NothingToSign {
+                total_inputs,
+                foreign_count,
+                already_signed_count,
+            } => {
+                assert_eq!(
+                    (total_inputs, foreign_count, already_signed_count),
+                    (1, 1, 0)
+                );
             }
             other => panic!("expected NothingToSign, got {other:?}"),
         }
@@ -580,7 +709,7 @@ mod test {
         input.witness_utxo = Some(txout_of(key, actual, 100_000));
 
         let psbt = psbt_of(vec![input], vec![foreign_txout(90_000)]);
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         assert!(
             err_string(err).contains("didn't match what we expected"),
@@ -613,7 +742,7 @@ mod test {
         );
 
         let psbt = psbt_of(vec![input], vec![foreign_txout(90_000)]);
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         assert!(
             err_string(err).contains("hardened"),
@@ -630,7 +759,7 @@ mod test {
         input.non_witness_utxo = None;
 
         let psbt = psbt_of(vec![input], vec![foreign_txout(90_000)]);
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         assert!(
             err_string(err).contains("missing witness and non-witness utxo"),
@@ -651,7 +780,7 @@ mod test {
             vec![owned_output(key, change_path), psbt::Output::default()],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -684,7 +813,7 @@ mod test {
             vec![owned_output(sibling, sibling_path)],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -727,7 +856,7 @@ mod test {
             vec![signed, no_internal_key, stranger],
             vec![foreign_txout(250_000)],
         );
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         match err {
             PsbtValidationError::NothingToSign {
@@ -772,7 +901,7 @@ mod test {
             vec![annotation],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -800,7 +929,7 @@ mod test {
             vec![annotation],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -826,7 +955,7 @@ mod test {
             vec![owned_output(key, claimed)],
         );
 
-        let err = TransactionTemplate::from_psbt(&psbt, key).unwrap_err();
+        let err = TransactionTemplate::from_psbt(&psbt, &[key]).unwrap_err();
 
         assert!(
             err_string(err).contains("didn't match what we expected"),
@@ -851,7 +980,7 @@ mod test {
             vec![owned_output(key, deep)],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -899,7 +1028,7 @@ mod test {
             vec![annotation],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -941,7 +1070,7 @@ mod test {
             ],
             vec![foreign_txout(150_000)],
         );
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -972,7 +1101,7 @@ mod test {
             ],
             vec![foreign_txout(350_000)],
         );
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 
@@ -1002,7 +1131,7 @@ mod test {
             ],
             vec![foreign_txout(150_000)],
         );
-        let template = TransactionTemplate::from_psbt(&psbt, key)
+        let template = TransactionTemplate::from_psbt(&psbt, &[key])
             .unwrap()
             .as_seen_by(key);
 

--- a/frostsnap_core/src/psbt.rs
+++ b/frostsnap_core/src/psbt.rs
@@ -1,6 +1,7 @@
 use crate::{
     bitcoin_transaction::{
-        LocalSpk, PushInput, SignatureCountMismatch, SpkDoesntMatchPathError, TransactionTemplate,
+        LocalSpk, PushInput, ScopedTo, SignatureCountMismatch, SpkDoesntMatchPathError,
+        TransactionTemplate,
     },
     message::EncodedSignature,
     tweak::{AppTweakKind, BitcoinBip32Path},
@@ -146,7 +147,10 @@ impl TransactionTemplate {
 
         Ok(template)
     }
+}
 
+/// Only a template narrowed to one key can say which input a signature belongs to.
+impl TransactionTemplate<ScopedTo> {
     /// Writes each signature onto the PSBT input it was produced for.
     ///
     /// The counterpart to [`Self::from_psbt`]: the template decided which inputs were ours,
@@ -470,7 +474,9 @@ mod test {
             vec![foreign_txout(90_000)],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         assert_eq!(
             template.inputs()[0].owner().local_owner(),
@@ -645,7 +651,9 @@ mod test {
             vec![owned_output(key, change_path), psbt::Output::default()],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         assert_eq!(
             template.outputs()[0].owner().local_owner(),
@@ -676,7 +684,9 @@ mod test {
             vec![owned_output(sibling, sibling_path)],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         assert_eq!(
             template.outputs()[0].owner(),
@@ -762,7 +772,9 @@ mod test {
             vec![annotation],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         assert_eq!(
             template.outputs()[0].owner(),
@@ -788,7 +800,9 @@ mod test {
             vec![annotation],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         assert_eq!(
             template.outputs()[0].owner(),
@@ -837,7 +851,9 @@ mod test {
             vec![owned_output(key, deep)],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         assert_eq!(
             template.outputs()[0].owner().local_owner(),
@@ -883,7 +899,9 @@ mod test {
             vec![annotation],
         );
 
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         assert_eq!(
             template.outputs()[0].owner(),
@@ -923,7 +941,9 @@ mod test {
             ],
             vec![foreign_txout(150_000)],
         );
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         let signed = template
             .attach_signatures_to_psbt(&[signature(7)], &psbt)
@@ -952,7 +972,9 @@ mod test {
             ],
             vec![foreign_txout(350_000)],
         );
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         let signed = template
             .attach_signatures_to_psbt(&[signature(1), signature(2)], &psbt)
@@ -980,7 +1002,9 @@ mod test {
             ],
             vec![foreign_txout(150_000)],
         );
-        let template = TransactionTemplate::from_psbt(&psbt, key).unwrap();
+        let template = TransactionTemplate::from_psbt(&psbt, key)
+            .unwrap()
+            .as_seen_by(key);
 
         assert!(template.attach_signatures_to_psbt(&[], &psbt).is_err());
         assert!(template

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -35,7 +35,7 @@ pub enum SignTask {
         event: Box<crate::nostr::UnsignedEvent>,
     },
     BitcoinTransaction {
-        tx_template: bitcoin_transaction::TransactionTemplate,
+        tx_template: bitcoin_transaction::TransactionTemplate<bitcoin_transaction::ScopedTo>,
         network: bitcoin::Network,
     },
 }
@@ -117,10 +117,7 @@ impl WireSignTask {
                 // allocated change or revealed an address past the ceiling would have its own task
                 // refused here. Reaching that is implausible today, and closing it properly means
                 // one shared issuance boundary in the wallet, which is the cleanup.
-                for (_, _, owner) in tx_template
-                    .as_seen_by(master_appkey)
-                    .iter_locally_owned_outputs()
-                {
+                for (_, _, owner) in tx_template.iter_locally_owned_outputs() {
                     let path = owner.bip32_path;
 
                     if path.account_keychain.account != BitcoinAccount::default() {
@@ -134,10 +131,7 @@ impl WireSignTask {
                     }
                 }
 
-                if !tx_template
-                    .as_seen_by(master_appkey)
-                    .has_any_inputs_to_sign()
-                {
+                if !tx_template.has_any_inputs_to_sign() {
                     return Err(SignTaskError::NothingToSign);
                 }
 
@@ -184,7 +178,6 @@ impl CheckedSignTask {
                 app_tweak: AppTweak::Nostr,
             }],
             SignTask::BitcoinTransaction { tx_template, .. } => tx_template
-                .as_seen_by(self.master_appkey)
                 .iter_sighashes_of_locally_owned_inputs()
                 .map(|(owner, sighash)| SignItem {
                     message: sighash.as_raw_hash().to_byte_array().to_vec(),

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -69,7 +69,7 @@ impl WireSignTask {
         template.into_iter().flat_map(move |template| {
             template
                 .as_seen_by(master_appkey)
-                .iter_locally_owned_outputs()
+                .iter_our_outputs()
                 .filter_map(move |(_, _, spk)| {
                     (spk.bip32_path.account_keychain == internal)
                         .then_some(spk.bip32_path.index.to_u32())
@@ -117,7 +117,7 @@ impl WireSignTask {
                 // allocated change or revealed an address past the ceiling would have its own task
                 // refused here. Reaching that is implausible today, and closing it properly means
                 // one shared issuance boundary in the wallet, which is the cleanup.
-                for (_, _, owner) in tx_template.iter_locally_owned_outputs() {
+                for (_, _, owner) in tx_template.iter_our_outputs() {
                     let path = owner.bip32_path;
 
                     if path.account_keychain.account != BitcoinAccount::default() {
@@ -178,7 +178,7 @@ impl CheckedSignTask {
                 app_tweak: AppTweak::Nostr,
             }],
             SignTask::BitcoinTransaction { tx_template, .. } => tx_template
-                .iter_sighashes_of_locally_owned_inputs()
+                .iter_our_input_sighashes()
                 .map(|(owner, sighash)| SignItem {
                     message: sighash.as_raw_hash().to_byte_array().to_vec(),
                     app_tweak: AppTweak::Bitcoin(owner.bip32_path),
@@ -308,7 +308,7 @@ mod test {
             "their output is a recipient, at their address"
         );
         assert_eq!(
-            tx_template.iter_locally_owned_outputs().count(),
+            tx_template.iter_our_outputs().count(),
             0,
             "and it is not ours"
         );
@@ -335,7 +335,6 @@ mod test {
         assert_eq!(prompt.fee, Amount::from_sat(10_000));
     }
 
-    /// A locally-owned input under a different key must be rejected.
     /// An input under another key is one we cannot sign, so it must not be counted as ours —
     /// leaving nothing here to sign at all.
     #[test]
@@ -367,8 +366,8 @@ mod test {
         );
     }
 
-    /// A send to an external (non-local) recipient is accepted: the owner check
-    /// only applies to locally-owned outputs.
+    /// A send to an external recipient is accepted: the owner check only applies to outputs
+    /// claiming to be ours.
     #[test]
     fn external_recipient_output_is_accepted() {
         let signing = signing_key();

--- a/frostsnap_core/tests/signature_mapping.rs
+++ b/frostsnap_core/tests/signature_mapping.rs
@@ -10,6 +10,7 @@ use frostsnap_core::{
     tweak::{BitcoinBip32Path, NormalIndex},
     MasterAppkey,
 };
+use std::collections::BTreeMap;
 
 fn idx(n: u32) -> NormalIndex {
     NormalIndex::new(n).expect("test index is in range")
@@ -404,6 +405,16 @@ fn another_keys_scripts_become_foreign() {
         mine.feerate().is_none(),
         "we cannot witness their input, so the weight is unknown"
     );
+    assert_eq!(
+        mine.our_net_value(),
+        -100_000,
+        "our balance moves by our own input alone; their side is not ours to count"
+    );
+    assert_eq!(
+        mine.foreign_net_values(),
+        BTreeMap::from([(their_spk.spk(), 50_000)]),
+        "netted against what they spend, where foreign_recipients reports the gross 150_000"
+    );
 
     // The other direction is the same story with the keys swapped.
     let theirs = template.as_seen_by(sibling);
@@ -415,6 +426,12 @@ fn another_keys_scripts_become_foreign() {
         vec![1]
     );
     assert_eq!(theirs.foreign_recipients().count(), 0);
+    assert_eq!(theirs.our_net_value(), 50_000);
+    assert_eq!(
+        theirs.foreign_net_values(),
+        BTreeMap::from([(our_spk.spk(), -100_000)]),
+        "we are the foreign party from their side, and we only spend"
+    );
 
     // Nothing was mutated: the original still knows who owns what. It cannot be *asked*
     // whose they are without naming a key, which is the point, so read the owners directly.

--- a/frostsnap_core/tests/signature_mapping.rs
+++ b/frostsnap_core/tests/signature_mapping.rs
@@ -245,7 +245,7 @@ fn a_foreign_input_at_one_of_our_own_output_scripts_is_still_foreign() {
 /// `is_mine` in the app is built from this. Sourcing it from a wallet index instead answers
 /// "has the wallet derived this spk yet", which is bounded by lookahead.
 #[test]
-fn owned_spks_covers_both_sides_at_any_depth() {
+fn our_spks_covers_both_sides_at_any_depth() {
     let key = key();
     let deep_input = BitcoinBip32Path::external(idx(500_000));
     let deep_output = BitcoinBip32Path::internal(idx(400_000));
@@ -297,7 +297,7 @@ fn owned_spks_covers_both_sides_at_any_depth() {
         script_pubkey: foreign_spk(0xbb),
     });
 
-    let owned = template.as_seen_by(key).owned_spks();
+    let owned = template.as_seen_by(key).our_spks();
 
     assert_eq!(
         owned.len(),
@@ -379,7 +379,7 @@ fn another_keys_scripts_become_foreign() {
     let mine = template.as_seen_by(ours);
 
     assert_eq!(
-        mine.iter_locally_owned_inputs()
+        mine.iter_our_inputs()
             .map(|(i, _, _)| i)
             .collect::<Vec<_>>(),
         vec![0],
@@ -394,7 +394,7 @@ fn another_keys_scripts_become_foreign() {
         vec![0],
         "our one signature belongs on our one input"
     );
-    assert!(!mine.owned_spks().contains_key(&their_spk.spk()));
+    assert!(!mine.our_spks().contains_key(&their_spk.spk()));
     assert_eq!(
         mine.foreign_recipients().collect::<Vec<_>>(),
         vec![(their_spk.spk().as_script(), 150_000)],
@@ -409,7 +409,7 @@ fn another_keys_scripts_become_foreign() {
     let theirs = template.as_seen_by(sibling);
     assert_eq!(
         theirs
-            .iter_locally_owned_inputs()
+            .iter_our_inputs()
             .map(|(i, _, _)| i)
             .collect::<Vec<_>>(),
         vec![1]

--- a/frostsnap_core/tests/signature_mapping.rs
+++ b/frostsnap_core/tests/signature_mapping.rs
@@ -416,6 +416,14 @@ fn another_keys_scripts_become_foreign() {
     );
     assert_eq!(theirs.foreign_recipients().count(), 0);
 
-    // Nothing was mutated: the original still knows who owns what.
-    assert_eq!(template.iter_locally_owned_inputs().count(), 2);
+    // Nothing was mutated: the original still knows who owns what. It cannot be *asked*
+    // whose they are without naming a key, which is the point, so read the owners directly.
+    assert_eq!(
+        template
+            .inputs()
+            .iter()
+            .filter(|input| input.owner().local_owner().is_some())
+            .count(),
+        2
+    );
 }

--- a/frostsnap_core/tests/user_prompt.rs
+++ b/frostsnap_core/tests/user_prompt.rs
@@ -45,7 +45,9 @@ fn push_change(template: &mut TransactionTemplate, sats: u64, index: u32) {
 }
 
 fn prompt(template: &TransactionTemplate) -> PromptSignBitcoinTx {
-    template.user_prompt(bitcoin::Network::Bitcoin)
+    template
+        .as_seen_by(MasterAppkey::derive_from_rootkey(G.normalize()))
+        .user_prompt(bitcoin::Network::Bitcoin)
 }
 
 fn summary(prompt: &PromptSignBitcoinTx) -> Vec<(u64, Option<BitcoinBip32Path>)> {

--- a/frostsnap_core/tests/wire_format.rs
+++ b/frostsnap_core/tests/wire_format.rs
@@ -14,7 +14,13 @@ fn idx(n: u32) -> NormalIndex {
     NormalIndex::new(n).unwrap()
 }
 
-/// Both sides, both owner kinds, non-default version and locktime.
+/// Both sides, both owner kinds, and a non-default locktime.
+///
+/// The version is left at `new()`'s default deliberately. These bytes were captured from code
+/// that predates the scope type parameter, which is what makes them evidence the encoding did
+/// not move; regenerating them to exercise another field spends that for a field nothing here
+/// touches. Cover `version` — which `psbt_template` reads out of a third-party PSBT — under
+/// its own fixture instead.
 fn representative_template() -> TransactionTemplate {
     let key = MasterAppkey::derive_from_rootkey(g!(2 * G).normalize());
     let path = BitcoinBip32Path::external(idx(7));

--- a/frostsnap_core/tests/wire_format.rs
+++ b/frostsnap_core/tests/wire_format.rs
@@ -1,0 +1,97 @@
+//! The template is bincode-encoded into `WireSignTask` and parsed by firmware, so its
+//! encoding is a compatibility surface. This pins it against a fixture captured before the
+//! scope type parameter existed.
+
+use bitcoin::{hashes::Hash, Amount, OutPoint, ScriptBuf, TxOut, Txid};
+use frostsnap_core::{
+    bitcoin_transaction::{LocalSpk, PushInput, TransactionTemplate},
+    schnorr_fun::fun::{g, G},
+    tweak::{BitcoinBip32Path, NormalIndex},
+    MasterAppkey,
+};
+
+fn idx(n: u32) -> NormalIndex {
+    NormalIndex::new(n).unwrap()
+}
+
+/// Both sides, both owner kinds, non-default version and locktime.
+fn representative_template() -> TransactionTemplate {
+    let key = MasterAppkey::derive_from_rootkey(g!(2 * G).normalize());
+    let path = BitcoinBip32Path::external(idx(7));
+    let mut template = TransactionTemplate::new();
+    template.set_lock_time(bitcoin::absolute::LockTime::from_height(812_345).unwrap());
+
+    let ours = TxOut {
+        value: Amount::from_sat(123_456),
+        script_pubkey: LocalSpk {
+            master_appkey: key,
+            bip32_path: path,
+        }
+        .spk(),
+    };
+    template
+        .push_owned_input(
+            PushInput::spend_outpoint(
+                &ours,
+                OutPoint {
+                    txid: Txid::from_byte_array([3u8; 32]),
+                    vout: 1,
+                },
+            ),
+            LocalSpk {
+                master_appkey: key,
+                bip32_path: path,
+            },
+        )
+        .unwrap();
+
+    let theirs = TxOut {
+        value: Amount::from_sat(99_000),
+        script_pubkey: ScriptBuf::from_bytes([&[0x51u8, 0x20][..], &[0xab; 32][..]].concat()),
+    };
+    template.push_foreign_input(PushInput::spend_outpoint(
+        &theirs,
+        OutPoint {
+            txid: Txid::from_byte_array([4u8; 32]),
+            vout: 0,
+        },
+    ));
+
+    template.push_owned_output(
+        Amount::from_sat(50_000),
+        LocalSpk {
+            master_appkey: key,
+            bip32_path: BitcoinBip32Path::internal(idx(2)),
+        },
+    );
+    template.push_foreign_output(TxOut {
+        value: Amount::from_sat(150_000),
+        script_pubkey: ScriptBuf::from_bytes([&[0x51u8, 0x20][..], &[0xcd; 32][..]].concat()),
+    });
+    template
+}
+
+/// Captured before the scope type parameter existed. If this changes, firmware that has not
+/// been upgraded can no longer parse a sign request.
+const ENCODED: &str = "04fc39650c000220030303030303030303030303030303030303030303030303030303030303030301fc40e20100010262e5d80f30c313d69a0186b54c4a1ace22cce7376dea84b689f130b786eb29d1000f25db8615dd0663b2ad400f1c6607163ace291ca8ef284b8d319b54bff90500000007fcfdffffff20040404040404040404040404040404040404040404040404040404040404040400fcb882010000225120ababababababababababababababababababababababababababababababababfcfdffffff02fb50c3010262e5d80f30c313d69a0186b54c4a1ace22cce7376dea84b689f130b786eb29d1000f25db8615dd0663b2ad400f1c6607163ace291ca8ef284b8d319b54bff90500000102fcf049020000225120cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd";
+
+#[test]
+fn template_encoding_is_unchanged() {
+    let encoded =
+        bincode::encode_to_vec(representative_template(), bincode::config::standard()).unwrap();
+
+    assert_eq!(
+        frostsnap_core::schnorr_fun::fun::hex::encode(&encoded),
+        ENCODED,
+        "the template's encoding is what firmware parses; it must not move"
+    );
+}
+
+#[test]
+fn template_decodes_the_captured_encoding() {
+    let bytes = frostsnap_core::schnorr_fun::fun::hex::decode(ENCODED).unwrap();
+    let (decoded, _): (TransactionTemplate, _) =
+        bincode::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+
+    assert_eq!(decoded, representative_template());
+}

--- a/frostsnapp/lib/psbt.dart
+++ b/frostsnapp/lib/psbt.dart
@@ -79,7 +79,7 @@ class LoadPsbtPageState extends State<LoadPsbtPage> {
     }
 
     final txDetails = TxDetailsModel(
-      tx: unsignedTx.details(masterAppkey: wallet.masterAppkey),
+      tx: unsignedTx.details(),
       chainTipHeight: wallet.superWallet.height(),
       now: DateTime.now(),
     );
@@ -490,10 +490,7 @@ Future<bool> showBroadcastConfirmDialog(
     context: context,
     barrierDismissible: false,
     builder: (dialogContext) {
-      final effect = tx.effect(
-        masterAppkey: masterAppkey,
-        network: superWallet.network,
-      );
+      final effect = tx.effect(network: superWallet.network);
       final effectWidget = EffectTable(effect: effect);
       return AlertDialog(
         title: Text("Broadcast?"),

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -635,7 +635,7 @@ class _WalletSendPageState extends State<WalletSendPage> {
     final chainTipHeight = walletCtx.wallet.superWallet.height();
     final now = DateTime.now();
 
-    final tx = unsignedTx?.details(masterAppkey: walletCtx.masterAppkey);
+    final tx = unsignedTx?.details();
     if (tx == null) return;
     final txDetails = TxDetailsModel(
       tx: tx,

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -10,7 +10,7 @@ use frostsnap_coordinator::bitcoin::chain_sync::{
 };
 pub use frostsnap_coordinator::bitcoin::wallet::ConfirmationTime;
 pub use frostsnap_coordinator::frostsnap_core::{self, MasterAppkey};
-use frostsnap_core::bitcoin_transaction::{self, TransactionTemplate};
+use frostsnap_core::bitcoin_transaction::{self, ScopedTo, TransactionTemplate};
 use frostsnap_core::message::EncodedSignature;
 use tracing::{event, Level};
 
@@ -189,15 +189,11 @@ pub struct Transaction {
     /// Present only when this came from a signing session, already normalised to the key it
     /// belongs to. Signatures are ordered by that key's owned inputs.
     #[frb(ignore)]
-    pub template: Option<TransactionTemplate>,
+    pub template: Option<TransactionTemplate<ScopedTo>>,
 }
 
 impl Transaction {
-    pub(crate) fn from_template(
-        tx_temp: &TransactionTemplate,
-        master_appkey: MasterAppkey,
-    ) -> Self {
-        let tx_temp = &tx_temp.as_seen_by(master_appkey);
+    pub(crate) fn from_template(tx_temp: &TransactionTemplate<ScopedTo>) -> Self {
         let raw_tx = tx_temp.to_rust_bitcoin_tx();
         let txid = tx_temp.txid();
         let is_mine = tx_temp
@@ -223,7 +219,7 @@ impl Transaction {
 
     pub(crate) fn fill_signatures(
         &mut self,
-        template: &TransactionTemplate,
+        template: &TransactionTemplate<ScopedTo>,
         signatures: &[EncodedSignature],
     ) -> Result<(), bitcoin_transaction::SignatureCountMismatch> {
         for (i, signature) in template.signatures_by_input_index(signatures)? {
@@ -640,7 +636,7 @@ mod test {
     #[test]
     fn with_signatures_agrees_with_the_template_it_delegates_to() {
         let template = template_with_a_foreign_input_first();
-        let tx = Transaction::from_template(&template, key());
+        let tx = Transaction::from_template(&template.as_seen_by(key()));
 
         for signatures in [vec![], vec![signature(7)], vec![signature(1), signature(2)]] {
             assert_eq!(
@@ -658,7 +654,8 @@ mod test {
     /// input a signature belongs to. Refusing beats guessing.
     #[test]
     fn with_signatures_refuses_a_transaction_that_did_not_come_from_signing() {
-        let mut tx = Transaction::from_template(&template_with_a_foreign_input_first(), key());
+        let mut tx =
+            Transaction::from_template(&template_with_a_foreign_input_first().as_seen_by(key()));
         tx.template = None;
 
         assert!(tx.with_signatures(vec![signature(7)]).is_err());
@@ -688,7 +685,7 @@ mod test {
             )
             .unwrap();
 
-        let tx = Transaction::from_template(&template, key);
+        let tx = Transaction::from_template(&template.as_seen_by(key));
         let recipients = tx.recipients();
 
         let ours = recipients.last().unwrap();
@@ -702,7 +699,8 @@ mod test {
     /// feerate disappeared from the review screen for exactly those transactions.
     #[test]
     fn fee_survives_an_input_the_wallet_has_never_seen() {
-        let tx = Transaction::from_template(&template_with_a_foreign_input_first(), key());
+        let tx =
+            Transaction::from_template(&template_with_a_foreign_input_first().as_seen_by(key()));
 
         assert_eq!(tx.prevouts.len(), 2, "both inputs, foreign one included");
         assert_eq!(tx.fee(), Some(50_000));

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -217,13 +217,22 @@ impl Transaction {
         }
     }
 
-    pub(crate) fn fill_signatures(
-        &mut self,
-        template: &TransactionTemplate<ScopedTo>,
-        signatures: &[EncodedSignature],
-    ) -> Result<(), bitcoin_transaction::SignatureCountMismatch> {
-        for (i, signature) in template.signatures_by_input_index(signatures)? {
-            self.inner.input[i].witness = bitcoin_transaction::signature_witness(signature);
+    /// Takes the template from `self`: passing one in would let a caller pair signatures
+    /// with a transaction they did not come from.
+    pub(crate) fn fill_signatures(&mut self, signatures: &[EncodedSignature]) -> Result<()> {
+        let placements = {
+            let template = self
+                .template
+                .as_ref()
+                .ok_or_else(|| anyhow!("this transaction did not come from a signing session"))?;
+            template
+                .signatures_by_input_index(signatures)?
+                .into_iter()
+                .map(|(i, signature)| (i, bitcoin_transaction::signature_witness(signature)))
+                .collect::<Vec<_>>()
+        };
+        for (i, witness) in placements {
+            self.inner.input[i].witness = witness;
         }
         Ok(())
     }

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -197,7 +197,7 @@ impl Transaction {
         let raw_tx = tx_temp.to_rust_bitcoin_tx();
         let txid = tx_temp.txid();
         let is_mine = tx_temp
-            .owned_spks()
+            .our_spks()
             .into_iter()
             .map(|(spk, path)| (spk, path.index.to_u32()))
             .collect::<HashMap<_, _>>();

--- a/frostsnapp/rust/src/api/send.rs
+++ b/frostsnapp/rust/src/api/send.rs
@@ -56,9 +56,8 @@ impl SuperWallet {
             .inner()
             .reserved_change_indices(plan.0.master_appkey(), BitcoinAccount::default());
         let mut inner = self.inner.lock().unwrap();
-        Ok(UnsignedTx {
-            master_appkey: plan.0.master_appkey(),
-            template_tx: inner.commit_send(&plan.0, reserved)?,
-        })
+        let template_tx = inner.commit_send(&plan.0, reserved)?;
+        UnsignedTx::new(template_tx, plan.0.master_appkey())
+            .ok_or_else(|| anyhow::anyhow!("the committed transaction spends none of our coins"))
     }
 }

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -91,14 +91,35 @@ pub struct UnsignedTx {
     /// The form that will be sent. Held unscoped because that is what goes on the wire, and
     /// there is deliberately no way back from a scoped one.
     ///
-    /// Crate-private so frb generates no accessor: it cannot name a second instantiation of
-    /// a generic, and Dart asks through the methods below anyway.
-    pub(crate) template_tx: TransactionTemplate,
+    /// Private so [`Self::new`] is the only way to get one, which is what makes its check an
+    /// invariant rather than a habit of the two callers. It also leaves frb no accessor to
+    /// generate, which it could not do for a second instantiation of a generic anyway.
+    template_tx: TransactionTemplate,
     /// Whose transaction this is. Every question about ownership needs it.
     pub master_appkey: MasterAppkey,
 }
 
 impl UnsignedTx {
+    /// Fails when no input belongs to `master_appkey`.
+    ///
+    /// Every reader below answers *for* that key without re-checking, so a template with
+    /// nothing of its own would report a balance and a recipient list for a transaction the
+    /// key has no part in. `psbt_to_tx_template` rejects a PSBT owned by none of the keys it
+    /// was given, which is a weaker statement as soon as it is given more than one.
+    #[frb(ignore)]
+    pub(crate) fn new(
+        template_tx: TransactionTemplate,
+        master_appkey: MasterAppkey,
+    ) -> Option<Self> {
+        template_tx
+            .as_seen_by(master_appkey)
+            .has_any_inputs_to_sign()
+            .then_some(Self {
+                template_tx,
+                master_appkey,
+            })
+    }
+
     /// This transaction as its own key sees it. Cheap enough for the handful of UI-rate
     /// reads below, and it keeps the sendable form the only one stored.
     #[frb(ignore)]

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -5,7 +5,6 @@ use super::{
 };
 use crate::{frb_generated::StreamSink, sink_wrap::SinkWrap};
 use anyhow::{anyhow, Result};
-use bitcoin::hex::DisplayHex;
 use flutter_rust_bridge::frb;
 pub use frostsnap_coordinator::signing::SigningState;
 pub use frostsnap_core::bitcoin_transaction::{ScopedTo, TransactionTemplate};
@@ -38,22 +37,6 @@ impl UnbroadcastedTx {
     }
 }
 
-#[derive(Debug, Clone)]
-#[frb(non_opaque)]
-pub enum SigningDetails {
-    Message {
-        message: String,
-    },
-    Transaction {
-        transaction: crate::api::bitcoin::Transaction,
-    },
-    Nostr {
-        id: String,
-        content: String,
-        hash_bytes: String,
-    },
-}
-
 #[frb(mirror(SigningState), unignore)]
 pub struct _SigningState {
     pub session_id: SignSessionId,
@@ -76,8 +59,6 @@ pub trait ActiveSignSessionExt {
     #[frb(sync)]
     fn state(&self) -> SigningState;
     #[frb(sync)]
-    fn details(&self, master_appkey: MasterAppkey) -> SigningDetails;
-    #[frb(sync)]
     fn access_structure_ref(&self) -> AccessStructureRef;
 }
 
@@ -97,24 +78,6 @@ impl ActiveSignSessionExt for ActiveSignSession {
         };
 
         state
-    }
-
-    #[frb(sync)]
-    fn details(&self, master_appkey: MasterAppkey) -> SigningDetails {
-        let session_init = &self.init;
-
-        let res = match session_init.group_request.sign_task.clone() {
-            WireSignTask::Test { message } => SigningDetails::Message { message },
-            WireSignTask::Nostr { event } => SigningDetails::Nostr {
-                id: event.id,
-                content: event.content,
-                hash_bytes: event.hash_bytes.to_lower_hex_string(),
-            },
-            WireSignTask::BitcoinTransaction(tx_temp) => SigningDetails::Transaction {
-                transaction: Transaction::from_template(&tx_temp.as_seen_by(master_appkey)),
-            },
-        };
-        res
     }
 
     #[frb(sync)]
@@ -344,10 +307,7 @@ impl Coordinator {
                         let mut tx = Transaction::from_template(&tx_temp.as_seen_by(master_appkey));
                         // Showing an unbroadcastable transaction is worse than omitting it:
                         // its witnesses would be on inputs that did not produce them.
-                        if let Err(e) = tx.fill_signatures(
-                            &tx_temp.as_seen_by(master_appkey),
-                            &session.signatures,
-                        ) {
+                        if let Err(e) = tx.fill_signatures(&session.signatures) {
                             event!(
                                 Level::ERROR,
                                 session = session_id.to_string(),

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Result};
 use bitcoin::hex::DisplayHex;
 use flutter_rust_bridge::frb;
 pub use frostsnap_coordinator::signing::SigningState;
-pub use frostsnap_core::bitcoin_transaction::TransactionTemplate;
+pub use frostsnap_core::bitcoin_transaction::{ScopedTo, TransactionTemplate};
 pub use frostsnap_core::coordinator::ActiveSignSession;
 pub use frostsnap_core::coordinator::{SignSessionProgress, StartSign};
 use frostsnap_core::MasterAppkey;
@@ -111,7 +111,7 @@ impl ActiveSignSessionExt for ActiveSignSession {
                 hash_bytes: event.hash_bytes.to_lower_hex_string(),
             },
             WireSignTask::BitcoinTransaction(tx_temp) => SigningDetails::Transaction {
-                transaction: Transaction::from_template(&tx_temp, master_appkey),
+                transaction: Transaction::from_template(&tx_temp.as_seen_by(master_appkey)),
             },
         };
         res
@@ -125,12 +125,24 @@ impl ActiveSignSessionExt for ActiveSignSession {
 
 #[derive(Clone, Debug)]
 pub struct UnsignedTx {
-    pub template_tx: TransactionTemplate,
+    /// The form that will be sent. Held unscoped because that is what goes on the wire, and
+    /// there is deliberately no way back from a scoped one.
+    ///
+    /// Crate-private so frb generates no accessor: it cannot name a second instantiation of
+    /// a generic, and Dart asks through the methods below anyway.
+    pub(crate) template_tx: TransactionTemplate,
     /// Whose transaction this is. Every question about ownership needs it.
     pub master_appkey: MasterAppkey,
 }
 
 impl UnsignedTx {
+    /// This transaction as its own key sees it. Cheap enough for the handful of UI-rate
+    /// reads below, and it keeps the sendable form the only one stored.
+    #[frb(ignore)]
+    fn scoped(&self) -> TransactionTemplate<ScopedTo> {
+        self.template_tx.as_seen_by(self.master_appkey)
+    }
+
     #[frb(sync)]
     pub fn txid(&self) -> String {
         self.template_tx.txid().to_string()
@@ -143,34 +155,33 @@ impl UnsignedTx {
 
     #[frb(sync)]
     pub fn feerate(&self) -> Option<f64> {
-        self.template_tx.feerate()
+        self.scoped().feerate()
     }
 
     #[frb(sync)]
-    pub fn details(&self, master_appkey: MasterAppkey) -> Transaction {
-        Transaction::from_template(&self.template_tx, master_appkey)
+    pub fn details(&self) -> Transaction {
+        Transaction::from_template(&self.scoped())
     }
 
     #[frb(sync)]
     pub fn complete(&self, signatures: Vec<EncodedSignature>) -> Result<SignedTx> {
         Ok(SignedTx {
-            signed_tx: self.template_tx.to_signed_rust_bitcoin_tx(&signatures)?,
+            signed_tx: self.scoped().to_signed_rust_bitcoin_tx(&signatures)?,
             unsigned_tx: self.clone(),
         })
     }
 
     #[frb(sync)]
-    pub fn effect(
-        &self,
-        master_appkey: MasterAppkey,
-        network: BitcoinNetwork,
-    ) -> Result<EffectOfTx> {
+    pub fn effect(&self, network: BitcoinNetwork) -> Result<EffectOfTx> {
+        // Taking a key as an argument would let a caller ask about one this transaction is
+        // not for; it is a property of the transaction, not of the question.
+        let master_appkey = self.master_appkey;
         use frostsnap_core::bitcoin_transaction::RootOwner;
         let fee = self
             .template_tx
             .fee()
             .ok_or(anyhow!("invalid transaction"))?;
-        let mut net_value = self.template_tx.net_value();
+        let mut net_value = self.scoped().net_value();
         let value_for_this_key = net_value
             .remove(&RootOwner::Local(master_appkey))
             .ok_or(anyhow!("this transaction has no effect on this key"))?;
@@ -178,9 +189,9 @@ impl UnsignedTx {
         let foreign_receiving_addresses = net_value
             .into_iter()
             .filter_map(|(owner, value)| match owner {
-                RootOwner::Local(_) => Some(Err(anyhow!(
-                    "we don't support spending from multiple different keys"
-                ))),
+                // Unreachable on a scoped template: another key's scripts are already foreign
+                // to it, and reported below as what they are — money leaving.
+                RootOwner::Local(_) => None,
                 RootOwner::Foreign(spk) => {
                     if value > 0 {
                         Some(Ok((
@@ -199,7 +210,7 @@ impl UnsignedTx {
         Ok(EffectOfTx {
             net_value: value_for_this_key,
             fee,
-            feerate: self.template_tx.feerate(),
+            feerate: self.scoped().feerate(),
             foreign_receiving_addresses,
         })
     }
@@ -218,12 +229,8 @@ impl SignedTx {
     }
 
     #[frb(sync)]
-    pub fn effect(
-        &self,
-        master_appkey: MasterAppkey,
-        network: BitcoinNetwork,
-    ) -> Result<EffectOfTx> {
-        self.unsigned_tx.effect(master_appkey, network)
+    pub fn effect(&self, network: BitcoinNetwork) -> Result<EffectOfTx> {
+        self.unsigned_tx.effect(network)
     }
 }
 
@@ -315,7 +322,7 @@ impl Coordinator {
                 let sign_task = &session.init.group_request.sign_task;
                 match sign_task {
                     WireSignTask::BitcoinTransaction(tx_temp) => {
-                        let tx = Transaction::from_template(tx_temp, master_appkey);
+                        let tx = Transaction::from_template(&tx_temp.as_seen_by(master_appkey));
                         let session_id = session.session_id();
                         Some(UnbroadcastedTx {
                             tx,
@@ -334,10 +341,13 @@ impl Coordinator {
             .filter_map(
                 |(&session_id, session)| match &session.init.group_request.sign_task {
                     WireSignTask::BitcoinTransaction(tx_temp) => {
-                        let mut tx = Transaction::from_template(tx_temp, master_appkey);
+                        let mut tx = Transaction::from_template(&tx_temp.as_seen_by(master_appkey));
                         // Showing an unbroadcastable transaction is worse than omitting it:
                         // its witnesses would be on inputs that did not produce them.
-                        if let Err(e) = tx.fill_signatures(tx_temp, &session.signatures) {
+                        if let Err(e) = tx.fill_signatures(
+                            &tx_temp.as_seen_by(master_appkey),
+                            &session.signatures,
+                        ) {
                             event!(
                                 Level::ERROR,
                                 session = session_id.to_string(),

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -134,46 +134,34 @@ impl UnsignedTx {
         })
     }
 
+    /// Takes no key: which key this is about is a property of the transaction, not of the
+    /// question, and a parameter would let a caller ask about one it is not for.
     #[frb(sync)]
     pub fn effect(&self, network: BitcoinNetwork) -> Result<EffectOfTx> {
-        // Taking a key as an argument would let a caller ask about one this transaction is
-        // not for; it is a property of the transaction, not of the question.
-        let master_appkey = self.master_appkey;
-        use frostsnap_core::bitcoin_transaction::RootOwner;
+        let scoped = self.scoped();
         let fee = self
             .template_tx
             .fee()
             .ok_or(anyhow!("invalid transaction"))?;
-        let mut net_value = self.scoped().net_value();
-        let value_for_this_key = net_value
-            .remove(&RootOwner::Local(master_appkey))
-            .ok_or(anyhow!("this transaction has no effect on this key"))?;
 
-        let foreign_receiving_addresses = net_value
+        let foreign_receiving_addresses = scoped
+            .foreign_net_values()
             .into_iter()
-            .filter_map(|(owner, value)| match owner {
-                // Unreachable on a scoped template: another key's scripts are already foreign
-                // to it, and reported below as what they are — money leaving.
-                RootOwner::Local(_) => None,
-                RootOwner::Foreign(spk) => {
-                    if value > 0 {
-                        Some(Ok((
-                            bitcoin::Address::from_script(spk.as_script(), network)
-                                .expect("will have address form")
-                                .to_string(),
-                            value as u64,
-                        )))
-                    } else {
-                        None
-                    }
-                }
+            .filter(|(_, value)| *value > 0)
+            .map(|(spk, value)| {
+                (
+                    bitcoin::Address::from_script(spk.as_script(), network)
+                        .expect("will have address form")
+                        .to_string(),
+                    value as u64,
+                )
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect();
 
         Ok(EffectOfTx {
-            net_value: value_for_this_key,
+            net_value: scoped.our_net_value(),
             fee,
-            feerate: self.scoped().feerate(),
+            feerate: scoped.feerate(),
             foreign_receiving_addresses,
         })
     }

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -300,11 +300,12 @@ impl SuperWallet {
         psbt: &Psbt,
         master_appkey: MasterAppkey,
     ) -> Result<UnsignedTx, PsbtValidationError> {
-        let template = TransactionTemplate::from_psbt(psbt, master_appkey)?;
+        let template = TransactionTemplate::from_psbt(psbt, &[master_appkey])?;
 
-        Ok(UnsignedTx {
-            template_tx: template,
-            master_appkey,
+        // Unreachable while one key goes in: `from_psbt` returning `Ok` already means that key
+        // owns an input. It is the guard for the day more than one does.
+        UnsignedTx::new(template, master_appkey).ok_or_else(|| {
+            PsbtValidationError::Other("no input in this PSBT belongs to this key".into())
         })
     }
 }


### PR DESCRIPTION
Follow-up to #560, which this is stacked on — review that one first.

#560 made every `TransactionTemplate` reader correct by normalising the template to the
signing key in `WireSignTask::check`. That works, but the guarantee is a *convention*: one
call, in one function, and nothing stops the next reader taking a template that never went
through it. Both forms are the same type, so the compiler cannot tell them apart.

This makes it a type.

```rust
pub struct TransactionTemplate<S = Unscoped> { …, scope: S }

pub struct Unscoped;                  // the form that travels
pub struct ScopedTo(MasterAppkey);    // narrowed to one key by as_seen_by
```

Readers that answer an ownership question — `iter_locally_owned_*`, `owned_spks`,
`signatures_by_input_index`, `to_signed_rust_bitcoin_tx`, `has_any_inputs_to_sign`,
`feerate`, `foreign_recipients`, `user_prompt`, `attach_signatures_to_psbt` — exist only on
`TransactionTemplate<ScopedTo>`. Asking an unscoped template whose inputs are whose is a
compile error. `fee`, `txid`, `net_value` and `to_rust_bitcoin_tx` need no key and stay on
both.

**`ScopedTo` implements no bincode.** A scoped template cannot be serialized at all, so the
form that goes over the wire is the general one by construction rather than by discipline.
`WireSignTask` carries `Unscoped`; `SignTask`, which only exists after `check`, carries
`ScopedTo`.

### The wire bytes do not move

Established before anything was built on it, because firmware parses them.
`frostsnap_core/tests/wire_format.rs` pins the bincode encoding of a template using both
sides and both owner kinds, captured before the type parameter existed; it still
round-trips. `Unscoped` is a unit struct whose derived `Encode` writes nothing.

That fixture is worth having regardless of this PR: nothing previously pinned the encoding,
so an accidental change to `Input`, `Output`, `SpkOwner` or `LocalSpk` would have shipped
and broken un-upgraded firmware silently.

### What the compiler found that the convention had hidden

- Three `as_seen_by` calls in `check` re-scoping an already-scoped template.
- Every reader on the app's display path refused to compile until handed a scoped template
  — the same sites an earlier sweep had flagged as reading ownership from a template
  nothing had checked.
- `Transaction::from_template` lost its `master_appkey` parameter: the scope carries it.
- `details` and `effect` lost arguments that could *disagree* with the template they were
  reading. `effect` took a key while reading a template that names its own; disagreement was
  not benign, and its "we don't support spending from multiple different keys" arm is now
  unreachable and deleted.

### Testing

Two `compile_fail` doctests pin the guarantees themselves, with expected error codes
(`E0599`, `E0277`) so they cannot pass for an unrelated reason — verified by moving a reader
onto the general impl and watching them fail.

`frostsnap_core --no-default-features` still builds, since the device parses the wire form.
