### PR TITLE
[coord] Keep Electrum error causes and the active server across disconnects

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -658,12 +658,11 @@ impl ConnLoop {
         // stale Connected while the socket closes. We don't infer it from `next`: a disable
         // arrives as a config change that maps to Next::Connect, the same as a same-server
         // reconnect, so `next` can't tell them apart.
-        let leaving = if handler.should_connect() {
-            ConnPhase::Disconnected
+        if handler.should_connect() {
+            handler.status.set_disconnected();
         } else {
-            ConnPhase::Idle
-        };
-        handler.status.set_phase(leaving);
+            handler.status.set_phase(ConnPhase::Idle);
+        }
         let shutdown_result = match conn {
             Conn::Tcp((rh, wh)) => rh.unsplit(wh).shutdown().await,
             Conn::Ssl((rh, wh)) => rh.unsplit(wh).shutdown().await,
@@ -678,7 +677,7 @@ impl ConnLoop {
         // Between attempts we are disconnected (will retry). The service teardown already
         // asserted this on the failover path; on the connect-failure path the phase is still
         // Connecting, so assert it here. Deduped, so the redundant case is silent.
-        self.handler.status.set_phase(ConnPhase::Disconnected);
+        self.handler.status.set_disconnected();
         if failover {
             self.handler.prefer_other_server(was_on_backup);
         }

--- a/frostsnap_coordinator/src/bitcoin/handler_state.rs
+++ b/frostsnap_coordinator/src/bitcoin/handler_state.rs
@@ -65,6 +65,13 @@ pub(super) fn reconnect_needed(
     }
 }
 
+fn connection_error_message(err: &TofuError) -> String {
+    match err {
+        TofuError::Other(err) => format!("{err:#}"),
+        TofuError::NotTrusted(_) => err.to_string(),
+    }
+}
+
 /// State needed for message handling and connection attempts.
 pub(super) struct HandlerState {
     pub genesis_hash: BlockHash,
@@ -194,7 +201,11 @@ impl HandlerState {
                 Err(err) => {
                     // Stay in the Connecting phase across the failover to the next server; a
                     // total failure settles to Disconnected in `backoff`.
-                    tracing::error!(err = err.to_string(), url, "failed to connect",);
+                    tracing::error!(
+                        err = connection_error_message(&err),
+                        url,
+                        "failed to connect",
+                    );
                 }
             }
         }
@@ -240,9 +251,10 @@ impl HandlerState {
                         );
                         let _ = response.send(Ok(ConnectionResult::CertificatePromptNeeded(*cert)));
                     }
-                    Err(TofuError::Other(e)) => {
-                        tracing::error!("Failed to connect to {}: {}", request.url, e);
-                        let _ = response.send(Ok(ConnectionResult::Failed(e.to_string())));
+                    Err(err @ TofuError::Other(_)) => {
+                        let err = connection_error_message(&err);
+                        tracing::error!("Failed to connect to {}: {}", request.url, err);
+                        let _ = response.send(Ok(ConnectionResult::Failed(err)));
                     }
                 }
                 false
@@ -311,10 +323,40 @@ impl HandlerState {
 mod tests {
     use super::*;
     use crate::bitcoin::chain_sync::ElectrumConfig;
+    use crate::bitcoin::tofu::verifier::UntrustedCertificate;
     use bdk_chain::bitcoin::{consensus, constants::genesis_block, params::Params, Network};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::sync::watch;
+
+    #[test]
+    fn ordinary_connection_errors_include_their_cause_chain() {
+        let err =
+            anyhow::Error::msg("Connection refused").context("connecting to tcp://127.0.0.1:1");
+        let err = TofuError::Other(err);
+
+        assert_eq!(
+            connection_error_message(&err),
+            "connecting to tcp://127.0.0.1:1: Connection refused"
+        );
+    }
+
+    #[test]
+    fn trust_decision_errors_keep_their_specialized_message() {
+        let err = TofuError::NotTrusted(Box::new(UntrustedCertificate {
+            fingerprint: "00".into(),
+            server_url: "ssl://electrum.example:50002".into(),
+            is_changed: false,
+            old_fingerprint: None,
+            certificate_der: vec![],
+            valid_for_names: None,
+        }));
+
+        assert_eq!(
+            connection_error_message(&err),
+            "Untrusted certificate for ssl://electrum.example:50002"
+        );
+    }
 
     /// A started handler plus the config `watch` sender (kept alive so the receiver passed to
     /// `establish` doesn't see a closed channel) and a receiver to drive `establish` with.

--- a/frostsnap_coordinator/src/bitcoin/status_tracker.rs
+++ b/frostsnap_coordinator/src/bitcoin/status_tracker.rs
@@ -11,14 +11,16 @@ pub(super) enum ConnPhase {
     Idle,
     Connecting { on_backup: bool },
     Connected { on_backup: bool },
-    Disconnected,
+    Disconnected { on_backup: bool },
 }
 
 impl ConnPhase {
     fn on_backup(self) -> bool {
         matches!(
             self,
-            ConnPhase::Connecting { on_backup: true } | ConnPhase::Connected { on_backup: true }
+            ConnPhase::Connecting { on_backup: true }
+                | ConnPhase::Connected { on_backup: true }
+                | ConnPhase::Disconnected { on_backup: true }
         )
     }
 
@@ -27,7 +29,7 @@ impl ConnPhase {
             ConnPhase::Idle => ChainStatusState::Idle,
             ConnPhase::Connecting { .. } => ChainStatusState::Connecting,
             ConnPhase::Connected { .. } => ChainStatusState::Connected,
-            ConnPhase::Disconnected => ChainStatusState::Disconnected,
+            ConnPhase::Disconnected { .. } => ChainStatusState::Disconnected,
         }
     }
 }
@@ -87,6 +89,13 @@ impl StatusTracker {
         self.emit();
     }
 
+    /// Move the current server into Disconnected without forgetting whether it was the backup.
+    pub(super) fn set_disconnected(&mut self) {
+        self.set_phase(ConnPhase::Disconnected {
+            on_backup: self.phase.on_backup(),
+        });
+    }
+
     /// Re-project and emit after a config-url change (phase unchanged); deduped, so a config
     /// change that doesn't alter the displayed status is silent.
     pub fn refresh(&mut self) {
@@ -129,7 +138,7 @@ mod tests {
 
         t.set_phase(ConnPhase::Connecting { on_backup: true });
         t.set_phase(ConnPhase::Connected { on_backup: false });
-        t.set_phase(ConnPhase::Disconnected);
+        t.set_phase(ConnPhase::Disconnected { on_backup: true });
         t.set_phase(ConnPhase::Idle);
 
         let log = log.lock().unwrap();
@@ -140,12 +149,26 @@ mod tests {
                 (ChainStatusState::Idle, false), // initial, from set_sink
                 (ChainStatusState::Connecting, true),
                 (ChainStatusState::Connected, false),
-                (ChainStatusState::Disconnected, false),
+                (ChainStatusState::Disconnected, true),
                 (ChainStatusState::Idle, false),
             ]
         );
         assert_eq!(log[1].primary_url, "tcp://p:1");
         assert_eq!(log[1].backup_url, "tcp://b:1");
+    }
+
+    #[test]
+    fn disconnect_keeps_the_current_server_identity() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let (mut t, _tx) = tracker(log.clone());
+
+        for on_backup in [false, true] {
+            t.set_phase(ConnPhase::Connected { on_backup });
+            t.set_disconnected();
+            let status = log.lock().unwrap().last().unwrap().clone();
+            assert_eq!(status.state, ChainStatusState::Disconnected);
+            assert_eq!(status.on_backup, on_backup);
+        }
     }
 
     /// Identical successive statuses are not re-emitted; a config-url change re-emits.


### PR DESCRIPTION
Two small regressions from the #508 connection rewrite, both about losing information on the way to the user. Status projection and error text only; failover and retry behaviour are unchanged.

## Connection errors lost their cause

Failures are wrapped as `connecting to ssl://host:port`, but the error dialog and Logs page rendered only that outer context, so the actionable `Connection refused` underneath never reached the user, and a timeout could leave no reason in Logs at all. Ordinary connection failures are now rendered with anyhow's alternate format so the full chain survives; trust-decision errors keep their specialised message.

## Disconnect forgot which server it was on

After failing over to the backup and then losing that connection too, `ConnPhase::Disconnected` carried no `on_backup`, so the UI labelled the disconnect with the primary URL. `Disconnected` now carries `on_backup`, and `StatusTracker::set_disconnected()` copies the active server identity when entering it.

## Tests

- `ordinary_connection_errors_include_their_cause_chain` / `trust_decision_errors_keep_their_specialized_message`
- `disconnect_keeps_the_current_server_identity` (both primary and backup directions)
- `cargo test -p frostsnap_coordinator --lib -- bitcoin::handler_state bitcoin::status_tracker bitcoin::chain_sync`: 11 passed
