### PR TITLE
fix: prevent duplicate wallet restorations

### DIFF
--- a/frostsnap_core/src/coordinator.rs
+++ b/frostsnap_core/src/coordinator.rs
@@ -90,6 +90,31 @@ pub enum KeyLocationState {
     },
 }
 
+/// The outcome of [`FrostCoordinator::find_share`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum ShareSearch {
+    Found(ShareLocation),
+    /// The share is in no wallet or restoration this coordinator could check.
+    NotFound,
+    /// The share is in no restoration and in no complete wallet that could be checked, but
+    /// these complete wallets could not be unlocked with the key given, so they could not
+    /// be ruled out.
+    CouldNotCheck {
+        locked_key_names: Vec<String>,
+    },
+}
+
+impl ShareSearch {
+    /// The location if the share was found. A wallet that could not be checked counts as
+    /// not found here, so only use this where that is acceptable.
+    pub fn found(self) -> Option<ShareLocation> {
+        match self {
+            ShareSearch::Found(location) => Some(location),
+            ShareSearch::NotFound | ShareSearch::CouldNotCheck { .. } => None,
+        }
+    }
+}
+
 impl CompleteKey {
     pub fn coord_share_decryption_contrib(
         &self,
@@ -511,81 +536,145 @@ impl FrostCoordinator {
         complete_wallet_shares.chain(restoration_shares)
     }
 
+    fn complete_share_location(
+        &self,
+        access_structure: &CoordAccessStructure,
+        share_index: ShareIndex,
+    ) -> ShareLocation {
+        let access_structure_ref = access_structure.access_structure_ref();
+        let key = self
+            .keys
+            .get(&access_structure_ref.key_id)
+            .expect("must exist");
+        ShareLocation {
+            device_ids: access_structure
+                .share_index_to_devices()
+                .get(&share_index)
+                .cloned()
+                .unwrap_or_default(),
+            share_index,
+            key_name: key.key_name.clone(),
+            key_purpose: key.purpose,
+            key_state: KeyLocationState::Complete {
+                access_structure_ref,
+            },
+        }
+    }
+
+    /// A restoration that already holds the share: physically (a device entered it) ahead
+    /// of virtually (it holds enough shares to compute it). Needs no key.
+    fn locate_in_restorations(&self, share_image: ShareImage) -> Option<ShareLocation> {
+        let restorations = || self.restoration.restorations.values();
+        let physical = restorations().find_map(|restoration| {
+            restoration
+                .access_structure
+                .share_image_to_devices()
+                .get(&share_image)
+                .cloned()
+                .map(|device_ids| restoration.share_location(share_image, device_ids))
+        });
+        physical.or_else(|| {
+            restorations()
+                .find(|restoration| {
+                    restoration
+                        .access_structure
+                        .shared_key
+                        .as_ref()
+                        .is_some_and(|shared_key| {
+                            shared_key.share_image(share_image.index) == share_image
+                        })
+                })
+                .map(|restoration| restoration.share_location(share_image, Vec::new()))
+        })
+    }
+
+    /// Everything about a share's whereabouts that needs no key: the wallet or restoration
+    /// the device says it belongs to, and any restoration that already holds the share.
+    pub(crate) fn locate_without_key(
+        &self,
+        share_image: ShareImage,
+        access_structure_ref: Option<AccessStructureRef>,
+    ) -> Option<ShareLocation> {
+        if let Some(access_structure) = access_structure_ref
+            .and_then(|access_structure_ref| self.get_access_structure(access_structure_ref))
+        {
+            return Some(self.complete_share_location(&access_structure, share_image.index));
+        }
+
+        // A restoration already holding this very share is named ahead of one that merely
+        // claims the same wallet, so a duplicate is reported where it actually is.
+        if let Some(location) = self.locate_in_restorations(share_image) {
+            return Some(location);
+        }
+
+        let access_structure_ref = access_structure_ref?;
+        self.restoration
+            .restorations
+            .values()
+            .find(|restoration| {
+                restoration.access_structure.access_structure_ref() == Some(access_structure_ref)
+            })
+            .map(|restoration| restoration.share_location(share_image, Vec::new()))
+    }
+
+    /// Look for a share on this coordinator: in a complete wallet first, then in a
+    /// restoration in progress.
+    ///
+    /// `access_structure_ref` is the wallet the share's device says it belongs to (devices
+    /// send one; a physical backup has none). It names the wallet without decrypting
+    /// anything and before a restoration holds enough shares to recognise the share image,
+    /// and it decides membership of complete wallets outright: a device derives it from the
+    /// same polynomial the coordinator does, so a wallet the ref misses cannot match by
+    /// image either. Without it a complete wallet can only be searched by recomputing the
+    /// share image from its root key, which needs `encryption_key`; if the share is then
+    /// found nowhere, a wallet that key could not unlock is reported as
+    /// [`ShareSearch::CouldNotCheck`] rather than silently treated as not holding it.
     pub fn find_share(
         &self,
         share_image: ShareImage,
+        access_structure_ref: Option<AccessStructureRef>,
         encryption_key: SymmetricKey,
-    ) -> Option<ShareLocation> {
-        // Check complete wallets first (they have priority)
-        let found = self.iter_access_structures().find(|access_structure| {
-            let access_structure_ref = access_structure.access_structure_ref();
-            let Some(root_shared_key) = self.root_shared_key(access_structure_ref, encryption_key)
-            else {
-                return false;
+    ) -> ShareSearch {
+        if access_structure_ref.is_some() {
+            return match self.locate_without_key(share_image, access_structure_ref) {
+                Some(location) => ShareSearch::Found(location),
+                None => ShareSearch::NotFound,
             };
-
-            let computed_share_image = root_shared_key.share_image(share_image.index);
-            computed_share_image == share_image
-        });
-
-        if let Some(access_structure) = found {
-            let access_structure_ref = access_structure.access_structure_ref();
-            let device_ids = access_structure
-                .share_index_to_devices()
-                .get(&share_image.index)
-                .cloned()
-                .unwrap_or_default();
-            let key = self
-                .keys
-                .get(&access_structure_ref.key_id)
-                .expect("must exist");
-
-            return Some(ShareLocation {
-                device_ids,
-                share_index: share_image.index,
-                key_name: key.key_name.clone(),
-                key_purpose: key.purpose,
-                key_state: KeyLocationState::Complete {
-                    access_structure_ref,
-                },
-            });
         }
 
-        // Check restorations
-        for restoration in self.restoration.restorations.values() {
-            let share_image_to_devices = restoration.access_structure.share_image_to_devices();
-
-            // Check physical shares
-            if let Some(device_ids) = share_image_to_devices.get(&share_image) {
-                return Some(ShareLocation {
-                    device_ids: device_ids.clone(),
-                    share_index: share_image.index,
-                    key_name: restoration.key_name.clone(),
-                    key_purpose: restoration.key_purpose,
-                    key_state: KeyLocationState::Restoring {
-                        restoration_id: restoration.restoration_id,
-                    },
-                });
-            }
-
-            // Check virtual shares (via cached SharedKey)
-            if let Some(shared_key) = &restoration.access_structure.shared_key {
-                let computed_share_image = shared_key.share_image(share_image.index);
-                if computed_share_image == share_image {
-                    return Some(ShareLocation {
-                        device_ids: Vec::new(),
-                        share_index: share_image.index,
-                        key_name: restoration.key_name.clone(),
-                        key_purpose: restoration.key_purpose,
-                        key_state: KeyLocationState::Restoring {
-                            restoration_id: restoration.restoration_id,
-                        },
-                    });
+        // Complete wallets first (they have priority), by recomputing the share image.
+        let mut locked_key_names: Vec<String> = Vec::new();
+        for access_structure in self.iter_access_structures() {
+            let access_structure_ref = access_structure.access_structure_ref();
+            match self.root_shared_key(access_structure_ref, encryption_key) {
+                Some(root_shared_key) => {
+                    if root_shared_key.share_image(share_image.index) == share_image {
+                        return ShareSearch::Found(
+                            self.complete_share_location(&access_structure, share_image.index),
+                        );
+                    }
+                }
+                None => {
+                    let key = self
+                        .keys
+                        .get(&access_structure_ref.key_id)
+                        .expect("must exist");
+                    if !locked_key_names.contains(&key.key_name) {
+                        locked_key_names.push(key.key_name.clone());
+                    }
                 }
             }
         }
 
-        None
+        if let Some(location) = self.locate_in_restorations(share_image) {
+            return ShareSearch::Found(location);
+        }
+
+        if locked_key_names.is_empty() {
+            ShareSearch::NotFound
+        } else {
+            ShareSearch::CouldNotCheck { locked_key_names }
+        }
     }
 
     pub fn get_frost_key(&self, key_id: KeyId) -> Option<&CoordFrostKey> {

--- a/frostsnap_core/src/coordinator/restoration.rs
+++ b/frostsnap_core/src/coordinator/restoration.rs
@@ -22,6 +22,23 @@ impl RestorationState {
         self.access_structure.needs_to_consolidate()
     }
 
+    /// Where `share_image` sits in this restoration, held by `device_ids`.
+    pub(crate) fn share_location(
+        &self,
+        share_image: ShareImage,
+        device_ids: Vec<DeviceId>,
+    ) -> ShareLocation {
+        ShareLocation {
+            device_ids,
+            share_index: share_image.index,
+            key_name: self.key_name.clone(),
+            key_purpose: self.key_purpose,
+            key_state: KeyLocationState::Restoring {
+                restoration_id: self.restoration_id,
+            },
+        }
+    }
+
     /// Prepare for saving a physical backup - returns the HeldShare2 to store
     fn prepare_save_physical_backup(
         &self,
@@ -555,10 +572,24 @@ impl FrostCoordinator {
         // structure ref check will catch it immediately or the fingerprint check will
         // exclude it from the restoration later.
 
-        // Use find_share to check if share exists elsewhere
-        if let Some(location) =
-            self.find_share(recover_share.held_share.share_image, encryption_key)
+        // Check if the share exists elsewhere. When this restoration already knows its
+        // wallet and the share names the same one, identity is settled: another restoration
+        // claiming that wallet (a duplicate from before that was prevented) must not stop
+        // this one continuing, so only a restoration actually holding the share counts.
+        let share_image = recover_share.held_share.share_image;
+        let share_ref = recover_share.held_share.access_structure_ref;
+        let found = if share_ref.is_some()
+            && share_ref == restoration.access_structure.access_structure_ref()
         {
+            self.locate_in_restorations(share_image)
+        } else {
+            // A complete wallet that cannot be unlocked is not held against the share:
+            // nothing in this flow can unlock it, and a share that does turn out to be its
+            // merges into it when the restoration finishes.
+            self.find_share(share_image, share_ref, encryption_key)
+                .found()
+        };
+        if let Some(location) = found {
             match location.key_state {
                 KeyLocationState::Restoring {
                     restoration_id: found_id,
@@ -603,8 +634,15 @@ impl FrostCoordinator {
             .get(&restoration_id)
             .ok_or(RestorePhysicalBackupError::UnknownRestorationId)?;
 
-        // Use find_share to check if share exists elsewhere
-        if let Some(location) = self.find_share(phase.backup.share_image, encryption_key) {
+        // Check if the share exists elsewhere. A physical backup carries no
+        // access_structure_ref, so this can only recognise the share by its image. A complete
+        // wallet that cannot be unlocked is not held against it: nothing in this flow can
+        // unlock it, and a share that does turn out to be its merges into it when the
+        // restoration finishes.
+        if let Some(location) = self
+            .find_share(phase.backup.share_image, None, encryption_key)
+            .found()
+        {
             match location.key_state {
                 KeyLocationState::Restoring {
                     restoration_id: found_id,
@@ -810,9 +848,22 @@ impl FrostCoordinator {
             .purpose
             .ok_or(StartRestorationFromShareError::MissingMetadata)?;
 
-        assert!(!self.restoration.restorations.contains_key(&restoration_id));
-        if let Some(access_structure_ref) = held_share.access_structure_ref {
-            assert!(self.get_access_structure(access_structure_ref).is_none());
+        if self.restoration.restorations.contains_key(&restoration_id) {
+            return Err(StartRestorationFromShareError::RestorationIdInUse);
+        }
+
+        // A wallet must not be restored twice: neither while it is already complete nor
+        // while another restoration of it is in progress. The device's ref names the wallet
+        // before the other restoration can recognise this share image, and a restoration may
+        // already hold this very share; neither needs a key. (A complete wallet that a share
+        // *without* a ref belongs to can only be recognised with the key — `find_share`,
+        // which the app consults before calling this.)
+        if let Some(location) =
+            self.locate_without_key(held_share.share_image, held_share.access_structure_ref)
+        {
+            return Err(StartRestorationFromShareError::ShareBelongsElsewhere {
+                location: Box::new(location),
+            });
         }
 
         self.mutate(Mutation::Restoration(
@@ -1496,6 +1547,10 @@ impl std::error::Error for RecoverShareError {}
 pub enum StartRestorationFromShareError {
     /// The share is missing required metadata (key_name or purpose)
     MissingMetadata,
+    /// The share's wallet already exists here, complete or being restored.
+    ShareBelongsElsewhere { location: Box<ShareLocation> },
+    /// A restoration with this id already exists.
+    RestorationIdInUse,
 }
 
 impl fmt::Display for StartRestorationFromShareError {
@@ -1503,6 +1558,24 @@ impl fmt::Display for StartRestorationFromShareError {
         match self {
             StartRestorationFromShareError::MissingMetadata => {
                 write!(f, "This key share doesn't have required metadata. It may have been created from a newer version of the app. Try upgrading the app.")
+            }
+            StartRestorationFromShareError::ShareBelongsElsewhere { location } => {
+                let noun = location.key_purpose.key_type_noun();
+                match location.key_state {
+                    KeyLocationState::Complete { .. } => write!(
+                        f,
+                        "This key share belongs to existing {noun} '{}'. Add it to that {noun} instead of starting a new restoration.",
+                        location.key_name
+                    ),
+                    KeyLocationState::Restoring { .. } => write!(
+                        f,
+                        "The {noun} '{}' is already being restored. Continue that restoration instead of starting a new one.",
+                        location.key_name
+                    ),
+                }
+            }
+            StartRestorationFromShareError::RestorationIdInUse => {
+                write!(f, "A restoration with this id already exists")
             }
         }
     }

--- a/frostsnap_core/tests/duplicate_wallet.rs
+++ b/frostsnap_core/tests/duplicate_wallet.rs
@@ -1,0 +1,338 @@
+//! A wallet must never be restored twice — not while it is already complete on this
+//! coordinator, and not while another restoration of it is already in progress.
+//!
+//! A share reported by a device carries the wallet's identity (`access_structure_ref`), so
+//! both are detectable from the very first share: before a restoration holds enough shares
+//! to recognise a share image cryptographically, and without decrypting anything.
+
+use common::TEST_ENCRYPTION_KEY;
+use frostsnap_core::coordinator::restoration::{
+    RecoverShare, RestorationMutation, RestoreRecoverShareError, StartRestorationFromShareError,
+};
+use frostsnap_core::coordinator::{KeyLocationState, Mutation, ShareSearch};
+use frostsnap_core::device::KeyPurpose;
+use frostsnap_core::message::HeldShare2;
+use frostsnap_core::schnorr_fun::frost::ShareImage;
+use frostsnap_core::{
+    AccessStructureId, AccessStructureRef, DeviceId, KeyId, RestorationId, SymmetricKey,
+};
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use schnorr_fun::fun::prelude::*;
+
+mod common;
+mod env;
+use crate::common::Run;
+use crate::env::TestEnv;
+
+/// A key the wallet was not encrypted under.
+const WRONG_ENCRYPTION_KEY: SymmetricKey = SymmetricKey([7u8; 32]);
+
+/// What a device holding `share_image` reports when asked for its shares.
+fn device_share(run: &Run, held_by: DeviceId, share_image: ShareImage) -> RecoverShare {
+    let key = run.coordinator.iter_keys().next().unwrap();
+    let access_structure = key.access_structures().next().unwrap();
+    RecoverShare {
+        held_by,
+        held_share: HeldShare2 {
+            access_structure_ref: Some(access_structure.access_structure_ref()),
+            share_image,
+            threshold: Some(access_structure.threshold()),
+            key_name: Some(key.key_name.clone()),
+            purpose: Some(key.purpose),
+            needs_consolidation: false,
+        },
+    }
+}
+
+/// One device share per device of the coordinator's (only) wallet.
+fn device_shares(run: &Run) -> Vec<RecoverShare> {
+    run.coordinator
+        .iter_shares(TEST_ENCRYPTION_KEY)
+        .map(|(share_image, location)| device_share(run, location.device_ids[0], share_image))
+        .collect()
+}
+
+/// Create a restoration holding `share` directly, the way one already in the database would
+/// look — bypassing the checks under test.
+fn restoration_holding(
+    run: &mut Run,
+    share: &RecoverShare,
+    rng: &mut ChaCha20Rng,
+) -> RestorationId {
+    let restoration_id = RestorationId::new(rng);
+    run.coordinator.mutate(Mutation::Restoration(
+        RestorationMutation::NewRestoration2 {
+            restoration_id,
+            key_name: share.held_share.key_name.clone().unwrap(),
+            starting_threshold: share.held_share.threshold,
+            key_purpose: share.held_share.purpose.unwrap(),
+        },
+    ));
+    run.coordinator.mutate(Mutation::Restoration(
+        RestorationMutation::RestorationProgress2 {
+            restoration_id,
+            device_id: share.held_by,
+            held_share: share.held_share.clone(),
+        },
+    ));
+    restoration_id
+}
+
+/// The same share as reported by a device that does not know which wallet it belongs to:
+/// a physical backup it has entered but not yet consolidated.
+fn without_wallet_identity(share: &RecoverShare) -> RecoverShare {
+    let mut share = share.clone();
+    share.held_share.access_structure_ref = None;
+    share.held_share.needs_consolidation = true;
+    share
+}
+
+#[test]
+fn a_second_restoration_of_the_same_wallet_is_refused() {
+    let mut rng = ChaCha20Rng::from_seed([21u8; 32]);
+    let mut env = TestEnv::default();
+    let mut run = Run::start_after_keygen(3, 2, &mut env, &mut rng, KeyPurpose::Test);
+    let shares = device_shares(&run);
+
+    run.clear_coordinator();
+
+    // The first device starts a restoration.
+    let messages = run.coordinator.request_held_shares(shares[0].held_by);
+    run.extend(messages);
+    run.run_until_finished(&mut env, &mut rng).unwrap();
+    let restoration = run.coordinator.restoring().next().unwrap();
+    let restoration_id = restoration.restoration_id;
+    // One share of a 2-of-3: the restoration cannot yet recognise the others by their image.
+    assert!(!restoration.is_restorable());
+
+    // The second device's share is nonetheless known to belong to that restoration ...
+    let second = &shares[1];
+    match run.coordinator.find_share(
+        second.held_share.share_image,
+        second.held_share.access_structure_ref,
+        TEST_ENCRYPTION_KEY,
+    ) {
+        ShareSearch::Found(location) => assert_eq!(
+            location.key_state,
+            KeyLocationState::Restoring { restoration_id }
+        ),
+        other => panic!("expected the share to be located in the restoration, got {other:?}"),
+    }
+
+    // ... so it cannot start a second restoration of the same wallet.
+    let err = run
+        .coordinator
+        .start_restoring_key_from_recover_share(second, RestorationId::new(&mut rng))
+        .unwrap_err();
+    match err {
+        StartRestorationFromShareError::ShareBelongsElsewhere { location } => assert_eq!(
+            location.key_state,
+            KeyLocationState::Restoring { restoration_id }
+        ),
+        other => panic!("expected ShareBelongsElsewhere, got {other:?}"),
+    }
+    assert_eq!(run.coordinator.restoring().count(), 1);
+}
+
+/// Used to trip an `assert!` in `start_restoring_key_from_recover_share`.
+#[test]
+fn restoring_a_wallet_that_already_exists_is_refused() {
+    let mut rng = ChaCha20Rng::from_seed([22u8; 32]);
+    let mut env = TestEnv::default();
+    let mut run = Run::start_after_keygen(3, 2, &mut env, &mut rng, KeyPurpose::Test);
+    let shares = device_shares(&run);
+    let access_structure_ref = shares[0].held_share.access_structure_ref.unwrap();
+
+    let err = run
+        .coordinator
+        .start_restoring_key_from_recover_share(&shares[0], RestorationId::new(&mut rng))
+        .unwrap_err();
+    match err {
+        StartRestorationFromShareError::ShareBelongsElsewhere { location } => assert_eq!(
+            location.key_state,
+            KeyLocationState::Complete {
+                access_structure_ref
+            }
+        ),
+        other => panic!("expected ShareBelongsElsewhere, got {other:?}"),
+    }
+    assert_eq!(run.coordinator.restoring().count(), 0);
+}
+
+/// `find_share` used to answer "not found" for a wallet it could not unlock, which read as
+/// "safe to restore" to every caller.
+#[test]
+fn a_locked_wallet_is_reported_rather_than_ignored() {
+    let mut rng = ChaCha20Rng::from_seed([23u8; 32]);
+    let mut env = TestEnv::default();
+    let run = Run::start_after_keygen(3, 2, &mut env, &mut rng, KeyPurpose::Test);
+    let key_name = run.coordinator.iter_keys().next().unwrap().key_name.clone();
+    let share = &device_shares(&run)[0];
+    let share_image = share.held_share.share_image;
+    let access_structure_ref = share.held_share.access_structure_ref.unwrap();
+
+    // Without the wallet's identity the share can only be recognised by unlocking the wallet.
+    assert_eq!(
+        run.coordinator
+            .find_share(share_image, None, WRONG_ENCRYPTION_KEY),
+        ShareSearch::CouldNotCheck {
+            locked_key_names: vec![key_name]
+        }
+    );
+
+    // With it nothing needs unlocking.
+    match run.coordinator.find_share(
+        share_image,
+        Some(access_structure_ref),
+        WRONG_ENCRYPTION_KEY,
+    ) {
+        ShareSearch::Found(location) => assert_eq!(
+            location.key_state,
+            KeyLocationState::Complete {
+                access_structure_ref
+            }
+        ),
+        other => panic!("expected the share to be located by its wallet's identity, got {other:?}"),
+    }
+
+    // And the right key still finds it by its image, as before.
+    match run
+        .coordinator
+        .find_share(share_image, None, TEST_ENCRYPTION_KEY)
+    {
+        ShareSearch::Found(location) => assert_eq!(location.device_ids, vec![share.held_by]),
+        other => panic!("expected the share to be located by its image, got {other:?}"),
+    }
+}
+
+/// A wallet that cannot be unlocked must not get in the way of restoring some other wallet:
+/// a device share names its wallet, and that decides the question without unlocking anything.
+#[test]
+fn a_locked_wallet_does_not_block_a_share_of_some_other_wallet() {
+    let mut rng = ChaCha20Rng::from_seed([24u8; 32]);
+    let mut env = TestEnv::default();
+    let run = Run::start_after_keygen(3, 2, &mut env, &mut rng, KeyPurpose::Test);
+
+    let other_wallet = AccessStructureRef {
+        key_id: KeyId([1u8; 32]),
+        access_structure_id: AccessStructureId([2u8; 32]),
+    };
+    let other_share_image = ShareImage {
+        index: s!(5).public(),
+        image: g!(11 * G).normalize().mark_zero(),
+    };
+
+    assert_eq!(
+        run.coordinator
+            .find_share(other_share_image, Some(other_wallet), WRONG_ENCRYPTION_KEY),
+        ShareSearch::NotFound
+    );
+    // Without the identity the locked wallet cannot be ruled out.
+    assert!(matches!(
+        run.coordinator
+            .find_share(other_share_image, None, WRONG_ENCRYPTION_KEY),
+        ShareSearch::CouldNotCheck { .. }
+    ));
+}
+
+/// A share already entered into one restoration is reported there, even when the device
+/// names a wallet that another restoration is recovering.
+#[test]
+fn a_share_held_by_one_restoration_cannot_be_added_to_another() {
+    let mut rng = ChaCha20Rng::from_seed([25u8; 32]);
+    let mut env = TestEnv::default();
+    let mut run = Run::start_after_keygen(3, 2, &mut env, &mut rng, KeyPurpose::Test);
+    let shares = device_shares(&run);
+    run.clear_coordinator();
+
+    // Restoration A starts from device 0, so it knows the wallet.
+    let messages = run.coordinator.request_held_shares(shares[0].held_by);
+    run.extend(messages);
+    run.run_until_finished(&mut env, &mut rng).unwrap();
+    let restoration_a = run.coordinator.restoring().next().unwrap().restoration_id;
+    // Restoration B holds device 1's share as a physical backup, so it does not.
+    let restoration_b =
+        restoration_holding(&mut run, &without_wallet_identity(&shares[1]), &mut rng);
+
+    // Device 1 consolidates and now names the wallet: its share is still B's.
+    let second = &shares[1];
+    match run.coordinator.find_share(
+        second.held_share.share_image,
+        second.held_share.access_structure_ref,
+        TEST_ENCRYPTION_KEY,
+    ) {
+        ShareSearch::Found(location) => {
+            assert_eq!(
+                location.key_state,
+                KeyLocationState::Restoring {
+                    restoration_id: restoration_b
+                }
+            );
+            assert_eq!(location.device_ids, vec![second.held_by]);
+        }
+        other => panic!("expected the share to be located in restoration B, got {other:?}"),
+    }
+    let err = run
+        .coordinator
+        .check_recover_share_compatible_with_restoration(restoration_a, second, TEST_ENCRYPTION_KEY)
+        .unwrap_err();
+    assert!(
+        matches!(&err, RestoreRecoverShareError::ShareBelongsElsewhere { location }
+            if location.key_state == KeyLocationState::Restoring { restoration_id: restoration_b }),
+        "expected ShareBelongsElsewhere naming restoration B, got {err:?}"
+    );
+}
+
+/// A share that names no wallet is still recognised as already being restored, by its image.
+#[test]
+fn a_second_restoration_from_a_share_without_wallet_identity_is_refused() {
+    let mut rng = ChaCha20Rng::from_seed([26u8; 32]);
+    let mut env = TestEnv::default();
+    let mut run = Run::start_after_keygen(3, 2, &mut env, &mut rng, KeyPurpose::Test);
+    let shares = device_shares(&run);
+    run.clear_coordinator();
+
+    let share = without_wallet_identity(&shares[0]);
+    let restoration_id = restoration_holding(&mut run, &share, &mut rng);
+
+    let err = run
+        .coordinator
+        .start_restoring_key_from_recover_share(&share, RestorationId::new(&mut rng))
+        .unwrap_err();
+    match err {
+        StartRestorationFromShareError::ShareBelongsElsewhere { location } => assert_eq!(
+            location.key_state,
+            KeyLocationState::Restoring { restoration_id }
+        ),
+        other => panic!("expected ShareBelongsElsewhere, got {other:?}"),
+    }
+    assert_eq!(run.coordinator.restoring().count(), 1);
+}
+
+/// Two restorations of one wallet could exist before this was prevented. Each must still
+/// be able to continue: the other's claim to the wallet is not a reason to refuse a share.
+#[test]
+fn a_restoration_that_knows_its_wallet_is_not_blocked_by_a_duplicate_claiming_it() {
+    let mut rng = ChaCha20Rng::from_seed([27u8; 32]);
+    let mut env = TestEnv::default();
+    let mut run = Run::start_after_keygen(3, 2, &mut env, &mut rng, KeyPurpose::Test);
+    let shares = device_shares(&run);
+    run.clear_coordinator();
+
+    let first = restoration_holding(&mut run, &shares[0], &mut rng);
+    let second = restoration_holding(&mut run, &shares[1], &mut rng);
+    assert_eq!(run.coordinator.restoring().count(), 2);
+
+    for restoration_id in [first, second] {
+        run.coordinator
+            .check_recover_share_compatible_with_restoration(
+                restoration_id,
+                &shares[2],
+                TEST_ENCRYPTION_KEY,
+            )
+            .unwrap_or_else(|err| {
+                panic!("device 2 should be able to join either restoration: {err}")
+            });
+    }
+}

--- a/frostsnap_core/tests/share_location.rs
+++ b/frostsnap_core/tests/share_location.rs
@@ -41,7 +41,10 @@ fn test_find_share_in_complete_wallet_single_device() {
     let first_device_id = expected_location.device_ids[0];
 
     // Now test find_share
-    let result = run.coordinator.find_share(share_image, TEST_ENCRYPTION_KEY);
+    let result = run
+        .coordinator
+        .find_share(share_image, None, TEST_ENCRYPTION_KEY)
+        .found();
 
     assert!(result.is_some(), "Should find share in complete wallet");
     let location = result.unwrap();
@@ -109,7 +112,10 @@ fn test_find_share_in_complete_wallet_multiple_devices() {
         .expect("should be able to add duplicate share");
 
     // Now find_share should return both devices
-    let result = run.coordinator.find_share(share_image, TEST_ENCRYPTION_KEY);
+    let result = run
+        .coordinator
+        .find_share(share_image, None, TEST_ENCRYPTION_KEY)
+        .found();
 
     assert!(result.is_some());
     let location = result.unwrap();
@@ -172,7 +178,8 @@ fn test_find_share_virtual_in_complete_wallet() {
     // Find this virtual share
     let result = run
         .coordinator
-        .find_share(virtual_share_image, TEST_ENCRYPTION_KEY);
+        .find_share(virtual_share_image, None, TEST_ENCRYPTION_KEY)
+        .found();
 
     assert!(
         result.is_some(),
@@ -225,7 +232,10 @@ fn test_find_share_in_restoration_physical() {
     let held_share = &restoration.access_structure.held_shares[0];
     let share_image = held_share.held_share.share_image;
 
-    let result = run.coordinator.find_share(share_image, TEST_ENCRYPTION_KEY);
+    let result = run
+        .coordinator
+        .find_share(share_image, None, TEST_ENCRYPTION_KEY)
+        .found();
 
     assert!(result.is_some(), "Should find share in restoration");
     let location = result.unwrap();
@@ -292,7 +302,8 @@ fn test_find_share_in_restoration_virtual() {
     // but no device has physically provided it to this coordinator
     let result = run
         .coordinator
-        .find_share(third_device_share_image, TEST_ENCRYPTION_KEY);
+        .find_share(third_device_share_image, None, TEST_ENCRYPTION_KEY)
+        .found();
 
     assert!(
         result.is_some(),
@@ -335,7 +346,10 @@ fn test_find_share_duplicate_same_restoration() {
         .share_image;
 
     // Try to find this share (which already exists in the restoration)
-    let result = run.coordinator.find_share(share_image, TEST_ENCRYPTION_KEY);
+    let result = run
+        .coordinator
+        .find_share(share_image, None, TEST_ENCRYPTION_KEY)
+        .found();
 
     assert!(result.is_some(), "Should find share already in restoration");
     let location = result.unwrap();
@@ -385,7 +399,10 @@ fn test_find_share_conflict_different_restorations() {
 
     // Now try to find the share from first restoration
     // It should be found in the first restoration
-    let result = run.coordinator.find_share(share_image, TEST_ENCRYPTION_KEY);
+    let result = run
+        .coordinator
+        .find_share(share_image, None, TEST_ENCRYPTION_KEY)
+        .found();
 
     assert!(result.is_some(), "Should find share in first restoration");
     let location = result.unwrap();
@@ -439,7 +456,10 @@ fn test_find_share_conflict_complete_vs_restoration() {
     run.run_until_finished(&mut env, &mut test_rng).unwrap();
 
     // Try to find the first device's share - it should be found in the complete wallet
-    let result = run.coordinator.find_share(share_image, TEST_ENCRYPTION_KEY);
+    let result = run
+        .coordinator
+        .find_share(share_image, None, TEST_ENCRYPTION_KEY)
+        .found();
 
     assert!(
         result.is_some(),

--- a/frostsnapp/rust/src/api/recovery.rs
+++ b/frostsnapp/rust/src/api/recovery.rs
@@ -10,6 +10,7 @@ pub use frostsnap_core::coordinator::restoration::{
     PhysicalBackupPhase, RecoverShare, RecoverShareError, RecoverShareErrorKind,
     RecoveringAccessStructure, RestorationShare, RestorationState, RestorationStatus,
     RestorePhysicalBackupError, RestoreRecoverShareError, ShareCompatibility, ShareCount,
+    StartRestorationFromShareError,
 };
 pub use frostsnap_core::coordinator::{KeyLocationState, ShareLocation};
 pub use frostsnap_core::{
@@ -17,7 +18,6 @@ pub use frostsnap_core::{
     schnorr_fun::frost::{Fingerprint, ShareImage, ShareIndex, SharedKey},
 };
 use frostsnap_core::{AccessStructureRef, DeviceId, RestorationId, SymmetricKey};
-use std::fmt;
 
 #[frb(mirror(WaitForSingleDeviceState), non_opaque)]
 pub enum _WaitForSingleDeviceState {
@@ -125,18 +125,23 @@ impl super::coordinator::Coordinator {
         &self,
         recover_share: &RecoverShare,
         encryption_key: SymmetricKey,
-    ) -> Option<StartRestorationError> {
-        // Use find_share to check if this share already exists
-        if let Some(location) = self
-            .0
+    ) -> Option<StartRestorationFromShareError> {
+        // A complete wallet that cannot be unlocked is not held against the share: nothing
+        // in this flow can unlock it, and a share that does turn out to be its merges into
+        // it when the restoration finishes.
+        self.0
             .inner()
-            .find_share(recover_share.held_share.share_image, encryption_key)
-        {
-            return Some(StartRestorationError::ShareBelongsElsewhere {
-                location: Box::new(location),
-            });
-        }
-        None
+            .find_share(
+                recover_share.held_share.share_image,
+                recover_share.held_share.access_structure_ref,
+                encryption_key,
+            )
+            .found()
+            .map(
+                |location| StartRestorationFromShareError::ShareBelongsElsewhere {
+                    location: Box::new(location),
+                },
+            )
     }
 
     pub fn check_physical_backup(
@@ -389,6 +394,13 @@ pub enum _RestorePhysicalBackupError {
     ShareBelongsElsewhere { location: Box<ShareLocation> },
 }
 
+#[frb(mirror(StartRestorationFromShareError))]
+pub enum _StartRestorationFromShareError {
+    MissingMetadata,
+    ShareBelongsElsewhere { location: Box<ShareLocation> },
+    RestorationIdInUse,
+}
+
 #[frb(mirror(RecoverShareError))]
 pub struct _RecoverShareError {
     pub key_purpose: KeyPurpose,
@@ -404,25 +416,8 @@ pub enum _RecoverShareErrorKind {
     DecryptionError,
 }
 
-#[derive(Debug, Clone)]
-pub enum StartRestorationError {
-    ShareBelongsElsewhere { location: Box<ShareLocation> },
-}
-
-impl fmt::Display for StartRestorationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            StartRestorationError::ShareBelongsElsewhere { location } => {
-                write!(f, "This key share belongs to existing {} '{}' and cannot be used to start a new restoration", location.key_purpose.key_type_noun(), location.key_name)
-            }
-        }
-    }
-}
-
-impl std::error::Error for StartRestorationError {}
-
 #[frb(external)]
-impl StartRestorationError {
+impl StartRestorationFromShareError {
     #[frb(sync)]
     pub fn to_string(&self) -> String {}
 }

--- a/frostsnapp/rust/src/coordinator.rs
+++ b/frostsnapp/rust/src/coordinator.rs
@@ -813,19 +813,12 @@ impl FfiCoordinator {
     ) -> Result<RestorationId> {
         let restoration_id = {
             let mut coordinator = self.coordinator.lock().unwrap();
-
-            if let Some(access_structure_ref) = recover_share.held_share.access_structure_ref {
-                if coordinator
-                    .get_access_structure(access_structure_ref)
-                    .is_some()
-                {
-                    return Err(anyhow!("we already know about this access structure"));
-                }
-            }
             let mut db = self.db.lock().unwrap();
             coordinator.staged_mutate(&mut *db, |coordinator| {
                 let restoration_id = RestorationId::new(&mut rand::thread_rng());
-                coordinator.start_restoring_key_from_recover_share(recover_share, restoration_id);
+                // Refuses a wallet that already exists or is already being restored.
+                coordinator
+                    .start_restoring_key_from_recover_share(recover_share, restoration_id)?;
                 Ok(restoration_id)
             })?
         };


### PR DESCRIPTION
## Summary
Fixes #298 
Prevent the coordinator from restoring the same wallet more than once, whether the wallet is already complete or another restoration is in progress.

## Changes

- Add explicit share search outcomes for found, absent and locked/uncheckable wallets.
- Use access structure identity to locate device shares without decrypting wallets.
- Reject duplicate restorations with recoverable errors instead of assertions.
- Preserve valid restoration behavior when unrelated wallets are locked.
- Propagate restoration errors through the Flutter Rust bridge.
- Add regression coverage for duplicate restorations, conflicting shares, locked wallets and physical backups.
- Update existing share location tests for the new lookup API.

## Testing

Added `frostsnap_core/tests/duplicate_wallet.rs` and updated the existing share location test suite.