### PR TITLE
An output with no address is a fact, not a panic

### DIFF
--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -465,31 +465,6 @@ impl TransactionTemplate<ScopedTo> {
                 .sum::<i64>()
     }
 
-    /// Net value flowing to each script that is not ours, negative where a foreign party
-    /// spends into this transaction.
-    ///
-    /// Distinct from [`Self::foreign_recipients`], which reports what an output pays
-    /// regardless of what its owner also spends.
-    pub fn foreign_net_values(&self) -> BTreeMap<ScriptBuf, i64> {
-        let mut net: BTreeMap<ScriptBuf, i64> = Default::default();
-
-        for input in &self.inputs {
-            if let SpkOwner::Foreign(spk) = &input.owner {
-                *net.entry(spk.clone()).or_default() -=
-                    i64::try_from(input.value).expect("value ridiculously large");
-            }
-        }
-
-        for output in &self.outputs {
-            if let SpkOwner::Foreign(spk) = &output.owner {
-                *net.entry(spk.clone()).or_default() +=
-                    i64::try_from(output.value).expect("value ridiculously large");
-            }
-        }
-
-        net
-    }
-
     pub fn foreign_recipients(&self) -> impl Iterator<Item = (&Script, u64)> {
         self.outputs
             .iter()
@@ -539,8 +514,7 @@ impl TransactionTemplate<ScopedTo> {
                     }
                 };
                 Some(PromptRecipient {
-                    address: bitcoin::Address::from_script(&output.owner.spk(), network)
-                        .expect("has address representation"),
+                    destination: PromptDestination::of(&output.owner.spk(), network),
                     amount: bitcoin::Amount::from_sat(output.value),
                     owned,
                 })
@@ -555,12 +529,31 @@ impl TransactionTemplate<ScopedTo> {
     }
 }
 
+/// Where an output pays, as far as the signer can be shown it.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PromptDestination {
+    Address(bitcoin::Address),
+    /// A script with no address rendering: an OP_RETURN data carrier, a bare multisig, a
+    /// future segwit version. Says nothing about whether it can be spent — only that we
+    /// cannot show it as an address, and a signing screen must not claim more than it knows.
+    UnrecognizedScript(ScriptBuf),
+}
+
+impl PromptDestination {
+    fn of(spk: &Script, network: bitcoin::Network) -> Self {
+        match bitcoin::Address::from_script(spk, network) {
+            Ok(address) => PromptDestination::Address(address),
+            Err(_) => PromptDestination::UnrecognizedScript(spk.into()),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct PromptRecipient {
-    pub address: bitcoin::Address,
+    pub destination: PromptDestination,
     pub amount: bitcoin::Amount,
-    /// `Some` iff the signing wallet itself derives [`address`](Self::address) at this
-    /// path — the prompt renders such a recipient as our own.
+    /// `Some` iff the signing wallet itself derives this output's script at that path — the
+    /// prompt renders such a recipient as our own.
     pub owned: Option<BitcoinBip32Path>,
 }
 

--- a/frostsnap_core/src/sign_task.rs
+++ b/frostsnap_core/src/sign_task.rs
@@ -257,8 +257,8 @@ impl std::error::Error for SignTaskError {}
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::bitcoin_transaction::PromptRecipient;
     use crate::bitcoin_transaction::{LocalSpk, TransactionTemplate};
+    use crate::bitcoin_transaction::{PromptDestination, PromptRecipient};
     use crate::tweak::{BitcoinBip32Path, NormalIndex};
     use bitcoin::{Amount, Network, ScriptBuf, TxOut};
     use schnorr_fun::fun::prelude::*;
@@ -326,13 +326,116 @@ mod test {
         assert_eq!(
             prompt.recipients,
             vec![PromptRecipient {
-                address: their_address,
+                destination: PromptDestination::Address(their_address),
                 amount: Amount::from_sat(90_000),
                 owned: None,
             }],
             "their output is disclosed at their address, and not as ours"
         );
         assert_eq!(prompt.fee, Amount::from_sat(10_000));
+    }
+
+    /// An OP_RETURN output is legal and a PSBT can carry one. `Address::from_script` has no
+    /// rendering for it, so building the prompt used to panic — on the device.
+    #[test]
+    fn an_output_with_no_address_form_is_shown_rather_than_fatal() {
+        let signing = signing_key();
+
+        let mut tx_template = TransactionTemplate::new();
+        tx_template.push_imaginary_owned_input(
+            LocalSpk {
+                master_appkey: signing,
+                bip32_path: BitcoinBip32Path::external(NormalIndex::ZERO),
+            },
+            Amount::from_sat(100_000),
+        );
+        let op_return = ScriptBuf::from_bytes(vec![0x6a, 0x04, 0xde, 0xad, 0xbe, 0xef]);
+        tx_template.push_foreign_output(TxOut {
+            value: Amount::from_sat(0),
+            script_pubkey: op_return.clone(),
+        });
+        tx_template.push_foreign_output(TxOut {
+            value: Amount::from_sat(90_000),
+            script_pubkey: ScriptBuf::from_bytes([&[0x51u8, 0x20][..], &[0xcc; 32][..]].concat()),
+        });
+
+        let checked = WireSignTask::BitcoinTransaction(tx_template)
+            .check(signing, KeyPurpose::Bitcoin(Network::Bitcoin))
+            .expect("an unaddressable output is not grounds for refusing to sign");
+
+        let SignTask::BitcoinTransaction { tx_template, .. } = &checked.inner else {
+            panic!("expected a bitcoin task")
+        };
+
+        let prompt = tx_template.user_prompt(Network::Bitcoin);
+
+        assert_eq!(
+            prompt.recipients.len(),
+            2,
+            "both outputs are disclosed: one the signer cannot see is worse than an awkward one"
+        );
+        assert!(
+            matches!(
+                &prompt.recipients[0].destination,
+                PromptDestination::UnrecognizedScript(spk) if *spk == op_return
+            ),
+            "the script we cannot render is carried, not dropped"
+        );
+        assert!(
+            matches!(
+                &prompt.recipients[1].destination,
+                PromptDestination::Address(_)
+            ),
+            "the payment still renders as an address"
+        );
+    }
+
+    /// The case that keeps the variant honest. A bare multisig has no address form either, but
+    /// it is perfectly spendable — so `UnrecognizedScript` must mean "we cannot render this",
+    /// never "nobody can spend this".
+    #[test]
+    fn a_spendable_script_with_no_address_form_is_also_unrecognized() {
+        let signing = signing_key();
+
+        let mut bare = alloc::vec![0x51u8, 0x21];
+        bare.extend_from_slice(&[0x02; 33]);
+        bare.extend_from_slice(&[0x51, 0xae]);
+        let bare_multisig = ScriptBuf::from_bytes(bare);
+        assert!(
+            !bare_multisig.is_op_return(),
+            "this output is spendable, which is the whole point of the case"
+        );
+
+        let mut tx_template = TransactionTemplate::new();
+        tx_template.push_imaginary_owned_input(
+            LocalSpk {
+                master_appkey: signing,
+                bip32_path: BitcoinBip32Path::external(NormalIndex::ZERO),
+            },
+            Amount::from_sat(100_000),
+        );
+        tx_template.push_foreign_output(TxOut {
+            value: Amount::from_sat(90_000),
+            script_pubkey: bare_multisig.clone(),
+        });
+
+        let checked = WireSignTask::BitcoinTransaction(tx_template)
+            .check(signing, KeyPurpose::Bitcoin(Network::Bitcoin))
+            .expect("a script we cannot render is not grounds for refusing to sign");
+
+        let SignTask::BitcoinTransaction { tx_template, .. } = &checked.inner else {
+            panic!("expected a bitcoin task")
+        };
+
+        assert_eq!(
+            tx_template.user_prompt(Network::Bitcoin).recipients,
+            alloc::vec![PromptRecipient {
+                destination: PromptDestination::UnrecognizedScript(bare_multisig),
+                amount: Amount::from_sat(90_000),
+                owned: None,
+            }],
+            "carried as a script we cannot show, with its real amount"
+        );
     }
 
     /// An input under another key is one we cannot sign, so it must not be counted as ours —

--- a/frostsnap_core/tests/signature_mapping.rs
+++ b/frostsnap_core/tests/signature_mapping.rs
@@ -10,7 +10,6 @@ use frostsnap_core::{
     tweak::{BitcoinBip32Path, NormalIndex},
     MasterAppkey,
 };
-use std::collections::BTreeMap;
 
 fn idx(n: u32) -> NormalIndex {
     NormalIndex::new(n).expect("test index is in range")
@@ -410,10 +409,13 @@ fn another_keys_scripts_become_foreign() {
         -100_000,
         "our balance moves by our own input alone; their side is not ours to count"
     );
+    // Both surfaces read `foreign_recipients` now — the device through `user_prompt`, the app
+    // through `effect`. This used to record them disagreeing, 150_000 gross against 50_000
+    // net, which meant one address showed a different number on each screen.
     assert_eq!(
-        mine.foreign_net_values(),
-        BTreeMap::from([(their_spk.spk(), 50_000)]),
-        "netted against what they spend, where foreign_recipients reports the gross 150_000"
+        mine.foreign_recipients().collect::<Vec<_>>(),
+        vec![(their_spk.spk().as_script(), 150_000)],
+        "the output's own value, which is what both screens now show"
     );
 
     // The other direction is the same story with the keys swapped.
@@ -427,11 +429,6 @@ fn another_keys_scripts_become_foreign() {
     );
     assert_eq!(theirs.foreign_recipients().count(), 0);
     assert_eq!(theirs.our_net_value(), 50_000);
-    assert_eq!(
-        theirs.foreign_net_values(),
-        BTreeMap::from([(our_spk.spk(), -100_000)]),
-        "we are the foreign party from their side, and we only spend"
-    );
 
     // Nothing was mutated: the original still knows who owns what. It cannot be *asked*
     // whose they are without naming a key, which is the point, so read the owners directly.

--- a/frostsnap_widgets/src/demo_widget.rs
+++ b/frostsnap_widgets/src/demo_widget.rs
@@ -465,8 +465,9 @@ macro_rules! demo_widget {
                     .unwrap()
                     .assume_checked();
 
+                use frostsnap_core::bitcoin_transaction::PromptDestination;
                 let recipient = |address: bitcoin::Address, sats: u64| PromptRecipient {
-                    address,
+                    destination: PromptDestination::Address(address),
                     amount: bitcoin::Amount::from_sat(sats),
                     owned: None,
                 };
@@ -480,7 +481,7 @@ macro_rules! demo_widget {
                         // Taproot: an output the wallet derives is always taproot, so a
                         // non-taproot "to self" is a state the device can never be shown.
                         PromptRecipient {
-                            address: p2tr_address,
+                            destination: PromptDestination::Address(p2tr_address),
                             amount: bitcoin::Amount::from_sat(150_000),
                             owned: Some(frostsnap_core::tweak::BitcoinBip32Path::internal(
                                 frostsnap_core::tweak::NormalIndex::new(3).unwrap(),

--- a/frostsnap_widgets/src/sign_prompt.rs
+++ b/frostsnap_widgets/src/sign_prompt.rs
@@ -14,7 +14,10 @@ use embedded_graphics::{
     geometry::Size,
     pixelcolor::{Gray8, Rgb565},
 };
-use frostsnap_core::{bitcoin_transaction::PromptSignBitcoinTx, tweak::BitcoinBip32Path};
+use frostsnap_core::{
+    bitcoin_transaction::{PromptDestination, PromptSignBitcoinTx},
+    tweak::BitcoinBip32Path,
+};
 use frostsnap_fonts::{
     Gray4Font, NOTO_SANS_17_REGULAR, NOTO_SANS_18_LIGHT, NOTO_SANS_18_MEDIUM, NOTO_SANS_24_BOLD,
 };
@@ -141,6 +144,40 @@ impl AddressPage {
 
         Self {
             center: Center::new(padded),
+        }
+    }
+}
+
+/// Shown for an output whose script has no address rendering.
+///
+/// It says only that, deliberately: such a script may well be spendable, and the one screen a
+/// user is meant to trust must not claim otherwise. The bytes are not drawn either —
+/// `AddressDisplay` earns trust by being checkable against another source, and arbitrary script
+/// hex cannot be, so showing it would borrow credibility it has not earned. The amount page
+/// beside this one carries the fact that matters.
+#[derive(Clone, frostsnap_macros::Widget)]
+pub struct UnrecognizedScriptPage {
+    #[widget_delegate]
+    center: Center<Column<(Text<Gray4TextStyle>, Text<Gray4TextStyle>)>>,
+}
+
+impl UnrecognizedScriptPage {
+    #[inline(never)]
+    pub fn new(index: usize) -> Self {
+        let title = Text::new(
+            format!("To Address #{}", index + 1),
+            Gray4TextStyle::new(FONT_PAGE_HEADER, PALETTE.text_secondary),
+        );
+        let body = Text::new(
+            "Unrecognized script".to_string(),
+            Gray4TextStyle::new(FONT_PAGE_HEADER, PALETTE.on_background),
+        );
+        let mut column = Column::new((title, body))
+            .with_main_axis_alignment(MainAxisAlignment::Center)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center);
+        column.set_uniform_gap(10);
+        Self {
+            center: Center::new(column),
         }
     }
 }
@@ -329,6 +366,7 @@ impl ConfirmationPage {
 type SignPromptPage = AnyOf<(
     AmountPage,
     AddressPage,
+    UnrecognizedScriptPage,
     FeePage,
     WarningPage,
     ConfirmationPage,
@@ -398,15 +436,21 @@ impl WidgetList for SignPromptPageList {
                     false,
                 )
             } else {
-                (
-                    SignPromptPage::new(AddressPage::new_with_seed(
-                        recipient_idx,
-                        &recipient.address,
-                        self.rand_seed,
-                        recipient.owned.as_ref(),
-                    )),
-                    true,
-                )
+                match &recipient.destination {
+                    PromptDestination::Address(address) => (
+                        SignPromptPage::new(AddressPage::new_with_seed(
+                            recipient_idx,
+                            address,
+                            self.rand_seed,
+                            recipient.owned.as_ref(),
+                        )),
+                        true,
+                    ),
+                    PromptDestination::UnrecognizedScript(_) => (
+                        SignPromptPage::new(UnrecognizedScriptPage::new(recipient_idx)),
+                        true,
+                    ),
+                }
             }
         } else if Some(index) == warning_page {
             (
@@ -491,5 +535,63 @@ impl SignTxPrompt {
             }
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::WidgetList;
+    use core::str::FromStr;
+    use frostsnap_core::bitcoin_transaction::PromptRecipient;
+
+    fn address() -> bitcoin::Address {
+        bitcoin::Address::from_str("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+            .unwrap()
+            .assume_checked()
+    }
+
+    fn prompt_of(destinations: alloc::vec::Vec<PromptDestination>) -> PromptSignBitcoinTx {
+        PromptSignBitcoinTx {
+            recipients: destinations
+                .into_iter()
+                .map(|destination| PromptRecipient {
+                    destination,
+                    amount: bitcoin::Amount::from_sat(10_000),
+                    owned: None,
+                })
+                .collect(),
+            fee: bitcoin::Amount::from_sat(100),
+            fee_rate_sats_per_vbyte: Some(1.0),
+        }
+    }
+
+    /// An output the signer never sees is the one outcome worse than an awkwardly rendered
+    /// one, so a script we cannot show must still take its place in the sequence.
+    #[test]
+    fn an_unrenderable_output_takes_up_the_same_pages_as_a_renderable_one() {
+        let data_carrier =
+            bitcoin::ScriptBuf::from_bytes(alloc::vec![0x6a, 0x04, 0xde, 0xad, 0xbe, 0xef]);
+
+        let all_addressable = SignPromptPageList::new_with_seed(
+            prompt_of(alloc::vec![
+                PromptDestination::Address(address()),
+                PromptDestination::Address(address()),
+            ]),
+            0,
+        );
+        let one_unrenderable = SignPromptPageList::new_with_seed(
+            prompt_of(alloc::vec![
+                PromptDestination::Address(address()),
+                PromptDestination::UnrecognizedScript(data_carrier),
+            ]),
+            0,
+        );
+
+        assert_eq!(all_addressable.len(), one_unrenderable.len());
+        assert!(
+            one_unrenderable.get(3).is_some(),
+            "the second output still has its destination page"
+        );
     }
 }

--- a/frostsnapp/lib/psbt.dart
+++ b/frostsnapp/lib/psbt.dart
@@ -389,19 +389,23 @@ class _AnimatedQrState extends State<AnimatedQr> {
 
 class EffectTable extends StatelessWidget {
   final EffectOfTx effect;
-  const EffectTable({super.key, required this.effect});
+  final BitcoinNetwork network;
+  const EffectTable({super.key, required this.effect, required this.network});
 
   @override
   Widget build(BuildContext context) {
-    List<TableRow> transactionRows = effect.foreignReceivingAddresses.map((
-      entry,
-    ) {
-      final (address, value) = entry;
+    List<TableRow> transactionRows = effect.foreignOutputs.map((output) {
+      final address = output.address(network: network)?.toString();
+      final value = output.amount;
       return TableRow(
         children: [
           Padding(
             padding: const EdgeInsets.all(8.0),
-            child: Text('Send to $address'),
+            child: Text(
+              address == null
+                  ? 'Send to an unrecognized script'
+                  : 'Send to $address',
+            ),
           ),
           Padding(
             padding: const EdgeInsets.all(8.0),
@@ -447,31 +451,40 @@ class EffectTable extends StatelessWidget {
     );
 
     final effectWidget = Column(
-      children: [describeEffect(context, effect), Divider(), effectTable],
+      children: [
+        describeEffect(context, effect, network),
+        Divider(),
+        effectTable,
+      ],
     );
 
     return effectWidget;
   }
 }
 
-Widget describeEffect(BuildContext context, EffectOfTx effect) {
+Widget describeEffect(
+  BuildContext context,
+  EffectOfTx effect,
+  BitcoinNetwork network,
+) {
   final style = DefaultTextStyle.of(
     context,
   ).style.copyWith(fontWeight: FontWeight.w600);
   final Widget description;
 
-  if (effect.foreignReceivingAddresses.length == 1) {
-    final (dest, amount) = effect.foreignReceivingAddresses[0];
+  if (effect.foreignOutputs.length == 1) {
+    final output = effect.foreignOutputs[0];
+    final dest = output.address(network: network)?.toString();
     description = Wrap(
       direction: Axis.horizontal,
       children: <Widget>[
         Text('Sending '),
-        SatoshiText(value: amount, style: style),
+        SatoshiText(value: output.amount, style: style),
         Text(' to '),
-        Text(dest, style: style),
+        Text(dest ?? 'an unrecognized script', style: style),
       ],
     );
-  } else if (effect.foreignReceivingAddresses.isEmpty) {
+  } else if (effect.foreignOutputs.isEmpty) {
     description = Text("Internal transfer");
   } else {
     description = Text("cannot describe this yet");
@@ -490,8 +503,11 @@ Future<bool> showBroadcastConfirmDialog(
     context: context,
     barrierDismissible: false,
     builder: (dialogContext) {
-      final effect = tx.effect(network: superWallet.network);
-      final effectWidget = EffectTable(effect: effect);
+      final effect = tx.effect();
+      final effectWidget = EffectTable(
+        effect: effect,
+        network: superWallet.network,
+      );
       return AlertDialog(
         title: Text("Broadcast?"),
         content: SizedBox(

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -567,6 +567,7 @@ pub fn txid_hex_string(txid: &Txid) -> String {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::api::signing::UnsignedTx;
     use bitcoin::{hashes::Hash, Amount, OutPoint, ScriptBuf, TxOut, Txid};
     use frostsnap_core::{
         bitcoin_transaction::{LocalSpk, PushInput},
@@ -595,7 +596,80 @@ mod test {
         }
     }
 
-    /// Input 0 is foreign, input 1 is ours.
+    /// Ours in, two payments to the SAME foreign address, then an OP_RETURN — three things
+    /// the old `Vec<(String, u64)>` could not represent: a key it shared, a script with no
+    /// address form, and a value it had to pre-render.
+    fn template_with_a_duplicate_payee_and_a_data_output() -> TransactionTemplate {
+        let key = key();
+        let path = BitcoinBip32Path::external(idx(0));
+        let owner = LocalSpk {
+            master_appkey: key,
+            bip32_path: path,
+        };
+        let mut template = TransactionTemplate::new();
+        let ours = TxOut {
+            value: Amount::from_sat(300_000),
+            script_pubkey: owner.spk(),
+        };
+        template
+            .push_owned_input(PushInput::spend_outpoint(&ours, outpoint(0)), owner)
+            .unwrap();
+
+        let payee = ScriptBuf::from_bytes([&[0x51u8, 0x20][..], &[0xdd; 32][..]].concat());
+        template.push_foreign_output(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: payee.clone(),
+        });
+        template.push_foreign_output(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: payee,
+        });
+        template.push_foreign_output(TxOut {
+            value: Amount::from_sat(0),
+            script_pubkey: ScriptBuf::from_bytes(vec![0x6a, 0x04, 0xde, 0xad, 0xbe, 0xef]),
+        });
+        template
+    }
+
+    /// The app half of the panic: `effect` unwrapped an address for every foreign output, so a
+    /// data output crashed the review screen.
+    #[test]
+    fn effect_reports_a_data_output_instead_of_panicking_on_it() {
+        let unsigned = UnsignedTx::new(template_with_a_duplicate_payee_and_a_data_output(), key())
+            .expect("the template spends an input of ours");
+        let effect = unsigned.effect().unwrap();
+        let data_output = effect.foreign_outputs.last().unwrap();
+
+        assert!(
+            data_output.address(BitcoinNetwork::Bitcoin).is_none(),
+            "no address form, reported as absent rather than unwrapped"
+        );
+        assert_eq!(data_output.amount, 0);
+    }
+
+    /// Keyed by script, two payments to one address became one row and the review screen
+    /// understated what was leaving.
+    #[test]
+    fn two_payments_to_one_address_stay_two_rows() {
+        let unsigned = UnsignedTx::new(template_with_a_duplicate_payee_and_a_data_output(), key())
+            .expect("the template spends an input of ours");
+        let effect = unsigned.effect().unwrap();
+
+        assert_eq!(effect.foreign_outputs.len(), 3);
+        assert_eq!(
+            effect.foreign_outputs[0].script_pubkey, effect.foreign_outputs[1].script_pubkey,
+            "same payee"
+        );
+        assert_eq!(
+            (
+                effect.foreign_outputs[0].amount,
+                effect.foreign_outputs[1].amount
+            ),
+            (100_000, 50_000),
+            "both amounts survive, where merging showed one row of 150_000"
+        );
+    }
+
     /// One input, ours — so the signed size is fully knowable and the rate is `Some`.
     fn single_owned_input_template() -> TransactionTemplate {
         let key = key();

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -1,6 +1,6 @@
 use super::super_wallet::SuperWallet;
 use super::{
-    bitcoin::{BitcoinNetwork, Psbt, RTransaction, Transaction},
+    bitcoin::{Psbt, RTransaction, Transaction, TxOutInfo},
     coordinator::Coordinator,
 };
 use crate::{frb_generated::StreamSink, sink_wrap::SinkWrap};
@@ -195,32 +195,26 @@ impl UnsignedTx {
     /// Takes no key: which key this is about is a property of the transaction, not of the
     /// question, and a parameter would let a caller ask about one it is not for.
     #[frb(sync)]
-    pub fn effect(&self, network: BitcoinNetwork) -> Result<EffectOfTx> {
+    /// Takes no network: an address is a rendering, and rendering belongs to whoever displays.
+    pub fn effect(&self) -> Result<EffectOfTx> {
         let scoped = self.scoped();
         let fee = self
             .template_tx
             .fee()
             .ok_or(anyhow!("invalid transaction"))?;
 
-        let foreign_receiving_addresses = scoped
-            .foreign_net_values()
+        let foreign_outputs = self
+            .details()
+            .recipients()
             .into_iter()
-            .filter(|(_, value)| *value > 0)
-            .map(|(spk, value)| {
-                (
-                    bitcoin::Address::from_script(spk.as_script(), network)
-                        .expect("will have address form")
-                        .to_string(),
-                    value as u64,
-                )
-            })
+            .filter(|output| !output.is_mine)
             .collect();
 
         Ok(EffectOfTx {
             net_value: scoped.our_net_value(),
             fee,
             feerate: scoped.feerate(),
-            foreign_receiving_addresses,
+            foreign_outputs,
         })
     }
 }
@@ -238,8 +232,8 @@ impl SignedTx {
     }
 
     #[frb(sync)]
-    pub fn effect(&self, network: BitcoinNetwork) -> Result<EffectOfTx> {
-        self.unsigned_tx.effect(network)
+    pub fn effect(&self) -> Result<EffectOfTx> {
+        self.unsigned_tx.effect()
     }
 }
 
@@ -499,5 +493,8 @@ pub struct EffectOfTx {
     pub net_value: i64,
     pub fee: u64,
     pub feerate: Option<f64>,
-    pub foreign_receiving_addresses: Vec<(String, u64)>,
+    /// One entry per output that is not ours, gross. `TxOutInfo::address` already answers
+    /// `Option`, so a script with no address form is a row the caller renders rather than a
+    /// panic — and one entry per output means two payments to one address stay two rows.
+    pub foreign_outputs: Vec<TxOutInfo>,
 }


### PR DESCRIPTION
`user_prompt` unwrapped `Address::from_script` for every disclosed output. An
OP_RETURN has no address rendering, `from_psbt` records anything it does not
recognise as foreign, and `WireSignTask::check` validates only the paths of
outputs claimed as ours — so a PSBT carrying a data output reached the signing
prompt and panicked the device.

`PromptRecipient` carries a `PromptDestination` now, either an `Address` or an
`UnrecognizedScript` holding the script. The variant is named for what is known:
`from_script` failing means rust-bitcoin has no address form, not that nobody can
spend the output — a bare multisig fails it and is spendable — and the one screen
a user is meant to trust must not claim more than it knows. There is a test using
exactly that script, asserting `!is_op_return`, so the name cannot drift back.

The device gets a page for it, so an output it cannot render still takes its place
in the sequence and the page arithmetic is unchanged; an output the signer never
sees would be the one outcome worse than an awkward one. The script's bytes are
not drawn — `AddressDisplay` earns trust by being checkable against another
source, and arbitrary hex cannot be.

`EffectOfTx.foreign_receiving_addresses` was the same defect on the app side and
three more besides: addresses pre-rendered to `String`, keyed by script so two
payments to one address merged into one row, netted and filtered to `> 0` so a
party who netted zero vanished. It is `foreign_outputs: Vec<TxOutInfo>` now, built
from `Transaction::recipients()` — not a new type, the one the neighbouring view
already used, whose `address(network)` answers `Option`. All four defects went at
once because each was a consequence of keeping a second model rather than a
separate mistake. `foreign_net_values` lost its only caller and is deleted, and
`effect` stopped taking a network: an address is a rendering, and rendering
belongs to whoever displays.

That closes the device/app divergence rather than documenting it. The assertion in
`another_keys_scripts_become_foreign` that pinned the two surfaces disagreeing
about one address — 150_000 gross against 50_000 net — now pins them agreeing.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>