### PR TITLE
device: gate prefill-words behind --cfg, not a cargo feature

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -11,7 +11,6 @@ debug_fps = []
 debug_mem = []
 debug_log = []
 debug = [ "debug_fps", "debug_mem", "debug_log" ]
-prefill-words = []
 # turns on the esp32c3 hardware stack guard
 stack_guard = []
 # FIXME: remove this feature when v2.rs is deleted (only used in legacy factory code)
@@ -60,3 +59,7 @@ path = "src/bin/frontier.rs"
 
 [[bin]]
 name = "widget_dev"
+
+[lints.rust]
+# prefill_words is deliberately a --cfg, not a feature: see src/widget_tree.rs.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(prefill_words)'] }

--- a/device/src/widget_tree.rs
+++ b/device/src/widget_tree.rs
@@ -196,7 +196,11 @@ impl WidgetTree {
     #[inline(never)]
     pub(crate) fn build_entering_backup(phase: EnterBackupPhase) -> Self {
         let mut widget = Box::new(EnterShareScreen::new());
-        if cfg!(feature = "prefill-words") {
+        // A --cfg, NOT a cargo feature: this flips backup-entry behavior, and features are
+        // additive, so the justfile's `--all-features` runs armed it — every typist keystroke
+        // then landed on a self-filling screen. Enable for manual firmware testing with
+        // RUSTFLAGS='--cfg prefill_words'.
+        if cfg!(prefill_words) {
             widget.prefill_test_words();
         }
         Self::EnterBackup {

--- a/frostsnap_widgets/Cargo.toml
+++ b/frostsnap_widgets/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [features]
 default = ["std"]
-prefill-words = []
 std = []
 
 [dependencies]

--- a/frostsnap_widgets/src/demo_widget.rs
+++ b/frostsnap_widgets/src/demo_widget.rs
@@ -106,7 +106,9 @@ macro_rules! demo_widget {
                 }
 
                 let mut screen = $crate::backup::EnterShareScreen::new();
-                if cfg!(feature = "prefill-words") {
+                // A --cfg, NOT a cargo feature: features are additive, so `--all-features`
+                // armed self-fill during tests. Enable with RUSTFLAGS='--cfg prefill_words'.
+                if cfg!(prefill_words) {
                     screen.prefill_test_words();
                 }
                 let done = Center::new(Text::new(

--- a/tools/widget_simulator/Cargo.toml
+++ b/tools/widget_simulator/Cargo.toml
@@ -3,9 +3,6 @@ name = "widget_simulator"
 version = "0.1.0"
 edition = "2024"
 
-[features]
-prefill-words = []
-
 [dependencies]
 frostsnap_widgets = { workspace = true, features = ["std"] }
 frostsnap_core.workspace = true
@@ -14,3 +11,8 @@ embedded-graphics-simulator = "0.8.0"
 rand.workspace = true
 bitcoin.workspace = true
 frost_backup.workspace = true
+
+[lints.rust]
+# demo_widget! expands `cfg!(prefill_words)` here, so the check-cfg must be declared
+# in this crate rather than in frostsnap_widgets where the macro is defined.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(prefill_words)'] }


### PR DESCRIPTION
## What the flag does

`prefill_test_words()` auto-fills the device's backup-entry screen with a fixed set of test words. It is a manual-testing convenience for firmware work.

## Why a cargo feature is the wrong mechanism

It was gated on `cfg!(feature = "prefill-words")`. Cargo features are **additive** across a workspace, and the justfile runs:

```
cargo check  --all-features --tests --bins   # check-ordinary
cargo clippy --all-features --tests --bins   # lint-ordinary
cargo check  --target riscv32imc-unknown-none-elf -p frostsnap_device -p frostsnap_cst816s --all-features
```

plus `just test-ordinary --release --all-features` in CI. So `--all-features` silently armed self-fill — the flag turned itself on in exactly the runs that should have been neutral.

## Observed symptom

A test harness typing into the backup-entry screen had every keystroke land on a screen that was populating itself. That presents as a typist/timing bug rather than a build-configuration one. It is CI-only and resists a `-p <crate>` reproduction, because only the workspace-wide `--all-features` invocation triggers it.

## The fix

Convert the gate to a `--cfg`, which `--all-features` cannot reach, and drop the now-unused `prefill-words = []` declarations from `device`, `frostsnap_widgets`, and `tools/widget_simulator`.

Enable it deliberately with:

```
RUSTFLAGS='--cfg prefill_words' just build-firmware
```

## Note on the check-cfg placement

`unexpected_cfgs` is warn-by-default and the justfile lints with `-Dwarnings`, so the cfg name has to be declared or the fix would itself break CI. `demo_widget!` expands `cfg!(prefill_words)` into the *destination* crate, not into `frostsnap_widgets` where the macro is defined (rustc says so explicitly: "using a cfg inside a macro will use the cfgs from the destination crate"). The `check-cfg` therefore goes in each macro consumer — `device` (for the `widget_dev` bin) and `tools/widget_simulator` — and is not needed in `frostsnap_widgets`.

## Verification

All run locally with `RUSTUP_TOOLCHAIN=stable` to match CI's lint jobs:

- `cargo check --all-features --tests --bins` — pass
- `cargo clippy --all-features --tests --bins -- -Dwarnings` — pass
- `cargo check --target riscv32imc-unknown-none-elf -p frostsnap_device -p frostsnap_cst816s --all-features` — pass, no `unexpected_cfgs`
- `cargo clippy -p frostsnap_device -p frostsnap_cst816s --target riscv32imc-unknown-none-elf --all-features -- -Dwarnings` — pass
- `cargo fmt -- --check` and `cargo fmt -p frostsnap_device -p frostsnap_cst816s -- --check` — pass

The gate was confirmed live in both directions with a temporary `const _: () = assert!(cfg!(prefill_words));` at the device call site and at the `demo_widget!` expansion site: it fails to compile under `--all-features` alone (proving the feature no longer arms it) and compiles under `RUSTFLAGS='--cfg prefill_words'` (proving the flag still reaches both paths). The scaffolding was removed before commit.
