### PR TITLE
Carry the chain tip in TxState so tx details refresh

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -366,7 +366,7 @@ impl ConnectionHandler {
     pub fn run<SW, F>(mut self, super_wallet: SW, update_action: F)
     where
         SW: Deref<Target = sync::Mutex<CoordSuperWallet>> + Clone + Send + 'static,
-        F: FnMut(MasterAppkey, Vec<crate::bitcoin::wallet::Transaction>) + Send + 'static,
+        F: FnMut(MasterAppkey, Vec<crate::bitcoin::wallet::Transaction>, u32) + Send + 'static,
     {
         let chain_tip: CheckPoint;
         let network: bitcoin::Network;
@@ -425,7 +425,7 @@ impl ConnectionHandler {
         mut action: F,
     ) where
         SW: Deref<Target = sync::Mutex<CoordSuperWallet>> + Clone + Send + 'static,
-        F: FnMut(MasterAppkey, Vec<crate::bitcoin::wallet::Transaction>) + Send,
+        F: FnMut(MasterAppkey, Vec<crate::bitcoin::wallet::Transaction>, u32) + Send,
     {
         for update in block_on_stream(update_recv) {
             let master_appkeys = update
@@ -442,9 +442,12 @@ impl ConnectionHandler {
                 }
             };
             if changed {
+                // Read under the same lock as the transactions: the tip is what they were
+                // canonicalized against, and a later read could be a block ahead of them.
+                let chain_tip_height = wallet.chain_tip().height();
                 for master_appkey in master_appkeys {
                     let txs = wallet.list_transactions(master_appkey);
-                    action(master_appkey, txs);
+                    action(master_appkey, txs, chain_tip_height);
                 }
             }
         }

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -473,8 +473,9 @@ class _TxListState extends State<TxList> {
                   child: Center(child: CircularProgressIndicator()),
                 );
               }
-              final transactions = snapshot.data?.txs ?? [];
-              final chainTipHeight = walletCtx.wallet.superWallet.height();
+              final txState = snapshot.data!;
+              final transactions = txState.txs;
+              final chainTipHeight = txState.chainTipHeight;
               final now = DateTime.now();
               return SliverList.builder(
                 itemCount: transactions.length,

--- a/frostsnapp/lib/wallet_receive.dart
+++ b/frostsnapp/lib/wallet_receive.dart
@@ -206,6 +206,10 @@ class _ReceiverPageState extends State<ReceivePage> {
   late final StreamSubscription txStreamSub;
   List<Transaction> allTxs = [];
 
+  /// The tip `allTxs` arrived with. Kept beside them so a tile counts confirmations against the
+  /// height its transaction was listed at, not against whatever the chain has since reached.
+  int chainTipHeight = 0;
+
   StreamSubscription<VerifyAddressProtocolState>? _verifyStreamSub;
   FullscreenActionDialogController? _fullscreenDialogController;
   bool verificationSuccess = false;
@@ -329,6 +333,7 @@ class _ReceiverPageState extends State<ReceivePage> {
         }
         setState(() {
           allTxs = txState.txs;
+          chainTipHeight = txState.chainTipHeight;
           if (addr != null) _address = addr;
         });
       }
@@ -575,7 +580,6 @@ class _ReceiverPageState extends State<ReceivePage> {
     final isFocused = focus == ReceivePageFocus.awaitTx;
     final theme = Theme.of(context);
     final now = DateTime.now();
-    final chainTipHeight = walletCtx.wallet.superWallet.height();
 
     final relevantTxs = allTxs.where((tx) {
       if (thisAddr == null || thisSpk == null) return false;

--- a/frostsnapp/lib/wallet_tx_details.dart
+++ b/frostsnapp/lib/wallet_tx_details.dart
@@ -155,7 +155,11 @@ class SigningFinished extends TxSigningParams {
 class TxDetailsModel {
   /// The raw transaction.
   Transaction tx;
-  final int chainTipHeight;
+
+  /// The tip `tx` is read against. It is what turns a confirmation height into a
+  /// confirmation count, so it has to move with the transaction: a stale one leaves a mined
+  /// transaction reading as pending.
+  int chainTipHeight;
   final DateTime now;
 
   TxDetailsModel({
@@ -164,7 +168,10 @@ class TxDetailsModel {
     required this.now,
   });
 
-  update(Transaction tx) => this.tx = tx;
+  update(Transaction tx, int chainTipHeight) {
+    this.tx = tx;
+    this.chainTipHeight = chainTipHeight;
+  }
 
   int get netValue => tx.balanceDelta() ?? 0;
 
@@ -398,7 +405,9 @@ class _TxDetailsPageState extends State<TxDetailsPage> {
 
   onTxStateData(TxState data) {
     final tx = data.txs.firstWhereOrNull((tx) => tx.txid == txDetails.tx.txid);
-    if (tx != null && mounted) setState(() => txDetails.update(tx));
+    if (tx != null && mounted) {
+      setState(() => txDetails.update(tx, data.chainTipHeight));
+    }
   }
 
   bool isFirstRun = true;

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -9,6 +9,7 @@ use frostsnap_coordinator::bitcoin::chain_sync::{
     default_backup_electrum_server, default_electrum_server, SUPPORTED_NETWORKS,
 };
 pub use frostsnap_coordinator::bitcoin::wallet::ConfirmationTime;
+use frostsnap_coordinator::bitcoin::wallet::Transaction as WalletTransaction;
 pub use frostsnap_coordinator::frostsnap_core::{self, MasterAppkey};
 use frostsnap_core::bitcoin_transaction::{ScopedTo, TransactionTemplate};
 use frostsnap_core::message::EncodedSignature;
@@ -432,8 +433,10 @@ pub struct _ConfirmationTime {
     pub time: u64,
 }
 
-impl From<Vec<frostsnap_coordinator::bitcoin::wallet::Transaction>> for TxState {
-    fn from(txs: Vec<frostsnap_coordinator::bitcoin::wallet::Transaction>) -> Self {
+/// The transactions and the chain tip they were canonicalized against, so a snapshot can never
+/// pair a transaction with a height from a different moment.
+impl From<(Vec<WalletTransaction>, u32)> for TxState {
+    fn from((txs, chain_tip_height): (Vec<WalletTransaction>, u32)) -> Self {
         let txs = txs
             .into_iter()
             .map(From::from)
@@ -472,12 +475,13 @@ impl From<Vec<frostsnap_coordinator::bitcoin::wallet::Transaction>> for TxState 
             balance,
             untrusted_pending_balance,
             txs,
+            chain_tip_height,
         }
     }
 }
 
-impl From<frostsnap_coordinator::bitcoin::wallet::Transaction> for Transaction {
-    fn from(value: frostsnap_coordinator::bitcoin::wallet::Transaction) -> Self {
+impl From<WalletTransaction> for Transaction {
+    fn from(value: WalletTransaction) -> Self {
         let inner: RTransaction = (value.inner).deref().clone();
         // In the canonical graph means broadcast or seen on chain, so `inner` carries real
         // witnesses and its own size is the signed size.

--- a/frostsnapp/rust/src/api/settings.rs
+++ b/frostsnapp/rust/src/api/settings.rs
@@ -97,10 +97,10 @@ impl Settings {
                 move || {
                     conn_handler.run(super_wallet.inner.clone(), {
                         let wallet_streams = super_wallet.wallet_streams.clone();
-                        move |master_appkey, txs| {
+                        move |master_appkey, txs, chain_tip_height| {
                             let wallet_streams = wallet_streams.lock().unwrap();
                             if let Some(stream) = wallet_streams.get(&master_appkey) {
-                                if let Err(err) = stream.add(txs.into()) {
+                                if let Err(err) = stream.add((txs, chain_tip_height).into()) {
                                     tracing::error!(
                                         {
                                             master_appkey = master_appkey.to_redacted_string(),

--- a/frostsnapp/rust/src/api/super_wallet.rs
+++ b/frostsnapp/rust/src/api/super_wallet.rs
@@ -34,6 +34,9 @@ pub struct TxState {
     pub txs: Vec<Transaction>,
     pub balance: i64,
     pub untrusted_pending_balance: i64,
+    /// The tip `txs` was canonicalized against. It travels with them so a listener updates both
+    /// at once and never renders a transaction against a height from another moment.
+    pub chain_tip_height: u32,
 }
 
 #[frb(external)]
@@ -100,8 +103,10 @@ impl SuperWallet {
 
     #[frb(sync)]
     pub fn tx_state(&self, master_appkey: MasterAppkey) -> TxState {
-        let txs = self.inner.lock().unwrap().list_transactions(master_appkey);
-        txs.into()
+        let mut wallet = self.inner.lock().unwrap();
+        let chain_tip_height = wallet.chain_tip().height();
+        let txs = wallet.list_transactions(master_appkey);
+        (txs, chain_tip_height).into()
     }
 
     pub fn reconnect(&self) {
@@ -272,8 +277,9 @@ impl SuperWallet {
                 inner.broadcast_success(tx);
                 let wallet_streams = self.wallet_streams.lock().unwrap();
                 if let Some(stream) = wallet_streams.get(&master_appkey) {
+                    let chain_tip_height = inner.chain_tip().height();
                     let txs = inner.list_transactions(master_appkey);
-                    stream.add(txs.into()).unwrap();
+                    stream.add((txs, chain_tip_height).into()).unwrap();
                 }
                 Ok(())
             }


### PR DESCRIPTION
A confirmation count comes from two values: the height a transaction was mined at, and the tip we count against. The tx state stream carried only the first, so a detail page captured the tip once when it was built and never moved it. A transaction mined while its page was open kept reading as pending, while the wallet home, which re-read the tip on every rebuild, already showed it as received.

Re-reading the tip in the Dart handler is not enough. That is a second lock acquisition at a later moment, so it can be a block ahead of the transactions it is paired with, and the update callback already runs under the wallet lock, so Dart cannot read inside the same critical section.

TxState now carries the tip its transactions were canonicalized against, read from the same guard that listed them, and TxDetailsModel updates both together. The home tx list and the receive page take the tip from the snapshot they already hold instead of reading it separately. The remaining superWallet.height() callers build details for transactions outside the canonical list, where the count is zero against any tip.