### PR TITLE
[app] Take the stranded-coins scan off the render thread

### DIFF
--- a/frostsnapp/lib/wallet_stranded_coins.dart
+++ b/frostsnapp/lib/wallet_stranded_coins.dart
@@ -25,28 +25,47 @@ const nudgeFeerate = 10.0;
 /// gap limit, so a coin past such a stretch would be missed. Any outgoing transaction
 /// consolidates those coins automatically (`plan_send` force-selects them); this banner exists
 /// so the user knows one is worth making.
-class StrandedCoinsBanner extends StatelessWidget {
+class StrandedCoinsBanner extends StatefulWidget {
   const StrandedCoinsBanner({super.key});
+
+  @override
+  State<StrandedCoinsBanner> createState() => _StrandedCoinsBannerState();
+}
+
+class _StrandedCoinsBannerState extends State<StrandedCoinsBanner> {
+  Stream<TxState>? _source;
+  Stream<(int, int)>? _stranded;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final walletCtx = WalletContext.of(context)!;
+    // Derived here rather than in build, where asyncMap would open a fresh subscription on every
+    // rebuild. Keyed on the source's identity so selecting another wallet re-derives: the streams
+    // are cached per key, so a different wallet is a different stream.
+    if (_source != walletCtx.txStream) {
+      _source = walletCtx.txStream;
+      _stranded = _source!.asyncMap(
+        (_) => walletCtx.superWallet.gapStrandedValue(
+          masterAppkey: walletCtx.masterAppkey,
+          feerate: nudgeFeerate,
+        ),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final walletCtx = WalletContext.of(context)!;
 
-    return StreamBuilder<TxState>(
-      stream: walletCtx.txStream,
+    return StreamBuilder<(int, int)>(
+      stream: _stranded,
       builder: (context, snapshot) {
-        var count = 0;
-        var sats = 0;
-        if (snapshot.hasData) {
-          final (strandedCount, strandedSats) = walletCtx.superWallet
-              .gapStrandedValue(
-                masterAppkey: walletCtx.masterAppkey,
-                feerate: nudgeFeerate,
-              );
-          count = strandedCount;
-          sats = strandedSats;
-        }
+        // The last figures stay up while the next scan runs — StreamBuilder holds the previous
+        // event, so recomputing never blinks the banner out and back. Not-yet-known reads as
+        // nothing to say, which is a state this banner already has and animates into.
+        final (count, sats) = snapshot.data ?? (0, 0);
 
         final card = count == 0
             ? SizedBox(width: double.infinity)

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -301,7 +301,11 @@ impl SuperWallet {
     /// `feerate` is the bar for mentioning a coin at all, not a price: nothing is spent here, and
     /// the caller decides what counts as worth rescuing. What a rescue actually moves is decided
     /// later, at the rate the user picks.
-    #[frb(sync, type_64bit_int)]
+    /// Not `sync`: it walks every unspent coin of the key and simulates a restore's crawl per
+    /// keychain, which is sub-millisecond on an ordinary wallet and long enough on a large one to
+    /// drop a frame if the render thread waits for it — or to wait on the wallet mutex behind a
+    /// sync.
+    #[frb(type_64bit_int)]
     pub fn gap_stranded_value(&self, master_appkey: MasterAppkey, feerate: f32) -> (u64, u64) {
         self.inner
             .lock()


### PR DESCRIPTION
`gapStrandedValue` was a `#[frb(sync)]` call inside the stranded-coins banner's `StreamBuilder`, so **every transaction event ran it on the UI thread**: a blocking hop into Rust that takes the wallet mutex, walks every unspent coin of the key and simulates a restore's crawl per keychain.

Sub-millisecond on an ordinary wallet. On a large one — or behind a sync holding the lock — long enough to drop frames on the screen the user is looking at. The banner is always mounted on the wallet home, so this ran on every sync tick.

It is now an ordinary async call, awaited off the render thread via `asyncMap` on the tx stream. The widget reads a value instead of acquiring a lock.

### No spinner, deliberately

The wait is typically under a millisecond and around 100ms at worst. Material's guidance is that an indicator which appears and vanishes reads as a glitch — and the correct policy for a variable wait (delay before showing, minimum time on screen once shown) would mean this one *never rendered at all*.

So instead:

- the last figures stay up while the next scan runs, since `StreamBuilder` holds the previous event — recomputing never blinks the banner out and back
- a not-yet-known count reads as nothing to say, which is a state the banner already had and already animates into via its `AnimatedSize`

### Two details worth flagging for review

- the derived stream is built in `didChangeDependencies`, not `build`, where `asyncMap` would open a fresh subscription on every rebuild
- it is keyed on the source stream's identity, so selecting another wallet re-derives — the streams are cached per key, so a different wallet is a different stream

### Verification

`dart analyze lib/` clean, `cargo check -p rust_lib_frostsnapp` clean, `dart format` clean, Flutter tests pass. Static checks cannot show that the banner still *renders*, so the change was also run against the full fsim e2e suite on a branch carrying it: **16 passed, 0 failed**, including a consolidation drive that funds two coins and consolidates twice.

`utxoCount` in #551 has the identical shape and is not fixed here.