### PR TITLE
TOFU host normalisation

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/handler_state.rs
+++ b/frostsnap_coordinator/src/bitcoin/handler_state.rs
@@ -13,7 +13,11 @@ use crate::settings::ElectrumEnabled;
 use super::{
     chain_sync::{ConnectionResult, ElectrumConfig, Message},
     status_tracker::{ConnPhase, StatusTracker},
-    tofu::{connection::Conn, trusted_certs::TrustedCertificates, verifier::TofuError},
+    tofu::{
+        connection::{host_from_url, Conn},
+        trusted_certs::TrustedCertificates,
+        verifier::TofuError,
+    },
 };
 
 /// Identifies the server a live connection is on. Carried by the connection state so failover
@@ -267,18 +271,10 @@ impl HandlerState {
                 tracing::info!(msg = "TrustCertificate", server_url = server_url);
                 let cert = certificate_der.into();
 
-                let hostname = match server_url.split_once("://") {
-                    Some((_, addr)) => addr
-                        .split_once(':')
-                        .map(|(host, _)| host)
-                        .unwrap_or(addr)
-                        .to_string(),
-                    None => server_url
-                        .split_once(':')
-                        .map(|(host, _)| host)
-                        .unwrap_or(&server_url)
-                        .to_string(),
-                };
+                // The url comes from the app as the user typed it, so it must be reduced to a
+                // host the same way `Conn::new` does. A key stored any other way is a key the
+                // next connection won't find.
+                let hostname = host_from_url(&server_url).to_string();
 
                 tracing::info!("Storing certificate for hostname: {}", hostname);
 

--- a/frostsnap_coordinator/src/bitcoin/handler_state.rs
+++ b/frostsnap_coordinator/src/bitcoin/handler_state.rs
@@ -274,7 +274,7 @@ impl HandlerState {
                 // The url comes from the app as the user typed it, so it must be reduced to a
                 // host the same way `Conn::new` does. A key stored any other way is a key the
                 // next connection won't find.
-                let hostname = host_from_url(&server_url).to_string();
+                let hostname = host_from_url(&server_url);
 
                 tracing::info!("Storing certificate for hostname: {}", hostname);
 

--- a/frostsnap_coordinator/src/bitcoin/tofu/connection.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/connection.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use tokio::net::{lookup_host, TcpStream};
 use tokio_rustls::{client::TlsStream, TlsConnector};
 
-use super::trusted_certs::TrustedCertificates;
+use super::trusted_certs::{TrustKey, TrustedCertificates};
 use super::verifier::{TofuCertVerifier, TofuError};
 use crate::persist::Persisted;
 
@@ -121,7 +121,7 @@ impl Conn {
             tracing::info!(url, "Connecting");
             if is_ssl {
                 let host = host_from_url(&socket_addr);
-                let stream = connect_with_tofu(&socket_addr, host, trusted_certificates).await?;
+                let stream = connect_with_tofu(&socket_addr, &host, trusted_certificates).await?;
                 let (mut rh, mut wh) = tokio::io::split(stream);
                 check_conn(&mut rh, &mut wh, genesis_hash)
                     .await
@@ -162,12 +162,13 @@ impl Conn {
 }
 
 /// The host part of an electrum url (with or without a `scheme://` prefix): the name TLS is
-/// verified against and the key the TOFU trust store is keyed by, so every caller must agree on
-/// it. An IPv6 literal is bracketed in a url but not in a server name, so `[2001:db8::1]:50002`
-/// has to come back as `2001:db8::1`: splitting on the first colon would give `[2001`.
-pub fn host_from_url(url: &str) -> &str {
+/// verified against, handed back as the `TrustKey` the trust store is keyed by so that every
+/// caller lands on the same key. An IPv6 literal is bracketed in a url but not in a server name,
+/// so `[2001:db8::1]:50002` has to come back as `2001:db8::1`: splitting on the first colon would
+/// give `[2001`.
+pub fn host_from_url(url: &str) -> TrustKey {
     let authority = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
-    match authority.strip_prefix('[') {
+    let host = match authority.strip_prefix('[') {
         Some(after_bracket) => after_bracket
             .split_once(']')
             .map(|(host, _)| host)
@@ -176,13 +177,14 @@ pub fn host_from_url(url: &str) -> &str {
             .split_once(':')
             .map(|(host, _)| host)
             .unwrap_or(authority),
-    }
+    };
+    TrustKey::new(host)
 }
 
 /// Attempt to connect with TOFU support
 async fn connect_with_tofu(
     socket_addr: &str,
-    host: &str,
+    host: &TrustKey,
     trusted_certificates: &mut Persisted<TrustedCertificates>,
 ) -> Result<TlsStream<TcpStream>, TofuError> {
     // webpki roots only. TOFU certs must never go in here: webpki treats every root as an
@@ -204,7 +206,7 @@ async fn connect_with_tofu(
         .with_custom_certificate_verifier(tofu_verifier.clone())
         .with_no_client_auth();
 
-    let dnsname = ServerName::try_from(host.to_owned())
+    let dnsname = ServerName::try_from(host.as_str().to_owned())
         .map_err(|e| TofuError::Other(anyhow!("Invalid DNS name: {}", e)))?;
 
     let sock = happy_eyeballs_connect(socket_addr).await.map_err(|e| {
@@ -316,15 +318,18 @@ mod tests {
 
     #[test]
     fn host_from_url_strips_scheme_port_and_ipv6_brackets() {
-        assert_eq!(host_from_url("ssl://[2001:db8::1]:50002"), "2001:db8::1");
-        assert_eq!(host_from_url("[2001:db8::1]:50002"), "2001:db8::1");
         assert_eq!(
-            host_from_url("ssl://electrum.frostsn.app:50002"),
+            host_from_url("ssl://[2001:db8::1]:50002").as_str(),
+            "2001:db8::1"
+        );
+        assert_eq!(host_from_url("[2001:db8::1]:50002").as_str(), "2001:db8::1");
+        assert_eq!(
+            host_from_url("ssl://electrum.frostsn.app:50002").as_str(),
             "electrum.frostsn.app"
         );
-        assert_eq!(host_from_url("192.0.2.1:50002"), "192.0.2.1");
+        assert_eq!(host_from_url("192.0.2.1:50002").as_str(), "192.0.2.1");
         assert_eq!(
-            host_from_url("electrum.frostsn.app"),
+            host_from_url("electrum.frostsn.app").as_str(),
             "electrum.frostsn.app"
         );
     }

--- a/frostsnap_coordinator/src/bitcoin/tofu/connection.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/connection.rs
@@ -120,13 +120,8 @@ impl Conn {
             };
             tracing::info!(url, "Connecting");
             if is_ssl {
-                let host = socket_addr
-                    .clone()
-                    .split_once(":")
-                    .map(|(host, _)| host.to_string())
-                    .unwrap_or(socket_addr.clone());
-
-                let stream = connect_with_tofu(&socket_addr, &host, trusted_certificates).await?;
+                let host = host_from_url(&socket_addr);
+                let stream = connect_with_tofu(&socket_addr, host, trusted_certificates).await?;
                 let (mut rh, mut wh) = tokio::io::split(stream);
                 check_conn(&mut rh, &mut wh, genesis_hash)
                     .await
@@ -163,6 +158,24 @@ impl Conn {
             TofuError::Other(e) => TofuError::Other(e.context(format!("connecting to {url}"))),
             not_trusted => not_trusted,
         })
+    }
+}
+
+/// The host part of an electrum url (with or without a `scheme://` prefix): the name TLS is
+/// verified against and the key the TOFU trust store is keyed by, so every caller must agree on
+/// it. An IPv6 literal is bracketed in a url but not in a server name, so `[2001:db8::1]:50002`
+/// has to come back as `2001:db8::1`: splitting on the first colon would give `[2001`.
+pub fn host_from_url(url: &str) -> &str {
+    let authority = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    match authority.strip_prefix('[') {
+        Some(after_bracket) => after_bracket
+            .split_once(']')
+            .map(|(host, _)| host)
+            .unwrap_or(after_bracket),
+        None => authority
+            .split_once(':')
+            .map(|(host, _)| host)
+            .unwrap_or(authority),
     }
 }
 
@@ -300,6 +313,21 @@ pub struct TargetServerReq {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn host_from_url_strips_scheme_port_and_ipv6_brackets() {
+        assert_eq!(host_from_url("ssl://[2001:db8::1]:50002"), "2001:db8::1");
+        assert_eq!(host_from_url("[2001:db8::1]:50002"), "2001:db8::1");
+        assert_eq!(
+            host_from_url("ssl://electrum.frostsn.app:50002"),
+            "electrum.frostsn.app"
+        );
+        assert_eq!(host_from_url("192.0.2.1:50002"), "192.0.2.1");
+        assert_eq!(
+            host_from_url("electrum.frostsn.app"),
+            "electrum.frostsn.app"
+        );
+    }
 
     #[tokio::test]
     #[ignore] // requires network

--- a/frostsnap_coordinator/src/bitcoin/tofu/trusted_certs.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/trusted_certs.rs
@@ -15,16 +15,51 @@ pub struct TrustedCertificate {
     pub added_at: i64, // Unix timestamp
 }
 
+/// The host name a trusted certificate is pinned to, with its case folded.
+///
+/// Host names are case-insensitive, so `Electrum.Frostsn.App` and `electrum.frostsn.app` have to
+/// land on the same entry: otherwise the first spelling gets an entry of its own and quietly
+/// side-steps the pin on the second. Folding lives in the only ordinary constructor, so a lookup
+/// added later cannot forget to do it. There is deliberately no `Borrow<str>` impl: it would let
+/// `HashMap::get` take a bare `&str` and skip the constructor again.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TrustKey(String);
+
+impl TrustKey {
+    pub fn new(host: impl AsRef<str>) -> Self {
+        Self(host.as_ref().to_ascii_lowercase())
+    }
+
+    /// A key read back from the database, kept exactly as it was stored.
+    ///
+    /// The in-memory key has to match the row it came from. `persist_update` does
+    /// `INSERT OR REPLACE` keyed by this value, so lowercasing on load would write a new row and
+    /// orphan the original, and `remove_certificate` would never delete it. A row stored before
+    /// canonicalisation therefore stays unreachable and the user is prompted once more, which is
+    /// the safe direction.
+    fn from_stored(stored: String) -> Self {
+        Self(stored)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for TrustKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TrustedCertificates {
     /// The network this certificate store is for
     network: bitcoin::Network,
-    /// Maps server_url -> trusted certificate. Host names are case-insensitive, so keys are
-    /// lowercased both on the way in and on lookup: otherwise `Electrum.Frostsn.App` would get
-    /// an entry of its own and quietly side-step the pin on `electrum.frostsn.app`. Entries
-    /// persisted before this canonicalisation keep their stored case and so are never found
-    /// again: the user gets prompted once more, which is the safe direction.
-    certificates: HashMap<String, TrustedCertificate>,
+    /// Maps trust key -> trusted certificate. An entry persisted before host names were
+    /// canonicalised keeps its stored case and so is never found again: the user gets prompted
+    /// once more, which is the safe direction.
+    certificates: HashMap<TrustKey, TrustedCertificate>,
 }
 
 #[derive(Debug, Clone)]
@@ -32,11 +67,11 @@ pub enum CertificateMutation {
     Add {
         network: bitcoin::Network,
         certificate: CertificateDer<'static>,
-        server_url: String,
+        server_url: TrustKey,
     },
     Remove {
         network: bitcoin::Network,
-        server_url: String,
+        server_url: TrustKey,
     },
 }
 
@@ -79,12 +114,9 @@ impl TrustedCertificates {
     pub fn add_certificate(
         &mut self,
         cert: CertificateDer<'static>,
-        mut server_url: String,
+        server_url: TrustKey,
         mutations: &mut Vec<CertificateMutation>,
     ) {
-        // Canonicalise here so the mutation carries the key that both the in-memory map and the
-        // persisted row get keyed by.
-        server_url.make_ascii_lowercase();
         // HashMap will automatically replace any existing entry
         self.mutate(
             CertificateMutation::Add {
@@ -98,10 +130,9 @@ impl TrustedCertificates {
 
     pub fn remove_certificate(
         &mut self,
-        mut server_url: String,
+        server_url: TrustKey,
         mutations: &mut Vec<CertificateMutation>,
     ) {
-        server_url.make_ascii_lowercase();
         self.mutate(
             CertificateMutation::Remove {
                 network: self.network,
@@ -115,24 +146,21 @@ impl TrustedCertificates {
     pub fn find_certificate_by_fingerprint(
         &self,
         fingerprint: &str,
-    ) -> Option<(&str, &TrustedCertificate)> {
+    ) -> Option<(&TrustKey, &TrustedCertificate)> {
         self.certificates
             .iter()
             .find(|(_, cert)| cert.certificate.sha256_fingerprint() == fingerprint)
-            .map(|(url, cert)| (url.as_str(), cert))
     }
 
-    pub fn get_all_certificates(&self) -> Vec<(String, TrustedCertificate)> {
+    pub fn get_all_certificates(&self) -> Vec<(TrustKey, TrustedCertificate)> {
         self.certificates
             .iter()
             .map(|(url, cert)| (url.clone(), cert.clone()))
             .collect()
     }
 
-    pub fn get_certificate_for_server(&self, server_url: &str) -> Option<&CertificateDer<'_>> {
-        self.certificates
-            .get(&server_url.to_ascii_lowercase())
-            .map(|tc| &tc.certificate)
+    pub fn get_certificate_for_server(&self, server_url: &TrustKey) -> Option<&CertificateDer<'_>> {
+        self.certificates.get(server_url).map(|tc| &tc.certificate)
     }
 
     #[cfg(test)]
@@ -228,7 +256,9 @@ impl Persist<rusqlite::Connection> for TrustedCertificates {
                         cert.added_at
                     );
                     // Directly insert to preserve the original added_at timestamp
-                    trusted_certs.certificates.insert(server_url, cert);
+                    trusted_certs
+                        .certificates
+                        .insert(TrustKey::from_stored(server_url), cert);
                 }
                 Err(e) => {
                     tracing::warn!("Failed to load trusted certificate: {:?}", e);
@@ -267,7 +297,7 @@ impl Persist<rusqlite::Connection> for TrustedCertificates {
                          VALUES (?1, ?2, ?3, ?4)",
                         params![
                             network.to_string(),
-                            server_url,
+                            server_url.as_str(),
                             certificate.as_ref(),
                             added_at
                         ],
@@ -285,7 +315,7 @@ impl Persist<rusqlite::Connection> for TrustedCertificates {
 
                     let rows_affected = conn.execute(
                         "DELETE FROM fs_trusted_certificates WHERE network = ?1 AND server_url = ?2",
-                        params![network.to_string(), server_url],
+                        params![network.to_string(), server_url.as_str()],
                     )?;
 
                     if rows_affected == 0 {
@@ -326,7 +356,7 @@ mod tests {
         let mut mutations = Vec::new();
         store.add_certificate(
             cert.clone(),
-            "test.example.com:443".to_string(),
+            TrustKey::new("test.example.com:443"),
             &mut mutations,
         );
 
@@ -338,7 +368,7 @@ mod tests {
         assert_eq!(loaded_store.certificates.len(), initial_count + 1);
         assert!(loaded_store
             .certificates
-            .contains_key("test.example.com:443"));
+            .contains_key(&TrustKey::new("test.example.com:443")));
 
         Ok(())
     }
@@ -356,14 +386,14 @@ mod tests {
         let mut mutations = Vec::new();
         store.add_certificate(
             cert.clone(),
-            "test.example.com:443".to_string(),
+            TrustKey::new("test.example.com:443"),
             &mut mutations,
         );
         store.persist_update(&mut conn, mutations)?;
 
         // Remove by server URL
         let mut mutations = Vec::new();
-        store.remove_certificate("test.example.com:443".to_string(), &mut mutations);
+        store.remove_certificate(TrustKey::new("test.example.com:443"), &mut mutations);
         store.persist_update(&mut conn, mutations)?;
 
         // Verify it's removed
@@ -383,7 +413,9 @@ mod tests {
             TrustedCertificates::migrate(&mut conn)?;
             let store1 = TrustedCertificates::load(&mut conn, bitcoin::Network::Bitcoin)?;
             assert_eq!(store1.certificates.len(), 1);
-            assert!(store1.certificates.contains_key(ELECTRUM_FROSTSN_APP_URL));
+            assert!(store1
+                .certificates
+                .contains_key(&TrustKey::new(ELECTRUM_FROSTSN_APP_URL)));
         }
 
         // Second initialization - should NOT insert again
@@ -392,7 +424,9 @@ mod tests {
             TrustedCertificates::migrate(&mut conn)?;
             let store2 = TrustedCertificates::load(&mut conn, bitcoin::Network::Bitcoin)?;
             assert_eq!(store2.certificates.len(), 1);
-            assert!(store2.certificates.contains_key(ELECTRUM_FROSTSN_APP_URL));
+            assert!(store2
+                .certificates
+                .contains_key(&TrustKey::new(ELECTRUM_FROSTSN_APP_URL)));
 
             // Verify there's still only one row in the database
             let count: i64 =
@@ -415,17 +449,19 @@ mod tests {
         let add_mutation = CertificateMutation::Add {
             network: bitcoin::Network::Bitcoin,
             certificate: cert.clone(),
-            server_url: "test.example.com:443".to_string(),
+            server_url: TrustKey::new("test.example.com:443"),
         };
 
         assert!(store.apply_mutation(&add_mutation));
         assert_eq!(store.certificates.len(), initial_count + 1);
-        assert!(store.certificates.contains_key("test.example.com:443"));
+        assert!(store
+            .certificates
+            .contains_key(&TrustKey::new("test.example.com:443")));
 
         // Test remove mutation
         let remove_mutation = CertificateMutation::Remove {
             network: bitcoin::Network::Bitcoin,
-            server_url: "test.example.com:443".to_string(),
+            server_url: TrustKey::new("test.example.com:443"),
         };
 
         assert!(store.apply_mutation(&remove_mutation));

--- a/frostsnap_coordinator/src/bitcoin/tofu/trusted_certs.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/trusted_certs.rs
@@ -19,7 +19,11 @@ pub struct TrustedCertificate {
 pub struct TrustedCertificates {
     /// The network this certificate store is for
     network: bitcoin::Network,
-    /// Maps server_url -> trusted certificate
+    /// Maps server_url -> trusted certificate. Host names are case-insensitive, so keys are
+    /// lowercased both on the way in and on lookup: otherwise `Electrum.Frostsn.App` would get
+    /// an entry of its own and quietly side-step the pin on `electrum.frostsn.app`. Entries
+    /// persisted before this canonicalisation keep their stored case and so are never found
+    /// again: the user gets prompted once more, which is the safe direction.
     certificates: HashMap<String, TrustedCertificate>,
 }
 
@@ -75,9 +79,12 @@ impl TrustedCertificates {
     pub fn add_certificate(
         &mut self,
         cert: CertificateDer<'static>,
-        server_url: String,
+        mut server_url: String,
         mutations: &mut Vec<CertificateMutation>,
     ) {
+        // Canonicalise here so the mutation carries the key that both the in-memory map and the
+        // persisted row get keyed by.
+        server_url.make_ascii_lowercase();
         // HashMap will automatically replace any existing entry
         self.mutate(
             CertificateMutation::Add {
@@ -91,9 +98,10 @@ impl TrustedCertificates {
 
     pub fn remove_certificate(
         &mut self,
-        server_url: String,
+        mut server_url: String,
         mutations: &mut Vec<CertificateMutation>,
     ) {
+        server_url.make_ascii_lowercase();
         self.mutate(
             CertificateMutation::Remove {
                 network: self.network,
@@ -122,7 +130,9 @@ impl TrustedCertificates {
     }
 
     pub fn get_certificate_for_server(&self, server_url: &str) -> Option<&CertificateDer<'_>> {
-        self.certificates.get(server_url).map(|tc| &tc.certificate)
+        self.certificates
+            .get(&server_url.to_ascii_lowercase())
+            .map(|tc| &tc.certificate)
     }
 
     #[cfg(test)]

--- a/frostsnap_coordinator/src/bitcoin/tofu/verifier.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/verifier.rs
@@ -4,7 +4,7 @@ use rustls::{DigitallySignedStruct, Error as RustlsError, SignatureScheme};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use super::trusted_certs::TrustedCertificates;
+use super::trusted_certs::{TrustKey, TrustedCertificates};
 
 /// Extension trait for certificate fingerprinting
 pub trait CertificateExt {
@@ -100,7 +100,7 @@ pub struct TofuCertVerifier {
     /// Trusted certificates store
     trusted_certs: TrustedCertificates,
     /// Storage for TOFU errors indexed by server URL
-    tofu_errors: Arc<Mutex<HashMap<String, TofuError>>>,
+    tofu_errors: Arc<Mutex<HashMap<TrustKey, TofuError>>>,
 }
 
 impl std::fmt::Debug for TofuCertVerifier {
@@ -122,11 +122,8 @@ impl TofuCertVerifier {
     }
 
     /// Extract the TOFU error for a specific server if any
-    pub fn take_tofu_error(&self, server_url: &str) -> Option<TofuError> {
-        self.tofu_errors
-            .lock()
-            .unwrap()
-            .remove(&server_url.to_ascii_lowercase())
+    pub fn take_tofu_error(&self, server_url: &TrustKey) -> Option<TofuError> {
+        self.tofu_errors.lock().unwrap().remove(server_url)
     }
 }
 
@@ -139,15 +136,12 @@ impl ServerCertVerifier for TofuCertVerifier {
         ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, RustlsError> {
-        // Host names are case-insensitive, so fold the case before this is used to key the
-        // trust store (and the captured errors): otherwise `Electrum.Frostsn.App` gets an
-        // entry of its own and the pin on `electrum.frostsn.app` is quietly side-stepped.
-        let server_str = server_name.to_str().to_ascii_lowercase();
+        let server_key = TrustKey::new(server_name.to_str());
 
-        tracing::info!("TOFU verifier checking server: {}", server_str);
+        tracing::info!("TOFU verifier checking server: {}", server_key);
 
         // Check if we have a TOFU certificate for this server
-        let previous_cert = self.trusted_certs.get_certificate_for_server(&server_str);
+        let previous_cert = self.trusted_certs.get_certificate_for_server(&server_key);
 
         if let Some(trusted_cert) = &previous_cert {
             if trusted_cert == &end_entity {
@@ -157,12 +151,12 @@ impl ServerCertVerifier for TofuCertVerifier {
                 // Certificate changed - this requires user approval, not PKI fallback
                 tracing::warn!(
                     "Certificate for {} has changed - capturing for user approval",
-                    server_str
+                    server_key
                 );
 
                 let untrusted_cert = UntrustedCertificate {
                     fingerprint: end_entity.sha256_fingerprint(),
-                    server_url: server_str.clone(),
+                    server_url: server_key.to_string(),
                     is_changed: true,
                     old_fingerprint: Some(trusted_cert.sha256_fingerprint()),
                     certificate_der: end_entity.to_vec(),
@@ -173,14 +167,14 @@ impl ServerCertVerifier for TofuCertVerifier {
                 self.tofu_errors
                     .lock()
                     .unwrap()
-                    .insert(server_str, tofu_error);
+                    .insert(server_key, tofu_error);
 
                 return Err(RustlsError::General(
                     "Certificate changed - requires user approval".to_string(),
                 ));
             }
         } else {
-            tracing::info!("No stored certificate found for {}", server_str);
+            tracing::info!("No stored certificate found for {}", server_key);
         }
 
         match self.base_verifier.verify_server_cert(
@@ -191,7 +185,7 @@ impl ServerCertVerifier for TofuCertVerifier {
             now,
         ) {
             Ok(verified) => {
-                tracing::debug!("Certificate validated via PKI for {}", server_str);
+                tracing::debug!("Certificate validated via PKI for {}", server_key);
                 Ok(verified)
             }
             Err(e) => {
@@ -235,7 +229,7 @@ impl ServerCertVerifier for TofuCertVerifier {
 
                     let untrusted_cert = UntrustedCertificate {
                         fingerprint: end_entity.sha256_fingerprint(),
-                        server_url: server_str.clone(),
+                        server_url: server_key.to_string(),
                         is_changed: previous_cert.is_some(),
                         old_fingerprint: previous_cert.map(|cert| cert.sha256_fingerprint()),
                         certificate_der: end_entity.to_vec(),
@@ -246,7 +240,7 @@ impl ServerCertVerifier for TofuCertVerifier {
                     self.tofu_errors
                         .lock()
                         .unwrap()
-                        .insert(server_str, tofu_error);
+                        .insert(server_key, tofu_error);
                 }
 
                 Err(e)
@@ -282,7 +276,7 @@ impl ServerCertVerifier for TofuCertVerifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bitcoin::tofu::trusted_certs::TrustedCertificates;
+    use crate::bitcoin::tofu::trusted_certs::{TrustKey, TrustedCertificates};
     use rustls::client::WebPkiServerVerifier;
     use rustls::pki_types::{ServerName, UnixTime};
 
@@ -335,7 +329,7 @@ mod tests {
         let result = tofu_verifier.verify_server_cert(&test_cert1, &[], &server_name, &[], now);
         assert!(result.is_err(), "First connection should fail");
 
-        let tofu_error = tofu_verifier.take_tofu_error("test.example.com");
+        let tofu_error = tofu_verifier.take_tofu_error(&TrustKey::new("test.example.com"));
         assert!(tofu_error.is_some(), "Should have captured TOFU error");
         match tofu_error.unwrap() {
             TofuError::NotTrusted(cert) => {
@@ -358,7 +352,7 @@ mod tests {
 
         trusted_certs.add_certificate(
             test_cert1.clone(),
-            "test.example.com".to_string(),
+            TrustKey::new("test.example.com"),
             &mut mutations,
         );
 
@@ -395,7 +389,11 @@ mod tests {
         ] {
             let mut trusted_certs =
                 TrustedCertificates::new_for_test(bdk_chain::bitcoin::Network::Bitcoin);
-            trusted_certs.add_certificate(test_cert1.clone(), stored.to_string(), &mut mutations);
+            trusted_certs.add_certificate(
+                test_cert1.clone(),
+                TrustKey::new(stored),
+                &mut mutations,
+            );
 
             let tofu_verifier = TofuCertVerifier::new(base_verifier.clone(), trusted_certs);
             let server_name = ServerName::try_from(connected_to).unwrap();
@@ -421,7 +419,7 @@ mod tests {
 
         trusted_certs.add_certificate(
             test_cert1.clone(),
-            "test.example.com".to_string(),
+            TrustKey::new("test.example.com"),
             &mut mutations,
         );
 
@@ -436,7 +434,7 @@ mod tests {
         let result = tofu_verifier.verify_server_cert(&test_cert2, &[], &server_name, &[], now);
         assert!(result.is_err(), "Different certificate should fail");
 
-        let tofu_error = tofu_verifier.take_tofu_error("test.example.com");
+        let tofu_error = tofu_verifier.take_tofu_error(&TrustKey::new("test.example.com"));
         assert!(
             tofu_error.is_some(),
             "Should have captured changed certificate"
@@ -472,7 +470,7 @@ mod tests {
             .unwrap();
 
         // Step 1: User accepts a certificate for attacker.com
-        trusted_certs.add_certificate(cert.clone(), "attacker.com".to_string(), &mut mutations);
+        trusted_certs.add_certificate(cert.clone(), TrustKey::new("attacker.com"), &mut mutations);
 
         let tofu_verifier = TofuCertVerifier::new(base_verifier.clone(), trusted_certs.clone());
 
@@ -489,7 +487,7 @@ mod tests {
         );
 
         // The certificate should be captured as unverified
-        let tofu_error = tofu_verifier.take_tofu_error("bank.com");
+        let tofu_error = tofu_verifier.take_tofu_error(&TrustKey::new("bank.com"));
         assert!(
             tofu_error.is_some(),
             "Should have captured the certificate for TOFU prompt"
@@ -511,18 +509,24 @@ mod tests {
 
         // Add a certificate for a server
         let cert1 = CertificateDer::from(TEST_CERT1.to_vec());
-        trusted_certs.add_certificate(cert1.clone(), "example.com:443".to_string(), &mut mutations);
+        trusted_certs.add_certificate(
+            cert1.clone(),
+            TrustKey::new("example.com:443"),
+            &mut mutations,
+        );
 
         // Check if we can find it
         let certs = trusted_certs.get_all_certificates();
-        let found = certs.iter().find(|(url, _)| url == "example.com:443");
+        let found = certs
+            .iter()
+            .find(|(url, _)| url.as_str() == "example.com:443");
 
         assert!(found.is_some(), "Should find the certificate");
         assert_eq!(found.unwrap().1.certificate, cert1);
 
         // Verify we can get the certificate back
         assert_eq!(
-            trusted_certs.get_certificate_for_server("example.com:443"),
+            trusted_certs.get_certificate_for_server(&TrustKey::new("example.com:443")),
             Some(&cert1)
         );
 
@@ -532,11 +536,15 @@ mod tests {
         let new_fingerprint = cert2.sha256_fingerprint();
 
         // Add second certificate (should replace the first one)
-        trusted_certs.add_certificate(cert2.clone(), "example.com:443".to_string(), &mut mutations);
+        trusted_certs.add_certificate(
+            cert2.clone(),
+            TrustKey::new("example.com:443"),
+            &mut mutations,
+        );
 
         // Only the second certificate should be stored for this server now
         assert_eq!(
-            trusted_certs.get_certificate_for_server("example.com:443"),
+            trusted_certs.get_certificate_for_server(&TrustKey::new("example.com:443")),
             Some(&cert2),
             "Server should now have cert2"
         );
@@ -583,7 +591,7 @@ mod tests {
         );
 
         // Most importantly: verify NO TOFU error was captured
-        let tofu_error = tofu_verifier.take_tofu_error("electrum.emzy.de");
+        let tofu_error = tofu_verifier.take_tofu_error(&TrustKey::new("electrum.emzy.de"));
         assert!(
             tofu_error.is_none(),
             "Should NOT capture TOFU error for unsupported cert version"

--- a/frostsnap_coordinator/src/bitcoin/tofu/verifier.rs
+++ b/frostsnap_coordinator/src/bitcoin/tofu/verifier.rs
@@ -123,7 +123,10 @@ impl TofuCertVerifier {
 
     /// Extract the TOFU error for a specific server if any
     pub fn take_tofu_error(&self, server_url: &str) -> Option<TofuError> {
-        self.tofu_errors.lock().unwrap().remove(server_url)
+        self.tofu_errors
+            .lock()
+            .unwrap()
+            .remove(&server_url.to_ascii_lowercase())
     }
 }
 
@@ -136,14 +139,15 @@ impl ServerCertVerifier for TofuCertVerifier {
         ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, RustlsError> {
-        let server_str = server_name.to_str();
+        // Host names are case-insensitive, so fold the case before this is used to key the
+        // trust store (and the captured errors): otherwise `Electrum.Frostsn.App` gets an
+        // entry of its own and the pin on `electrum.frostsn.app` is quietly side-stepped.
+        let server_str = server_name.to_str().to_ascii_lowercase();
 
-        tracing::info!("TOFU verifier checking server: {}", server_str.as_ref());
+        tracing::info!("TOFU verifier checking server: {}", server_str);
 
         // Check if we have a TOFU certificate for this server
-        let previous_cert = self
-            .trusted_certs
-            .get_certificate_for_server(server_str.as_ref());
+        let previous_cert = self.trusted_certs.get_certificate_for_server(&server_str);
 
         if let Some(trusted_cert) = &previous_cert {
             if trusted_cert == &end_entity {
@@ -153,12 +157,12 @@ impl ServerCertVerifier for TofuCertVerifier {
                 // Certificate changed - this requires user approval, not PKI fallback
                 tracing::warn!(
                     "Certificate for {} has changed - capturing for user approval",
-                    server_str.as_ref()
+                    server_str
                 );
 
                 let untrusted_cert = UntrustedCertificate {
                     fingerprint: end_entity.sha256_fingerprint(),
-                    server_url: server_str.to_string(),
+                    server_url: server_str.clone(),
                     is_changed: true,
                     old_fingerprint: Some(trusted_cert.sha256_fingerprint()),
                     certificate_der: end_entity.to_vec(),
@@ -169,14 +173,14 @@ impl ServerCertVerifier for TofuCertVerifier {
                 self.tofu_errors
                     .lock()
                     .unwrap()
-                    .insert(server_str.to_string(), tofu_error);
+                    .insert(server_str, tofu_error);
 
                 return Err(RustlsError::General(
                     "Certificate changed - requires user approval".to_string(),
                 ));
             }
         } else {
-            tracing::info!("No stored certificate found for {}", server_str.as_ref());
+            tracing::info!("No stored certificate found for {}", server_str);
         }
 
         match self.base_verifier.verify_server_cert(
@@ -231,7 +235,7 @@ impl ServerCertVerifier for TofuCertVerifier {
 
                     let untrusted_cert = UntrustedCertificate {
                         fingerprint: end_entity.sha256_fingerprint(),
-                        server_url: server_str.to_string(),
+                        server_url: server_str.clone(),
                         is_changed: previous_cert.is_some(),
                         old_fingerprint: previous_cert.map(|cert| cert.sha256_fingerprint()),
                         certificate_der: end_entity.to_vec(),
@@ -242,7 +246,7 @@ impl ServerCertVerifier for TofuCertVerifier {
                     self.tofu_errors
                         .lock()
                         .unwrap()
-                        .insert(server_str.to_string(), tofu_error);
+                        .insert(server_str, tofu_error);
                 }
 
                 Err(e)
@@ -368,6 +372,40 @@ mod tests {
 
         let result = tofu_verifier.verify_server_cert(&test_cert1, &[], &server_name, &[], now);
         assert!(result.is_ok(), "Trusted certificate should be accepted");
+    }
+
+    /// Re-spelling a host name in different capitalisation must not get you past a pin. Both
+    /// directions are checked: the mixed-case spelling being the one in the trust store, and it
+    /// being the one we connect to.
+    #[test]
+    fn test_tofu_trust_is_case_insensitive() {
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let base_verifier = WebPkiServerVerifier::builder(Arc::new(root_store))
+            .build()
+            .unwrap();
+
+        let test_cert1 = CertificateDer::from(TEST_CERT1.to_vec());
+        let now = test_now();
+        let mut mutations = Vec::new();
+
+        for (stored, connected_to) in [
+            ("test.example.com", "Test.Example.Com"),
+            ("Test.Example.Com", "test.example.com"),
+        ] {
+            let mut trusted_certs =
+                TrustedCertificates::new_for_test(bdk_chain::bitcoin::Network::Bitcoin);
+            trusted_certs.add_certificate(test_cert1.clone(), stored.to_string(), &mut mutations);
+
+            let tofu_verifier = TofuCertVerifier::new(base_verifier.clone(), trusted_certs);
+            let server_name = ServerName::try_from(connected_to).unwrap();
+
+            let result = tofu_verifier.verify_server_cert(&test_cert1, &[], &server_name, &[], now);
+            assert!(
+                result.is_ok(),
+                "certificate trusted for {stored} should be trusted for {connected_to}"
+            );
+        }
     }
 
     #[test]

--- a/frostsnap_coordinator/tests/tofu_tests.rs
+++ b/frostsnap_coordinator/tests/tofu_tests.rs
@@ -1,4 +1,4 @@
-use frostsnap_coordinator::bitcoin::tofu::trusted_certs::TrustedCertificates;
+use frostsnap_coordinator::bitcoin::tofu::trusted_certs::{TrustKey, TrustedCertificates};
 use frostsnap_coordinator::persist::Persist;
 use rusqlite::Connection;
 use rustls_pki_types::ServerName;
@@ -24,7 +24,7 @@ async fn test_electrum_frostsn_app_ssl_connection() {
     // Verify that electrum.frostsn.app is pre-trusted
     assert!(
         trusted_certs
-            .get_certificate_for_server("electrum.frostsn.app")
+            .get_certificate_for_server(&TrustKey::new("electrum.frostsn.app"))
             .is_some(),
         "electrum.frostsn.app should be pre-trusted"
     );


### PR DESCRIPTION
I want to spend some more time on this to review 269f21fdff0ebddb708229ddb13850f32dbd8e0a.

Host names are case-insensitive, so `Electrum.Frostsn.App` and `electrum.frostsn.app` have to land on the same entry, otherwise it creates an additional one. 

Having an _always-lowercase_ `TrustKey` type is probably the cleanest/safest solution, but almost felt like overkill 9d724007fb9b0f71bd8b26c860d52516ac266c2c
