### PR TITLE
Don't add TOFU certs to the PKI root store

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/tofu/connection.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/connection.rs
@@ -172,8 +172,12 @@ async fn connect_with_tofu(
     host: &str,
     trusted_certificates: &mut Persisted<TrustedCertificates>,
 ) -> Result<TlsStream<TcpStream>, TofuError> {
-    // Create combined certificate store with PKI roots and TOFU certs
-    let root_store = trusted_certificates.create_combined_cert_store();
+    // webpki roots only. TOFU certs must never go in here: webpki treats every root as an
+    // unconstrained CA regardless of its basicConstraints, so a TOFU'd leaf would let whoever
+    // holds its key mint a cert for any other host. TOFU trust is per-host exact match in
+    // `TofuCertVerifier`, which runs before this verifier is ever consulted.
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let base_verifier = WebPkiServerVerifier::builder(Arc::new(root_store))
         .build()
         .map_err(|e| TofuError::Other(anyhow!("Failed to create verifier: {:?}", e)))?;

--- a/frostsnap_coordinator/src/bitcoin/tofu/trusted_certs.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/trusted_certs.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use bdk_chain::{bitcoin, rusqlite_impl::migrate_schema};
 use rusqlite::params;
-use rustls::RootCertStore;
 use rustls_pki_types::CertificateDer;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -102,25 +101,6 @@ impl TrustedCertificates {
             },
             mutations,
         );
-    }
-
-    pub fn create_combined_cert_store(&self) -> RootCertStore {
-        // Start with standard PKI certificates from webpki-roots
-        let mut store = RootCertStore::empty();
-        store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-
-        // Add user-trusted certificates
-        for (server_url, trusted_cert) in &self.certificates {
-            if let Err(e) = store.add(trusted_cert.certificate.clone()) {
-                tracing::warn!(
-                    "Failed to add trusted certificate for {}: {:?}",
-                    server_url,
-                    e
-                );
-            }
-        }
-
-        store
     }
 
     /// Find a certificate by its SHA256 fingerprint (raw hex, no colons)

--- a/frostsnap_coordinator/src/bitcoin/tofu/verifier.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/verifier.rs
@@ -89,7 +89,8 @@ impl From<anyhow::Error> for TofuError {
 ///    - Most real-world attacks would produce certificates that fail validation entirely
 ///
 /// 4. **What We DO Guarantee**:
-///    - Certificates are properly scoped to specific servers (no certificate confusion)
+///    - Certificates are properly scoped to specific servers (no certificate confusion). This
+///      relies on TOFU certs never entering the PKI root store — see `connect_with_tofu`.
 ///    - Once trusted, we detect any changes to the certificate
 ///    - We don't capture certificates with structural problems
 pub struct TofuCertVerifier {
@@ -413,8 +414,9 @@ mod tests {
 
     #[test]
     fn test_certificate_confusion_attack_prevention() {
-        // This test should FAIL if the vulnerability exists
-        // A certificate accepted for one server should NOT be accepted for a different server
+        // A certificate accepted for one server should NOT be accepted for a different server.
+        // Only covers byte-for-byte reuse: TEST_CERT1 has no SAN for "bank.com" so it fails name
+        // checking anyway, which is why this can't detect PKI root store leakage on its own.
 
         let mut trusted_certs =
             TrustedCertificates::new_for_test(bdk_chain::bitcoin::Network::Bitcoin);


### PR DESCRIPTION
`create_combined_cert_store` put every TOFU-trusted certificate into the base verifier's `RootCertStore`, where webpki treats it as an unconstrained CA -- basicConstraints and keyUsage are never checked on an anchor. A leaf trusted for one host could then mint a certificate for any other host, with no TOFU prompt.

Nothing is lost: `verify_server_cert` matches stored certs byte-for-byte and returns before the base verifier runs, so the root store only ever applied to hosts with no TOFU entry.