### PR TITLE
[coord] Fix inverted revealed check in address_info

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -293,7 +293,7 @@ impl CoordSuperWallet {
         let keychain = (master_appkey, path.account_keychain);
         let used = self.tx_graph.index.is_used(keychain, path.index.to_u32());
         let revealed =
-            self.tx_graph.index.last_revealed_index(keychain) <= Some(path.index.to_u32());
+            Some(path.index.to_u32()) <= self.tx_graph.index.last_revealed_index(keychain);
         let spk = super::peek_spk(master_appkey, path);
         AddressInfo {
             index: path.index.to_u32(),


### PR DESCRIPTION
`address_info` computed `revealed` with its operands the wrong way around.

`last_revealed_index` returns the highest index a keychain has revealed so far, so an address is revealed when its own index is at or below that frontier. The comparison asked the opposite: whether the frontier was at or below the address index. With `last_revealed = 5`:

| index | reported | correct |
| --- | --- | --- |
| 3 | false | true |
| 5 | true | true |
| 9 | true | false |

Only `index == last_revealed` came out right.

The `Option` ordering made it worse at the start of a wallet's life. Rust orders `None < Some(_)`, so a keychain that has revealed nothing compared as less than every `Some(index)`, and a fresh wallet reported every address as revealed.

There is no live reader today: `AddressInfo.revealed` is consumed only by `isRevealed` in `frostsnapp/lib/wallet_receive.dart`, which nothing references. So this is a latent defect with no current user-visible effect. It arrived with 215d7ad7 "[native,app] Remove address metadata".