### PR TITLE
Say why a PSBT wouldn't parse

### DIFF
--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -580,6 +580,12 @@ impl Psbt {
     pub fn deserialize(bytes: &[u8]) -> Result<Psbt, PsbtError> {}
 }
 
+#[frb(external)]
+impl PsbtError {
+    #[frb(sync)]
+    pub fn to_string(&self) -> String {}
+}
+
 #[frb(sync)]
 pub fn compute_txid_of_psbt(psbt: &Psbt) -> Txid {
     psbt.unsigned_tx.compute_txid()


### PR DESCRIPTION
`PsbtValidationError` already has a `to_string` mirror, so a PSBT that fails to parse at all surfaces as "Instance of 'PsbtErrorImpl'" instead.