### PR TITLE
[psbt] `check_spk` and `Transaction::fee` cleanup

### DIFF
--- a/frostsnap_core/src/bitcoin_transaction.rs
+++ b/frostsnap_core/src/bitcoin_transaction.rs
@@ -220,19 +220,7 @@ impl TransactionTemplate<Unscoped> {
         owner: LocalSpk,
     ) -> Result<(), Box<SpkDoesntMatchPathError>> {
         let txout = input.prev_txout.txout();
-        let expected_spk = owner.spk();
-
-        if txout.script_pubkey != expected_spk {
-            return Err(Box::new(SpkDoesntMatchPathError {
-                got: txout.script_pubkey.clone(),
-                expected: expected_spk,
-                path: owner
-                    .bip32_path
-                    .path_segments_from_bitcoin_appkey()
-                    .collect(),
-                master_appkey: owner.master_appkey,
-            }));
-        }
+        owner.check_spk(&txout.script_pubkey)?;
 
         self.inputs.push(Input {
             outpoint: input.prev_txout.outpoint(),
@@ -279,19 +267,7 @@ impl TransactionTemplate<Unscoped> {
         txout: &TxOut,
         owner: LocalSpk,
     ) -> Result<(), Box<SpkDoesntMatchPathError>> {
-        let expected_spk = owner.spk();
-
-        if txout.script_pubkey != expected_spk {
-            return Err(Box::new(SpkDoesntMatchPathError {
-                got: txout.script_pubkey.clone(),
-                expected: expected_spk,
-                path: owner
-                    .bip32_path
-                    .path_segments_from_bitcoin_appkey()
-                    .collect(),
-                master_appkey: owner.master_appkey,
-            }));
-        }
+        owner.check_spk(&txout.script_pubkey)?;
 
         self.push_owned_output(txout.value, owner);
         Ok(())
@@ -694,6 +670,24 @@ pub struct LocalSpk {
 }
 
 impl LocalSpk {
+    /// Proves this owner derives `spk`, which is what separates a claim that is ours from one
+    /// that is merely made. A PSBT names a key and a path; only the script decides.
+    fn check_spk(&self, spk: &ScriptBuf) -> Result<(), Box<SpkDoesntMatchPathError>> {
+        let expected = self.spk();
+        if *spk != expected {
+            return Err(Box::new(SpkDoesntMatchPathError {
+                got: spk.clone(),
+                expected,
+                path: self
+                    .bip32_path
+                    .path_segments_from_bitcoin_appkey()
+                    .collect(),
+                master_appkey: self.master_appkey,
+            }));
+        }
+        Ok(())
+    }
+
     pub fn spk(&self) -> ScriptBuf {
         let expected_external_xonly =
             AppTweak::Bitcoin(self.bip32_path).derive_xonly_key(&self.master_appkey.to_xpub());

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -368,9 +368,7 @@ impl Transaction {
     /// Returns `None` if any input is missing a previous output.
     #[frb(sync, type_64bit_int)]
     pub fn fee(&self) -> Option<u64> {
-        let inputs_sum = self._sum_inputs(None)?;
-        let outputs_sum = self._sum_outputs(None);
-        Some(inputs_sum.saturating_sub(outputs_sum))
+        Self::fee_from(&self.prevouts, &self.inner)
     }
 
     #[frb(sync, type_64bit_int)]


### PR DESCRIPTION
`push_owned_input` and `push_owned_output_checked` carried the same code block. Thought it could be safer/more useful to pull out `check_spk`.

`Transaction::fee` and `fee_from` are the same subtraction over the same prevouts, in one impl. `fee_from` has to stay, being callable before there is a `Self`, so `fee` delegates to it.

