### PR TITLE
Release naming and security policy additions

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -31,5 +31,5 @@ jobs:
         run: just package-dmg ${{ github.workspace }}/Frostsnap.app
       - name: Upload DMG to release
         run: |
-          mv Frostsnap.dmg "Frostsnap-${{ env.TAG_NAME }}.dmg"
-          gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}.dmg#Frostsnap-mac.dmg" --clobber
+          mv Frostsnap.dmg "Frostsnap-${{ env.TAG_NAME }}-mac.dmg"
+          gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}-mac.dmg" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,12 @@ jobs:
           env: prod
       - name: Upload APK to release
         run: |
-          cp frostsnapp/build/app/outputs/flutter-apk/app-direct-release.apk "Frostsnap-${{ env.TAG_NAME }}.apk"
-          gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}.apk#Frostsnap-android.apk" --clobber
+          cp frostsnapp/build/app/outputs/flutter-apk/app-direct-release.apk "Frostsnap-${{ env.TAG_NAME }}-android.apk"
+          gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}-android.apk" --clobber
       - name: Upload App Bundle to release
         run: |
-          cp frostsnapp/build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab "Frostsnap-${{ env.TAG_NAME }}.aab"
-          gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}.aab#Frostsnap-android.aab" --clobber
+          cp frostsnapp/build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab "Frostsnap-${{ env.TAG_NAME }}-android.aab"
+          gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}-android.aab" --clobber
 
   build-linux:
     name: "Build Linux"
@@ -112,8 +112,8 @@ jobs:
       - run: just build-appimage
       - name: Upload AppImage to release
         run: |
-          mv Frostsnap-x86_64.AppImage "Frostsnap-${{ env.TAG_NAME }}.AppImage"
-          gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}.AppImage#Frostsnap-linux-x86_64.AppImage" --clobber
+          mv Frostsnap-x86_64.AppImage "Frostsnap-${{ env.TAG_NAME }}-linux-x86_64.AppImage"
+          gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}-linux-x86_64.AppImage" --clobber
 
   build-windows:
     name: "Build Windows"
@@ -130,9 +130,9 @@ jobs:
           firmware_path: firmware/firmware.bin
           env: prod
       - name: Zip Windows build
-        run: Compress-Archive -Path frostsnapp/build/windows/x64/runner/Release/* -DestinationPath Frostsnap-${{ env.TAG_NAME }}.zip
+        run: Compress-Archive -Path frostsnapp/build/windows/x64/runner/Release/* -DestinationPath Frostsnap-${{ env.TAG_NAME }}-windows.zip
       - name: Upload Windows build to release
-        run: gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}.zip#Frostsnap-windows.zip" --clobber
+        run: gh release upload ${{ env.TAG_NAME }} "Frostsnap-${{ env.TAG_NAME }}-windows.zip" --clobber
 
   build-macos:
     name: "Build macOS"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,70 @@
 # Security Policy
 
+Our PGP key is published at **[frostsnap.com/pgp.txt](https://frostsnap.com/pgp.txt)**. You may use it to
+encrypt a report, and to verify the signatures on our releases. The fingerprint is:
+
+```
+F19C CCCD 876B 6E57 FB71  2206 A9D5 981F 42B0 EA50
+```
+
+<details>
+<summary><code>Frostsnap &lt;security@frostsnap.com&gt;</code> — full public key</summary>
+
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQGNBGi2XKkBDADBXSgjpneN6FCx0tp+ml+EBR9uoI3a6QH9grTQuebDKvcfeQw+
+ri6YdPR93AmitEg//kah9tMx0B2VANQ/XC4O/8NDF0RLzcPCAIzqkQ0Y8wlo+EQu
+NKHyNmKu7Z+6OOwOWnBiBMGzRIkylES/CCU4+PoJGWyaTwbmT210b0HYbvJKlWue
+QAjJ1TSVqAHPvz2xZJ0GARQtamUeaBaCMVvQoKjxzku3giSS+qKRr0rZtYUQIRPA
+ZcfCHmulvEiIOYRz6UA0rQfiY3FBOV+uuP3WrGcCEwYNv848LNlmPyjc2wQLuGII
+JGMF7WiyBrEQjJZm/bwx+XP6dZzLnsQq8jRG1bexLooBwfxgxhky+QrBB9S9Hpui
+zn0FxgCWbcD2rruXtq9DZKxIx8YgpSokZxX8LO39negz0PRydQytFp8Pma+s57MK
+r3UnikhRrn5zlZZ4Zj1NS7HOlhEpWTsYpRGGclpEI8S87sW2YfqUJvNiitAZSvds
+camn7XZtkf1+Px8AEQEAAbQiRnJvc3RzbmFwIDxzZWN1cml0eUBmcm9zdHNuYXAu
+Y29tPokBzgQTAQoAOBYhBPGczM2Ha25X+3EiBqnVmB9CsOpQBQJotlypAhsvBQsJ
+CAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEKnVmB9CsOpQJaYL/1AurAh9nqXn6JZq
+Cieh2hhUj6FChTvAbawXwemPQWjral2LXxG4ESylkCJBCeSz88SqPaSt2Q6jW3We
+HTWpA3OGgS0qUewi9rmSIgjyiOBw225lsHouOCYdf/zkb0faTFwlOiuuGyUW4iyQ
+EXi+Q0qNJHOjPwRRftJldzEyxDCeU9BY4gvWLccPJZhQkuHXw2hEZkSd/W9Q38Cl
+xsM4uDd9orSV/D3kRGzU1NZkvrrGbI6l9u8XKwGMODjgHVAbSPksVMflyCHw5iDX
+IBetOOeTA1Ab/y7biaIlUvafrkljSxkpdYv2SLSJ/0OMH2t9BJ1ldz1JjU8ET6fw
+4En8nIZVqiQnWy0KBrw4nD1iu3pyDXGM8ZXSuSPN4qvhOQ3V2ADMOH0Ou02YVqIM
+rdU6IZqxhebpiEUUYQksxwkwheiwFCMr2DWKGv18U/DrgrezYiEG+Rfb59qKuQuW
+YN7SxNX0PB/9yFvUenTcTgKMu0OILu9YVlH9h+8CSkFyPRFT17kBjQRotlypAQwA
+uqLAfa+2AOw6SyxcnwJQAyXh9YX2mNpFEcf3dGTYVN2KA6QZ5X1KdDIoOfTa6/5z
+sn/h+nulMvEgMGRLVhcwWfT+FMZbuQvt41A2gt5fyKd/xIIF8oMKFCrc0plS1ipb
+4LyeXhOm3pI/yY1Gy+euXChS6bbykSb6tnHkuwdbrWrfSqJqNnfVz2HAelqGk/4w
+aZHjmEt4IuX3Jzc8vh+HBAnWK4Rwf6ICzRXNcG0Po/mE/5zTKLixADV8eRvANjnI
+THunUkMo8V1QRi4auE8yqVXjF+MiROtlKGCuIAMhLCdavxJOH7KAqwtfy2g6ZXX7
+D3dJ544Fa9OjmVyxulVKmoFlSHdRp0qDieC9Pc4ZsHmvBJJmUr6T7n0pQ0Cs5xKH
+78hiYAlJhTtCwMQNluxki0k56ue210ZCvq6PVyOYgmhGK1IJ97WGpV/i3P7X6ISK
+sh0qw9xkQi5aP6OjtBB1nSIU3a4uLWmIrlC5IPO14UHO+8FB9Ci52YfB6fLZozlJ
+ABEBAAGJA2wEGAEKACAWIQTxnMzNh2tuV/txIgap1ZgfQrDqUAUCaLZcqQIbLgHA
+CRCp1ZgfQrDqUMD0IAQZAQoAHRYhBKDZn1WaLiDP5tGKvf4lIYReVo2uBQJotlyp
+AAoJEP4lIYReVo2uF0IL/R435WIXIOfeFpSikw78PwjNxIuxg/Tvv+sFuPKtw43J
+qTvFWzI75XWOEG6+tSGZFGpZo42UnyozIdQerhNqFXbFsEGu7zKIUaoAYXjoZOxg
++nnPQvB2MGxnlcYmdTJzo3Ch4+NVW5zp7iJ44apee7jFMnB9w/9OR3xMy4/Vy70I
+gEVVbiZz/o8UftR+p7fdTIun4q4HRUOHKumQgKBHwAgV4DdeM6hvBYJAbHWGnDwf
+VhAHAp0bqIoDQxTF7vVfeQ4iK013lB3MiRqXsvoP3P+xnU4dy2cocGzNXVjdPsvE
+Vh2gPs/c6pLJssoOB40uQFD7IKCc32VVQ2mRdfFgyi+rDBS7JqVv+I7NtYFouoVk
+krUX4XnIgpRqhWurcs6UJiqEOJ4pPfWKnonpmzlZEm5dIXpiBFnUy10hWdGpdSJZ
+si+qPQlc4D9+DgJsqw9Mazht46388gMCpOHgXPz8mAY2XB5zWeGUsN6i0YE/Eaai
+bKeWAKWhBauXa55pZSIuVT51C/43zfuumZSmxad+hMNB/VbyfpJww3kJCHaPoVXy
+/NfVsNhdYQNtBdNvi8eGtMBJGaOLqW4OqOdrrhbLAN+uX+MyI28SW+7ZrTBcibNp
+ZlIynJ4kGSWzVuZwZASGcY1MKBhNh7+lWG6EateAnSFSaaqcLdoJDlXzwArYy2zK
+gkRwIYN+Mz8LSVWf4DUvob+WE3NKAHpOMSIPqOALAITuJbUt/gdt8pE8/xqUKJBN
+U9dfh7V6xWsdCmTnZ1GdEhJ1cwazMs4mc32LEap/Dc2PE4uMVdYFT4YaVjKUV33F
+ISfIEmTxoqpC4V75/q18Tv8+mZQQ28SpAWJt8FjiknZRn5xM4yzpz3VShstpHyDX
+bjZu5y2IDQQSpjVbQuLsI/fNA69DNJ3h2Nuj7rOWjjOqDEKkVoKZtNNAxECEkmhK
+F1efn67jhbCNbUbx/G+8Q1LxNo06AXD1/mnqB2ZBpXA335YF0yQiUK5bmEZc4rnX
+hLszo5K360jxmc99nsP32ZAaBhE=
+=KZYc
+-----END PGP PUBLIC KEY BLOCK-----
+```
+
+</details>
+
 ## Reporting a vulnerability
 
 **Email [security@frostsnap.com](mailto:security@frostsnap.com).**
@@ -59,6 +124,9 @@ coordinated disclosure above: publishing before we have agreed a timeline forfei
 
 If we believe the attack is deployable and profitable to actually carry out, we may reward more, depending on
 severity.
+
+Submissions are assessed case by case. Whether an award is made, and its size, is at our sole discretion;
+nothing here is an offer, and no report creates an entitlement to payment.
 
 ### Exception: malicious backups and ransom
 


### PR DESCRIPTION
Two small things:

094b42c0 puts the platform in the release asset filenames and drops the #labels. Right now the name shown on the release page, the name you actually download, and the name in CHECKSUMS are three different strings, which is why the .asc files looked misaligned on `v0.3.0`. Now they all match.

f5b45f33 adds our PGP key and fingerprint to `SECURITY.md` so you can verify a release from a checkout instead of going to the site. Same key that's on `frostsnap.com/pgp.txt`. Also adds a line to the bounty section saying awards are case by case and at our discretion, and that nothing there is a binding offer.