### PR TITLE
app: support Base64 and Hex encoded PSBTs (fixes #569)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,7 @@ name = "rust_lib_frostsnapp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "bincode",
  "bip21",
  "bitcoin",
@@ -3887,6 +3888,7 @@ dependencies = [
  "frostsnap_desktop_camera",
  "frostsnap_secure_boot",
  "futures",
+ "hex",
  "image",
  "lazy_static",
  "rand 0.8.6",

--- a/frostsnapp/lib/psbt.dart
+++ b/frostsnapp/lib/psbt.dart
@@ -50,7 +50,7 @@ class LoadPsbtPageState extends State<LoadPsbtPage> {
     final UnsignedTx unsignedTx;
 
     try {
-      psbt = Psbt.deserialize(bytes: psbtBytes);
+      psbt = deserializePsbt(bytes: psbtBytes);
     } catch (e) {
       if (context.mounted) {
         await showExceptionDialog(

--- a/frostsnapp/rust/Cargo.toml
+++ b/frostsnapp/rust/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 anyhow = "1"
+base64 = "0.22"
 frostsnap_coordinator = { workspace = true }
 frostsnap_core = { workspace = true }
 lazy_static = "1.4"
@@ -24,6 +25,7 @@ rand = "0.8"
 time = { version = "0.3.36", features = ["formatting"] }
 bip21 = {version = "0.5.0", default-features = false}
 futures.workspace = true
+hex = "0.4"
 
 [build-dependencies]
 frostsnap_secure_boot.workspace = true

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 pub use bitcoin::Transaction as RTransaction;
 pub use bitcoin::{
     psbt::Error as PsbtError, Address, Network as BitcoinNetwork, OutPoint, Psbt, ScriptBuf, TxOut,
@@ -546,10 +547,35 @@ impl AddressExt for bitcoin::Address {
 impl Psbt {
     #[frb(sync)]
     pub fn serialize(&self) -> Vec<u8> {}
+}
 
-    #[frb(sync)]
-    #[allow(unused)]
-    pub fn deserialize(bytes: &[u8]) -> Result<Psbt, PsbtError> {}
+const PSBT_MAGIC: &[u8] = b"psbt\xff";
+
+/// Deserializes a binary PSBT or its Base64/hex text representation.
+#[frb(sync)]
+pub fn deserialize_psbt(bytes: &[u8]) -> std::result::Result<Psbt, PsbtError> {
+    if bytes.starts_with(PSBT_MAGIC) {
+        return Psbt::deserialize(bytes);
+    }
+
+    // `from_utf8_lossy` leaves valid text unchanged and lets malformed input
+    // gracefully fall through to the usual rust-bitcoin deserialization error.
+    let text = String::from_utf8_lossy(bytes);
+    let text = text.trim().trim_matches('"').trim();
+
+    if let Ok(decoded) = BASE64_STANDARD.decode(text) {
+        if decoded.starts_with(PSBT_MAGIC) {
+            return Psbt::deserialize(&decoded);
+        }
+    }
+
+    if let Ok(decoded) = hex::decode(text) {
+        if decoded.starts_with(PSBT_MAGIC) {
+            return Psbt::deserialize(&decoded);
+        }
+    }
+
+    Psbt::deserialize(bytes)
 }
 
 #[frb(external)]
@@ -909,5 +935,39 @@ mod test {
             "the fee is knowable but the signed size is not: we cannot weigh a witness for an \
              input that is not ours. `is_some()` here is what let an inflated rate stand."
         );
+    }
+
+    fn valid_psbt_bytes() -> Vec<u8> {
+        Psbt::from_unsigned_tx(bitcoin::Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        })
+        .expect("empty unsigned transaction is valid")
+        .serialize()
+    }
+
+    #[test]
+    fn deserialize_psbt_accepts_binary_psbt() {
+        let bytes = valid_psbt_bytes();
+        assert!(deserialize_psbt(&bytes).is_ok());
+    }
+
+    #[test]
+    fn deserialize_psbt_accepts_base64_psbt() {
+        let encoded = BASE64_STANDARD.encode(valid_psbt_bytes());
+        assert!(deserialize_psbt(format!("  \"{encoded}\"  ").as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn deserialize_psbt_accepts_hex_psbt() {
+        let encoded = hex::encode(valid_psbt_bytes());
+        assert!(deserialize_psbt(format!("  \"{encoded}\"  ").as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn deserialize_psbt_rejects_invalid_input() {
+        assert!(deserialize_psbt(b"not a PSBT").is_err());
     }
 }


### PR DESCRIPTION
Fixes #569

Bitcoin Core and several other wallets export PSBTs as Base64 text by default (`walletcreatefundedpsbt`), but the app previously expected raw binary starting with `psbt\xff`.

## Changes

- Added `deserialize_psbt` in `frostsnapp/rust/src/api/bitcoin.rs` to auto-detect the input format: it checks for the raw magic bytes first, then falls back to decoding trimmed Base64 or hex text before handing off to rust-bitcoin.
- Updated `psbt.dart` to route through `deserializePsbt`.
- Added the `base64` and `hex` crates to `frostsnapp/rust/Cargo.toml`.
- Added 4 unit tests covering binary, Base64, hex, and invalid payloads.

## Testing

- `cargo test -p rust_lib_frostsnapp`: all tests passing.
- Replicated the CI jobs locally: `lint-ordinary`, `lint-device`, firmware build + stack check (frontier), and `lint-app` all green; full `test-ordinary --release --all-features --locked` suite passes.
