### PR TITLE
[coord,app] Count confirmations in Rust, from the tip the snapshot was made at

### DIFF
--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -386,6 +386,8 @@ impl CoordSuperWallet {
 
     pub fn list_transactions(&mut self, master_appkey: MasterAppkey) -> Vec<Transaction> {
         self.lazily_initialize_key(master_appkey);
+        let chain_tip = self.chain.tip();
+        let chain_tip_height = chain_tip.height();
         // bdk's canonical order is topological (spend-depth), not by time, so reverse it to
         // get child-before-parent, then sort newest-first by chain position (pending first,
         // then confirmed by height). Stable sort keeps the child-before-parent tiebreak.
@@ -394,7 +396,7 @@ impl CoordSuperWallet {
             .graph()
             .list_ordered_canonical_txs(
                 self.chain.as_ref(),
-                self.chain.tip().block_id(),
+                chain_tip.block_id(),
                 CanonicalizationParams::default(),
             )
             .collect::<Vec<_>>();
@@ -412,6 +414,9 @@ impl CoordSuperWallet {
                     }),
                     _ => None,
                 };
+                let confirmations = confirmation_time.as_ref().map_or(0, |confirmation| {
+                    confirmation.confirmations_at_tip(chain_tip_height)
+                });
                 let last_seen = canonical_tx.tx_node.last_seen;
                 let prevouts =
                     self.get_prevouts(inner.input.iter().map(|txin| txin.previous_output));
@@ -435,6 +440,7 @@ impl CoordSuperWallet {
                         inner,
                         txid,
                         confirmation_time,
+                        confirmations,
                         last_seen,
                         prevouts,
                         is_mine,
@@ -586,6 +592,8 @@ pub struct Transaction {
     pub txid: Txid,
 
     pub confirmation_time: Option<ConfirmationTime>,
+    /// Confirmations against the same chain snapshot that canonicalized this transaction.
+    pub confirmations: u32,
     pub last_seen: Option<u64>,
 
     pub prevouts: HashMap<OutPoint, TxOut>,
@@ -599,11 +607,31 @@ pub struct ConfirmationTime {
     pub time: u64,
 }
 
+impl ConfirmationTime {
+    fn confirmations_at_tip(&self, chain_tip_height: u32) -> u32 {
+        chain_tip_height
+            .checked_sub(self.height)
+            .map_or(0, |depth| depth + 1)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use bitcoin::key::{Secp256k1, TweakedPublicKey};
     use frostsnap_core::{schnorr_fun::fun::Point, tweak::AppTweak};
+
+    #[test]
+    fn confirmation_count_is_derived_from_the_wallet_snapshot_tip() {
+        let confirmation = ConfirmationTime {
+            height: 100,
+            time: 0,
+        };
+
+        assert_eq!(confirmation.confirmations_at_tip(100), 1);
+        assert_eq!(confirmation.confirmations_at_tip(105), 6);
+        assert_eq!(confirmation.confirmations_at_tip(99), 0);
+    }
 
     #[test]
     fn wallet_descriptors_match_our_tweaking() {

--- a/frostsnapp/lib/psbt.dart
+++ b/frostsnapp/lib/psbt.dart
@@ -80,7 +80,6 @@ class LoadPsbtPageState extends State<LoadPsbtPage> {
 
     final txDetails = TxDetailsModel(
       tx: unsignedTx.details(),
-      chainTipHeight: wallet.superWallet.height(),
       now: DateTime.now(),
     );
 

--- a/frostsnapp/lib/wallet.dart
+++ b/frostsnapp/lib/wallet.dart
@@ -389,7 +389,6 @@ class _TxListState extends State<TxList> {
             walletCtx.txStream.map((_) => {}),
           ]),
           builder: (context, _) {
-            final chainTipHeight = walletCtx.wallet.superWallet.height();
             final now = DateTime.now();
             final unbroadcastedTiles = coord
                 .unbroadcastedTxs(
@@ -399,7 +398,6 @@ class _TxListState extends State<TxList> {
                 .map((unbroadcastedTx) {
                   final txDetails = TxDetailsModel(
                     tx: unbroadcastedTx.tx,
-                    chainTipHeight: chainTipHeight,
                     now: now,
                   );
                   final session = unbroadcastedTx.activeSession;
@@ -477,15 +475,14 @@ class _TxListState extends State<TxList> {
                   child: Center(child: CircularProgressIndicator()),
                 );
               }
-              final transactions = snapshot.data?.txs ?? [];
-              final chainTipHeight = walletCtx.wallet.superWallet.height();
+              final txState = snapshot.data!;
+              final transactions = txState.txs;
               final now = DateTime.now();
               return SliverList.builder(
                 itemCount: transactions.length,
                 itemBuilder: (context, index) {
                   final txDetails = TxDetailsModel(
                     tx: transactions[index],
-                    chainTipHeight: chainTipHeight,
                     now: now,
                   );
                   return TxSentOrReceivedTile(
@@ -864,7 +861,6 @@ class WalletBottomBar extends StatelessWidget {
 
     final txDetails = TxDetailsModel(
       tx: unbroadcastedTx.tx,
-      chainTipHeight: walletCtx.wallet.superWallet.height(),
       now: DateTime.now(),
     );
     final session = unbroadcastedTx.activeSession;
@@ -958,7 +954,6 @@ class WalletBottomBar extends StatelessWidget {
                   final uncanonicalTx = unbroadcastedTxs[index];
                   final txDetails = TxDetailsModel(
                     tx: uncanonicalTx.tx,
-                    chainTipHeight: walletCtx.superWallet.height(),
                     now: DateTime.now(),
                   );
                   return TxSentOrReceivedTile(

--- a/frostsnapp/lib/wallet_receive.dart
+++ b/frostsnapp/lib/wallet_receive.dart
@@ -575,7 +575,6 @@ class _ReceiverPageState extends State<ReceivePage> {
     final isFocused = focus == ReceivePageFocus.awaitTx;
     final theme = Theme.of(context);
     final now = DateTime.now();
-    final chainTipHeight = walletCtx.wallet.superWallet.height();
 
     final relevantTxs = allTxs.where((tx) {
       if (thisAddr == null || thisSpk == null) return false;
@@ -584,11 +583,7 @@ class _ReceiverPageState extends State<ReceivePage> {
       return (netSpent > 0 || netReceived > 0);
     }).toList();
     final txTiles = relevantTxs.map((tx) {
-      final txDetails = TxDetailsModel(
-        tx: tx,
-        chainTipHeight: chainTipHeight,
-        now: now,
-      );
+      final txDetails = TxDetailsModel(tx: tx, now: now);
       return TxSentOrReceivedTile(
         txDetails: txDetails,
         onTap: () => showBottomSheetOrDialog(

--- a/frostsnapp/lib/wallet_send.dart
+++ b/frostsnapp/lib/wallet_send.dart
@@ -626,14 +626,9 @@ class _WalletSendPageState extends State<WalletSendPage> {
     final fsCtx = FrostsnapContext.of(context)!;
     final walletCtx = WalletContext.of(context)!;
     final access = walletCtx.wallet.frostKey()!.accessStructures()[0];
-    final chainTipHeight = walletCtx.wallet.superWallet.height();
     final now = DateTime.now();
 
-    final txDetails = TxDetailsModel(
-      tx: unsignedTx.details(),
-      chainTipHeight: chainTipHeight,
-      now: now,
-    );
+    final txDetails = TxDetailsModel(tx: unsignedTx.details(), now: now);
     nextPageOrPop(null);
     await showBottomSheetOrDialog(
       context,

--- a/frostsnapp/lib/wallet_stranded_coins.dart
+++ b/frostsnapp/lib/wallet_stranded_coins.dart
@@ -254,11 +254,7 @@ class _ConsolidatePageState extends State<ConsolidatePage> {
 
     final access = walletCtx.wallet.frostKey()!.accessStructures()[0];
     final tx = unsignedTx.details();
-    final txDetails = TxDetailsModel(
-      tx: tx,
-      chainTipHeight: walletCtx.wallet.superWallet.height(),
-      now: DateTime.now(),
-    );
+    final txDetails = TxDetailsModel(tx: tx, now: DateTime.now());
     if (!context.mounted) return;
     Navigator.pop(context);
     await showBottomSheetOrDialog(

--- a/frostsnapp/lib/wallet_tx_details.dart
+++ b/frostsnapp/lib/wallet_tx_details.dart
@@ -155,25 +155,15 @@ class SigningFinished extends TxSigningParams {
 class TxDetailsModel {
   /// The raw transaction.
   Transaction tx;
-  final int chainTipHeight;
   final DateTime now;
 
-  TxDetailsModel({
-    required this.tx,
-    required this.chainTipHeight,
-    required this.now,
-  });
+  TxDetailsModel({required this.tx, required this.now});
 
   update(Transaction tx) => this.tx = tx;
 
   int get netValue => tx.balanceDelta() ?? 0;
 
-  /// Number of blocks in our view of the best chain.
-  int get chainLength => chainTipHeight + 1;
-
-  /// Number of tx confirmations.
-  int get confirmations =>
-      chainLength - (tx.confirmationTime?.height ?? chainLength);
+  int get confirmations => tx.confirmations;
   bool get isConfirmed => confirmations > 0;
   bool get isSend => (tx.balanceDelta() ?? 0) < 0;
 

--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -9,6 +9,7 @@ use frostsnap_coordinator::bitcoin::chain_sync::{
     default_backup_electrum_server, default_electrum_server, SUPPORTED_NETWORKS,
 };
 pub use frostsnap_coordinator::bitcoin::wallet::ConfirmationTime;
+use frostsnap_coordinator::bitcoin::wallet::Transaction as WalletTransaction;
 pub use frostsnap_coordinator::frostsnap_core::{self, MasterAppkey};
 use frostsnap_core::bitcoin_transaction::{ScopedTo, TransactionTemplate};
 use frostsnap_core::message::EncodedSignature;
@@ -183,6 +184,8 @@ pub struct Transaction {
     pub inner: RTransaction,
     pub txid: String,
     pub confirmation_time: Option<ConfirmationTime>,
+    /// Confirmations computed by the wallet model for this transaction snapshot.
+    pub confirmations: u32,
     pub last_seen: Option<u64>,
     pub prevouts: HashMap<bitcoin::OutPoint, bitcoin::TxOut>,
     pub is_mine: HashMap<bitcoin::ScriptBuf, u32>,
@@ -214,6 +217,7 @@ impl Transaction {
             inner: raw_tx,
             txid: txid.to_string(),
             confirmation_time: None,
+            confirmations: 0,
             last_seen: None,
             prevouts,
             is_mine,
@@ -432,8 +436,8 @@ pub struct _ConfirmationTime {
     pub time: u64,
 }
 
-impl From<Vec<frostsnap_coordinator::bitcoin::wallet::Transaction>> for TxState {
-    fn from(txs: Vec<frostsnap_coordinator::bitcoin::wallet::Transaction>) -> Self {
+impl From<Vec<WalletTransaction>> for TxState {
+    fn from(txs: Vec<WalletTransaction>) -> Self {
         let txs = txs
             .into_iter()
             .map(From::from)
@@ -476,8 +480,8 @@ impl From<Vec<frostsnap_coordinator::bitcoin::wallet::Transaction>> for TxState 
     }
 }
 
-impl From<frostsnap_coordinator::bitcoin::wallet::Transaction> for Transaction {
-    fn from(value: frostsnap_coordinator::bitcoin::wallet::Transaction) -> Self {
+impl From<WalletTransaction> for Transaction {
+    fn from(value: WalletTransaction) -> Self {
         let inner: RTransaction = (value.inner).deref().clone();
         // In the canonical graph means broadcast or seen on chain, so `inner` carries real
         // witnesses and its own size is the signed size.
@@ -487,6 +491,7 @@ impl From<frostsnap_coordinator::bitcoin::wallet::Transaction> for Transaction {
             inner,
             txid: value.txid.to_string(),
             confirmation_time: value.confirmation_time,
+            confirmations: value.confirmations,
             last_seen: value.last_seen,
             prevouts: value.prevouts,
             is_mine: value.is_mine,


### PR DESCRIPTION
**Intended to replace #585** — same bug, different side of the bridge.

An open transaction-details page kept the chain height it captured when it was built, so a transaction mined while the page was open stayed "Receiving…" with no confirmations while the wallet home, which re-read the tip on every rebuild, already showed it received.

#585 fixes this by shipping `chain_tip_height` alongside `txs` in `TxState` and keeping the `tip − height + 1` arithmetic in Dart. This does it one level down: `list_transactions` already holds the tip it canonicalises against, so it computes `confirmations` there and carries it on the `Transaction`. That means:

- `TxState` and the `ConnectionHandler::run` callback are unchanged — one new `u32` on `Transaction` is the whole bridge change.
- `TxDetailsModel` loses `chainTipHeight`/`chainLength`; all eight `superWallet.height()` reads at construction sites (tx list, receive, send, PSBT, stranded coins, bottom bar) go away, so there's no remaining path that can pair a transaction with a height from a different moment.
- Unsigned/unbroadcast transactions get `confirmations: 0` by construction, which is what those `height()` reads were always effectively producing.

## Tests

- `confirmation_count_is_derived_from_the_wallet_snapshot_tip` pins the off-by-one (`tip == height → 1`, `height > tip → 0`).
- `cargo test -p frostsnap_coordinator --lib -- bitcoin::wallet`, `cargo check -p rust_lib_frostsnapp --locked`, `flutter analyze`: clean.
