### PR TITLE
Surface a signing session that failed to start

### DIFF
--- a/frostsnapp/lib/theme.dart
+++ b/frostsnapp/lib/theme.dart
@@ -16,6 +16,13 @@ const double iconSize = 20.0;
 /// M3 standard dialog constraints
 const dialogConstraints = BoxConstraints(minWidth: 280, maxWidth: 560);
 
+/// Converts bridge exceptions into text suitable for showing to a user.
+///
+/// Flutter Rust Bridge's [AnyhowException.toString] includes the Dart wrapper
+/// name. The underlying Rust error message is the useful part.
+String displayExceptionMessage(Object exception) =>
+    exception is AnyhowException ? exception.message : exception.toString();
+
 RoundedRectangleBorder cardShape(BuildContext context) =>
     RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(28)),
@@ -240,13 +247,7 @@ Future<void> showExceptionDialog(
       final colorScheme = theme.colorScheme;
       final scrollController = ScrollController();
 
-      // Extract error message based on exception type
-      final String errorMessage;
-      if (exception is AnyhowException) {
-        errorMessage = exception.message;
-      } else {
-        errorMessage = exception.toString();
-      }
+      final errorMessage = displayExceptionMessage(exception);
 
       return AlertDialog(
         constraints: const BoxConstraints(maxWidth: 560),

--- a/frostsnapp/lib/wallet_tx_details.dart
+++ b/frostsnapp/lib/wallet_tx_details.dart
@@ -367,6 +367,7 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
   late final StreamSubscription<TxState> txStateSub;
   StreamSubscription<DeviceListUpdate>? devicesSub;
   StreamSubscription<SigningState>? signingSub;
+  bool signingErrorHandled = false;
   SigningState? signingState;
   bool? broadcastDone;
   Set<DeviceId> connectedDevices = deviceIdSet([]);
@@ -498,6 +499,21 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
     Navigator.pop(context);
   }
 
+  // Reached from the synchronous catch and from the stream's onError; whichever
+  // comes first wins so the same failure isn't shown twice.
+  void _onSigningError(Object error) {
+    if (signingErrorHandled) return;
+    signingErrorHandled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      showErrorSnackbar(
+        context,
+        'Signing failed: ${displayExceptionMessage(error)}',
+      );
+      Navigator.popUntil(context, (r) => r.isFirst);
+    });
+  }
+
   @override
   void initState() {
     super.initState();
@@ -540,11 +556,7 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
             // puts the failure onto the stream instead. Without this the error
             // is an unhandled zone error and the screen sits on a session that
             // never began.
-            onError: (error) {
-              if (!mounted) return;
-              showErrorSnackbar(context, error.toString());
-              Navigator.popUntil(context, (r) => r.isFirst);
-            },
+            onError: _onSigningError,
           );
           signingSub = sub;
         case SigningFinished():
@@ -554,10 +566,7 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
           break;
       }
     } catch (e) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        showErrorSnackbar(context, e.toString());
-        Navigator.popUntil(context, (r) => r.isFirst);
-      });
+      _onSigningError(e);
     }
   }
 

--- a/frostsnapp/lib/wallet_tx_details.dart
+++ b/frostsnapp/lib/wallet_tx_details.dart
@@ -529,11 +529,23 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
           devicesSub = GlobalStreams.deviceListSubject.listen(onDeviceListData);
           broadcastDone = false;
           late final StreamSubscription<SigningState> sub;
-          sub = signingParams.startSigning().listen((state) {
-            // Ensure `onSigningSessionData` is called sequentially.
-            sub.pause();
-            onSigningSessionData(state).whenComplete(sub.resume);
-          });
+          sub = signingParams.startSigning().listen(
+            (state) {
+              // Ensure `onSigningSessionData` is called sequentially.
+              sub.pause();
+              onSigningSessionData(state).whenComplete(sub.resume);
+            },
+            // A session that failed to start arrives here rather than at the
+            // call: frb drops the `Result` of a stream-returning call, so rust
+            // puts the failure onto the stream instead. Without this the error
+            // is an unhandled zone error and the screen sits on a session that
+            // never began.
+            onError: (error) {
+              if (!mounted) return;
+              showErrorSnackbar(context, error.toString());
+              Navigator.popUntil(context, (r) => r.isFirst);
+            },
+          );
           signingSub = sub;
         case SigningFinished():
           // Signing is over; there is no stream to follow, only a transaction to send.

--- a/frostsnapp/rust/src/api/signing.rs
+++ b/frostsnapp/rust/src/api/signing.rs
@@ -3,7 +3,10 @@ use super::{
     bitcoin::{Psbt, RTransaction, Transaction, TxOutInfo},
     coordinator::Coordinator,
 };
-use crate::{frb_generated::StreamSink, sink_wrap::SinkWrap};
+use crate::{
+    frb_generated::StreamSink,
+    sink_wrap::{report_start_failure, SinkWrap},
+};
 use anyhow::{anyhow, Result};
 use flutter_rust_bridge::frb;
 pub use frostsnap_coordinator::signing::SigningState;
@@ -255,13 +258,14 @@ impl Coordinator {
         message: String,
         sink: StreamSink<SigningState>,
     ) -> Result<()> {
-        self.0.start_signing(
-            access_structure_ref,
-            devices.into_iter().collect(),
-            WireSignTask::Test { message },
-            SinkWrap(sink),
-        )?;
-        Ok(())
+        report_start_failure(sink, |sink| {
+            self.0.start_signing(
+                access_structure_ref,
+                devices.into_iter().collect(),
+                WireSignTask::Test { message },
+                sink,
+            )
+        })
     }
 
     /// Borrows rather than takes: frb disposes the Dart handle for a value it moves, and the
@@ -275,13 +279,14 @@ impl Coordinator {
         devices: Vec<DeviceId>,
         sink: StreamSink<SigningState>,
     ) -> Result<()> {
-        self.0.start_signing(
-            access_structure_ref,
-            devices.into_iter().collect(),
-            WireSignTask::BitcoinTransaction(unsigned_tx.template_tx.clone()),
-            SinkWrap(sink),
-        )?;
-        Ok(())
+        report_start_failure(sink, |sink| {
+            self.0.start_signing(
+                access_structure_ref,
+                devices.into_iter().collect(),
+                WireSignTask::BitcoinTransaction(unsigned_tx.template_tx.clone()),
+                sink,
+            )
+        })
     }
 
     #[frb(sync)]
@@ -294,8 +299,9 @@ impl Coordinator {
         session_id: SignSessionId,
         sink: StreamSink<SigningState>,
     ) -> Result<()> {
-        self.0
-            .try_restore_signing_session(session_id, SinkWrap(sink))
+        report_start_failure(sink, |sink| {
+            self.0.try_restore_signing_session(session_id, sink)
+        })
     }
 
     #[frb(sync)]

--- a/frostsnapp/rust/src/sink_wrap.rs
+++ b/frostsnapp/rust/src/sink_wrap.rs
@@ -25,19 +25,27 @@ pub struct SinkWrap<T>(pub StreamSink<T>);
 /// Dart port and clones for free, so the error path keeps one and the failure arrives where the
 /// screen is already listening.
 ///
-/// The error is encoded the way frb encodes one for an ordinary call, so Dart decodes it into the
-/// same `AnyhowException` it would have received had the `Result` reached it.
+/// Once the error is on the stream this returns `Ok(())`: the dropped `Result` would otherwise
+/// surface the same failure a second time as an unhandled zone error. Only a failure to deliver
+/// is returned.
 ///
 /// `T: Clone` is frb's, not ours: it derives `Clone` on a sink that holds `T` only in a
 /// `PhantomData`, and the derive asks for it anyway.
-pub fn report_start_failure<T: SseEncode + Clone, R>(
+pub fn report_start_failure<T: SseEncode + Clone>(
     sink: StreamSink<T>,
-    start: impl FnOnce(SinkWrap<T>) -> anyhow::Result<R>,
-) -> anyhow::Result<R> {
+    start: impl FnOnce(SinkWrap<T>) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
     let error_sink = sink.clone();
-    start(SinkWrap(sink)).inspect_err(|e| {
-        let _ = error_sink.add_error(format!("{e:?}"));
-    })
+    match start(SinkWrap(sink)) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let message = error.to_string();
+            error_sink.add_error(error).map_err(|send_error| {
+                anyhow::anyhow!("failed to deliver stream start error ({send_error}): {message}")
+            })?;
+            Ok(())
+        }
+    }
 }
 
 macro_rules! bridge_sink {

--- a/frostsnapp/rust/src/sink_wrap.rs
+++ b/frostsnapp/rust/src/sink_wrap.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{coordinator::KeyState, device_list::DeviceListUpdate},
-    frb_generated::StreamSink,
+    frb_generated::{SseEncode, StreamSink},
 };
 use frostsnap_coordinator::{
     // bitcoin::chain_sync::ChainStatus,
@@ -16,6 +16,29 @@ use frostsnap_coordinator::{
 // we need to wrap it so we can impl it on foreign FRB type. You can't do a single generic impl. Try
 // it if you don't believe me.
 pub struct SinkWrap<T>(pub StreamSink<T>);
+
+/// Runs something that consumes `sink`, putting a failure to start onto that same stream.
+///
+/// frb compiles a stream-returning function into a fire-and-forget call: it drops the `Result`
+/// rather than handing it back, so an error returned from one of them reaches nobody and the
+/// screen goes on waiting for a session that was never created. A `StreamSink` is a handle to a
+/// Dart port and clones for free, so the error path keeps one and the failure arrives where the
+/// screen is already listening.
+///
+/// The error is encoded the way frb encodes one for an ordinary call, so Dart decodes it into the
+/// same `AnyhowException` it would have received had the `Result` reached it.
+///
+/// `T: Clone` is frb's, not ours: it derives `Clone` on a sink that holds `T` only in a
+/// `PhantomData`, and the derive asks for it anyway.
+pub fn report_start_failure<T: SseEncode + Clone, R>(
+    sink: StreamSink<T>,
+    start: impl FnOnce(SinkWrap<T>) -> anyhow::Result<R>,
+) -> anyhow::Result<R> {
+    let error_sink = sink.clone();
+    start(SinkWrap(sink)).inspect_err(|e| {
+        let _ = error_sink.add_error(format!("{e:?}"));
+    })
+}
 
 macro_rules! bridge_sink {
     ($type:ty) => {


### PR DESCRIPTION
Not super confident that this code is of good quality
```
pub fn report_start_failure<T: SseEncode + Clone, R>(
    sink: StreamSink<T>,
    start: impl FnOnce(SinkWrap<T>) -> anyhow::Result<R>,
) -> anyhow::Result<R>
```

Currently untested.