### PR TITLE
Tag a recipient we derive as our own output

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -603,8 +603,26 @@ impl CoordSuperWallet {
             );
         }
 
+        // A recipient this wallet derives is not money leaving, and the signer has to be able
+        // to see that: tag it owned so the prompt names it as ours instead of showing a
+        // self-payment as an ordinary send. Only the coordinator can answer this — the device is
+        // told which outputs are its own — but it is not trusted on it, because a `Local` output
+        // carries key and path rather than a script and the device derives the script itself.
+        // `push_owned_output_checked` re-derives here too, so a path that does not reproduce the
+        // planned script is caught before it reaches a signing session.
         for txo in &plan.recipients {
-            template.push_foreign_output(txo.clone());
+            match self.spk_path(plan.master_appkey, txo.script_pubkey.clone()) {
+                Some(bip32_path) => template
+                    .push_owned_output_checked(
+                        txo,
+                        LocalSpk {
+                            master_appkey: plan.master_appkey,
+                            bip32_path,
+                        },
+                    )
+                    .expect("spk_path resolved this path from this very script"),
+                None => template.push_foreign_output(txo.clone()),
+            }
         }
 
         Ok(template)
@@ -836,6 +854,96 @@ mod test {
                 )
                 .unwrap()
         }
+
+        /// Plan a payment to one of our own receive addresses, the way a user does it: read the
+        /// address off the receive screen, then paste it into send.
+        fn plan_to_own_address(&mut self, index: u32, sats: u64) -> SendPlan {
+            let own = bitcoin::Address::from_script(
+                &crate::bitcoin::peek_spk(
+                    self.master_appkey,
+                    BitcoinBip32Path {
+                        account_keychain: BitcoinAccountKeychain::external(),
+                        index: NormalIndex::new(index).expect("fixture index below 2^31"),
+                    },
+                ),
+                NETWORK,
+            )
+            .expect("a taproot spk has an address form");
+            self.wallet
+                .plan_send(self.master_appkey, [(own, Some(sats))], 1.0)
+                .unwrap()
+        }
+    }
+
+    /// Paying our own receive address is not money leaving, and the prompt the device shows is
+    /// built from what the coordinator tags. Tagging it foreign — which is all `commit_send` ever
+    /// did — renders a self-payment identically to paying a stranger on the one screen the user is
+    /// meant to check.
+    #[test]
+    fn a_recipient_we_derive_is_tagged_owned() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        let plan = f.plan_to_own_address(7, 200_000);
+        let template = f.wallet.commit_send(&plan, []).unwrap();
+
+        let paid = template
+            .outputs()
+            .iter()
+            .find(|output| output.value == 200_000)
+            .expect("the payment is in the template");
+        let owner = paid
+            .owner
+            .local_owner()
+            .expect("a script this wallet derives is ours, not foreign");
+        assert_eq!(owner.master_appkey, f.master_appkey);
+        assert_eq!(
+            owner.bip32_path,
+            BitcoinBip32Path {
+                account_keychain: BitcoinAccountKeychain::external(),
+                index: NormalIndex::new(7).unwrap(),
+            },
+        );
+    }
+
+    /// The tag has to survive into the prompt, since that is the whole point of setting it. A
+    /// self-payment has no foreign output, so `hide_single_change` stops applying and the change
+    /// is disclosed too — both outputs come back to us and the signer is shown both.
+    #[test]
+    fn the_prompt_names_a_self_payment_as_ours() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        let plan = f.plan_to_own_address(7, 200_000);
+        let template = f.wallet.commit_send(&plan, []).unwrap();
+        let prompt = template.as_seen_by(f.master_appkey).user_prompt(NETWORK);
+
+        assert!(
+            prompt.recipients.iter().all(|r| r.owned.is_some()),
+            "nothing in a self-payment leaves the wallet",
+        );
+        assert_eq!(prompt.foreign_value(), None, "no value is at foreign risk");
+    }
+
+    /// The other half of the same decision: an address we do not derive stays foreign. A tag that
+    /// said otherwise would tell the signer money is coming back when it is leaving.
+    #[test]
+    fn a_foreign_recipient_stays_foreign() {
+        let mut f = Fixture::new();
+        f.fund(0, 1_000_000, 100);
+
+        let plan = f.plan(200_000);
+        let template = f.wallet.commit_send(&plan, []).unwrap();
+
+        let paid = template
+            .outputs()
+            .iter()
+            .find(|output| output.value == 200_000)
+            .expect("the payment is in the template");
+        assert!(
+            paid.owner.local_owner().is_none(),
+            "a script we do not derive is not ours",
+        );
     }
 
     /// The feature, in the shape that produced it. 0.3 could pay change far past the frontier it


### PR DESCRIPTION
## The bug

Paying one of your own addresses is not money leaving the wallet, but `commit_send` tagged every recipient foreign regardless:

```rust
for txo in &plan.recipients {
    template.push_foreign_output(txo.clone());
}
```

So the device rendered a self-payment identically to paying a stranger. Grab a receive address off the receive screen, paste it into send, and the signing prompt shows an ordinary outgoing payment — no "To Self". The one screen a user is meant to trust is the one that couldn't tell the two apart.

Reported after hitting it on a signet wallet: the app's "To self" pill showed, the device said nothing.

## Why this reads as an omission

The rest of the feature was already built for this case and never reached it:

- `PromptRecipient` carries `owned`, and the prompt's disclosure rule reasons explicitly about *"any other local output — or more than one change output — is value returning to us that the signer must be shown"*. An owned **external** output is only ever produced by a self-payment — a branch the coordinator could not generate.
- `value_at_risk` already falls back to `value_moved()` when nothing is foreign, so the high-fee warning stays armed on a transaction with no foreign recipient.
- `owned_address_label` → `spk_path` asks exactly this question, and shipped in the same PR as the prompt — wired into the Flutter send screen, not into the template builder.
- The only non-test caller of `push_owned_output_checked` was `frostsnap_core/src/psbt.rs`. An imported PSBT paying us said "To Self"; a send built in the app did not.

## The fix

Resolve each recipient against the wallet's own scripts and tag the ones we derive.

The coordinator is the only party that can answer this — the device is *told* which outputs are its own — but it is not trusted on the answer. A `Local` output carries key and BIP32 path rather than a script, and the device derives the script itself (`LocalSpk::spk()`), so a tag can never name a script we don't own; the worst a lying coordinator could do is name a different address the user genuinely holds. `push_owned_output_checked` re-derives on this side too, rejecting a path that doesn't reproduce the planned script before it reaches a signing session.

**The resulting transaction is unchanged** — for a `Local` output the spk is derived rather than stored, and `check_spk` guarantees it equals the planned one.

## Consequence worth reviewing

A self-payment has no foreign output, so `hide_single_change` stops applying and the change output is disclosed alongside the payment. Both outputs return to us and the signer is shown both, which is what that rule asks for — but it does mean a fully-self send now shows two rows on the device rather than one.

## Tests

Three added to `bitcoin::send`, verified to fail without the fix (the foreign control passes either way):

- `a_recipient_we_derive_is_tagged_owned` — the template tags it `Local` at the right path
- `the_prompt_names_a_self_payment_as_ours` — the tag survives into `user_prompt`, and `foreign_value()` is `None`
- `a_foreign_recipient_stays_foreign` — control; an address we don't derive stays foreign

`cargo test -p frostsnap_coordinator` green, `cargo fmt` clean, no new clippy findings.

## Not included

The app's transaction *summary* has a related gap I hit while tracing this: `wallet_tx_details.dart` branches on `isSend` and shows only foreign outputs for sends, so a self-payment's details screen lists **no outputs at all**. Fixing it needs `TxOutInfo` to carry the keychain (`list_transactions` currently drops `account_keychain` when building `is_mine`), so it's an FFI change and a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)