### PR TITLE
Fix master's two clippy failures from the 1.98 lint bump

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/handler_state.rs
+++ b/frostsnap_coordinator/src/bitcoin/handler_state.rs
@@ -238,7 +238,7 @@ impl HandlerState {
                             request.url,
                             cert.fingerprint
                         );
-                        let _ = response.send(Ok(ConnectionResult::CertificatePromptNeeded(cert)));
+                        let _ = response.send(Ok(ConnectionResult::CertificatePromptNeeded(*cert)));
                     }
                     Err(TofuError::Other(e)) => {
                         tracing::error!("Failed to connect to {}: {}", request.url, e);

--- a/frostsnap_coordinator/src/bitcoin/tofu/verifier.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/verifier.rs
@@ -35,8 +35,9 @@ pub struct UntrustedCertificate {
 /// Custom error type that includes certificate data for TOFU prompts
 #[derive(Debug)]
 pub enum TofuError {
-    /// Certificate not trusted - needs user approval
-    NotTrusted(UntrustedCertificate),
+    /// Certificate not trusted - needs user approval. Boxed because the certificate carries a DER
+    /// blob, and an `Err` this large is paid for on every `Ok` return of every function in the chain.
+    NotTrusted(Box<UntrustedCertificate>),
     /// Other connection error
     Other(anyhow::Error),
 }
@@ -163,7 +164,7 @@ impl ServerCertVerifier for TofuCertVerifier {
                     valid_for_names: None,
                 };
 
-                let tofu_error = TofuError::NotTrusted(untrusted_cert);
+                let tofu_error = TofuError::NotTrusted(Box::new(untrusted_cert));
                 self.tofu_errors
                     .lock()
                     .unwrap()
@@ -236,7 +237,7 @@ impl ServerCertVerifier for TofuCertVerifier {
                         valid_for_names,
                     };
 
-                    let tofu_error = TofuError::NotTrusted(untrusted_cert);
+                    let tofu_error = TofuError::NotTrusted(Box::new(untrusted_cert));
                     self.tofu_errors
                         .lock()
                         .unwrap()

--- a/frostsnap_widgets/src/vec_framebuffer.rs
+++ b/frostsnap_widgets/src/vec_framebuffer.rs
@@ -122,7 +122,7 @@ impl FramebufferColor for Rgb565 {
         let value = raw.into_inner();
         let byte0 = (value & 0xFF) as u8;
         let byte1 = ((value >> 8) & 0xFF) as u8;
-        for chunk in data.chunks_exact_mut(2) {
+        for chunk in data.as_chunks_mut::<2>().0 {
             chunk[0] = byte0;
             chunk[1] = byte1;
         }


### PR DESCRIPTION
`master` is red on two clippy lints that did not exist when the code was written. Neither
is a new mistake — a newer clippy meets `-D warnings`.

**`chunks_exact_to_as_chunks`** — `frostsnap_widgets/src/vec_framebuffer.rs:125`, in
`fill_data`, where the chunk size is the constant `2`. `as_chunks_mut::<2>().0` is the same
iteration with the length known to the type, which is the point of the lint. Fails
`lint-device`, so both firmware boards go red.

**`result_large_err`** — twice on the TOFU connection path.
`TofuError::NotTrusted` carries an `UntrustedCertificate` holding a DER blob, at least 128
bytes, and every `Ok` return in that chain pays for it. Boxed, which is clippy's suggestion
and the right shape here: the error is the rare branch and the certificate really is large.
One consuming site in `handler_state.rs` derefs it back. Fails `lint-ordinary`.

Both surfaced on #560's CI but neither file is in that PR's diff — they are `master`'s.