### PR TITLE
Upgrade bdk_electrum_streaming to 0.7, persist its Cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_electrum_streaming"
-version = "0.5.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16576b1efa0960f4c6d65d588005889ee9bee600d47540adca62d21003154bc"
+checksum = "0b76decece975a438ab263082cb223757dd4137b0f3ff7aebdd868a75cb46875"
 dependencies = [
  "anyhow",
  "bdk_core",
@@ -360,6 +360,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "miniscript",
+ "serde",
  "serde_json",
  "tracing",
 ]

--- a/frostsnap_coordinator/Cargo.toml
+++ b/frostsnap_coordinator/Cargo.toml
@@ -23,7 +23,7 @@ rsa.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 
 bdk_chain = { version = "0.23.3", features = ["rusqlite"] }
-bdk_electrum_streaming = { version = "0.5.3" }
+bdk_electrum_streaming = { version = "0.7" }
 bdk_coin_select = { version = "0.4.1" }
 
 

--- a/frostsnap_coordinator/src/bitcoin.rs
+++ b/frostsnap_coordinator/src/bitcoin.rs
@@ -1,4 +1,5 @@
 pub mod chain_sync;
+mod electrum_cache;
 mod handler_state;
 pub mod outgoing;
 pub mod psbt;

--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -7,8 +7,8 @@ use bdk_chain::{
     CheckPoint, ConfirmationBlockTime,
 };
 use bdk_electrum_streaming::{
-    electrum_streaming_client::request, run_async, AsyncReceiver, AsyncState, Cache,
-    DerivedSpkTracker, ReqCoord, Update,
+    electrum_streaming_client::{request, ElectrumScriptHash},
+    run_async, AsyncReceiver, AsyncState, Cache, DerivedSpkTracker, ReqCoord, Update,
 };
 use frostsnap_core::MasterAppkey;
 use futures::{
@@ -345,6 +345,26 @@ pub const fn default_backup_electrum_server(network: bitcoin::Network) -> &'stat
     }
 }
 
+/// Rebuild the half of the cache that is derived from the wallet rather than persisted.
+///
+/// [`Cache::tx_cache`] is deliberately not persisted — every part of it is already in the
+/// wallet, and a second copy would only give the two something to disagree about. That makes
+/// this the only thing standing between a restart and a silently missed eviction: the chain
+/// source reports one by missing a txid from the history the server now gives, so a txid it
+/// was never told about cannot go missing.
+fn seed_tx_cache_from_wallet(cache: &mut Cache, super_wallet: &CoordSuperWallet) {
+    cache.tx_cache.txs.extend(super_wallet.tx_cache());
+    cache.tx_cache.anchors.extend(super_wallet.anchor_cache());
+    for (spk, txid) in super_wallet.spk_txid_cache() {
+        cache
+            .tx_cache
+            .spk_txids
+            .entry(ElectrumScriptHash::new(&spk))
+            .or_default()
+            .insert(txid);
+    }
+}
+
 pub struct ConnectionHandler {
     client: KeychainClient,
     client_recv: KeychainClientReceiver,
@@ -382,11 +402,7 @@ impl ConnectionHandler {
             let super_wallet = super_wallet.lock().expect("must lock");
             network = super_wallet.network;
             chain_tip = super_wallet.chain_tip();
-            self.cache.tx_cache.txs.extend(super_wallet.tx_cache());
-            self.cache
-                .tx_cache
-                .anchors
-                .extend(super_wallet.anchor_cache());
+            seed_tx_cache_from_wallet(&mut self.cache, &super_wallet);
         }
 
         tracing::info!("Running ConnectionHandler for {} network", network);

--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -35,12 +35,13 @@ use tokio::sync::watch;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing::{event, Level};
 
-use crate::persist::Persisted;
+use crate::persist::{Persist, Persisted};
 use crate::settings::ElectrumEnabled;
 use crate::Sink;
 
 use super::{
     descriptor_for_account_keychain,
+    electrum_cache::ElectrumCache,
     handler_state::{ConnectedTo, Establish, HandlerState},
     status_tracker::ConnPhase,
     tofu::{
@@ -154,7 +155,7 @@ pub struct ChainClient {
 
 impl ChainClient {
     pub fn new(
-        genesis_hash: BlockHash,
+        network: bitcoin::Network,
         config: ElectrumConfig,
         trusted_certificates: Persisted<TrustedCertificates>,
         db: Arc<sync::Mutex<rusqlite::Connection>>,
@@ -162,7 +163,12 @@ impl ChainClient {
         let (req_sender, req_recv) = mpsc::unbounded();
         let (client, client_recv) = KeychainClient::new();
         let (config_tx, config_rx) = watch::channel(config);
-        let cache = Cache::default();
+        let genesis_hash = bitcoin::constants::genesis_block(network).block_hash();
+        let electrum_cache = {
+            let mut db_ = db.lock().unwrap();
+            Persisted::<ElectrumCache>::new(&mut db_, network)
+                .expect("must load persisted electrum cache")
+        };
         (
             Self {
                 req_sender,
@@ -173,7 +179,8 @@ impl ChainClient {
             ConnectionHandler {
                 req_recv,
                 client_recv,
-                cache,
+                cache: electrum_cache.cache.clone(),
+                network,
                 client,
                 genesis_hash,
                 trusted_certificates,
@@ -343,6 +350,7 @@ pub struct ConnectionHandler {
     client_recv: KeychainClientReceiver,
     req_recv: mpsc::UnboundedReceiver<Message>,
     cache: Cache,
+    network: bitcoin::Network,
     genesis_hash: BlockHash,
     trusted_certificates: Persisted<TrustedCertificates>,
     db: Arc<sync::Mutex<rusqlite::Connection>>,
@@ -374,8 +382,11 @@ impl ConnectionHandler {
             let super_wallet = super_wallet.lock().expect("must lock");
             network = super_wallet.network;
             chain_tip = super_wallet.chain_tip();
-            self.cache.txs.extend(super_wallet.tx_cache());
-            self.cache.anchors.extend(super_wallet.anchor_cache());
+            self.cache.tx_cache.txs.extend(super_wallet.tx_cache());
+            self.cache
+                .tx_cache
+                .anchors
+                .extend(super_wallet.anchor_cache());
         }
 
         tracing::info!("Running ConnectionHandler for {} network", network);
@@ -396,7 +407,7 @@ impl ConnectionHandler {
             self.genesis_hash,
             self.config_rx.clone(),
             self.trusted_certificates,
-            self.db,
+            self.db.clone(),
         );
 
         let electrum_state = AsyncState::<KeychainId>::new(
@@ -414,6 +425,8 @@ impl ConnectionHandler {
             update_sender,
             electrum_state,
             config_rx: self.config_rx,
+            network: self.network,
+            db: self.db,
         };
 
         rt.block_on(conn_loop.drive());
@@ -479,11 +492,35 @@ struct ConnLoop {
     update_sender: mpsc::UnboundedSender<Update<KeychainId>>,
     electrum_state: AsyncState<KeychainId>,
     config_rx: watch::Receiver<ElectrumConfig>,
+    network: bitcoin::Network,
+    db: Arc<sync::Mutex<rusqlite::Connection>>,
 }
 
 impl ConnLoop {
     const PING_DELAY: Duration = Duration::from_secs(21);
     const PING_TIMEOUT: Duration = Duration::from_secs(3);
+
+    /// Snapshot `subscriptions`/`headers` to the db (`tx_cache` is never written — see
+    /// `electrum_cache` module docs). Called whenever a connection ends, which is the natural
+    /// checkpoint: best-effort, so a failure just means a slower resync next launch, not
+    /// something to bubble up.
+    ///
+    /// Takes its inputs explicitly (not `&self`) so it can be called with `self.network` and
+    /// `self.electrum_state` still live inside `service`'s field-destructured borrows.
+    fn persist_cache(
+        network: bitcoin::Network,
+        db: &sync::Mutex<rusqlite::Connection>,
+        cache: &Cache,
+    ) {
+        let electrum_cache = ElectrumCache::new(network, cache.clone());
+        let result = db
+            .lock()
+            .map_err(|_| anyhow!("db mutex poisoned"))
+            .and_then(|mut conn| electrum_cache.persist_update(&mut conn, ()));
+        if let Err(err) = result {
+            tracing::warn!(error = err.to_string(), "Failed to persist electrum cache");
+        }
+    }
 
     async fn drive(&mut self) {
         let mut next = Next::Idle;
@@ -563,6 +600,7 @@ impl ConnLoop {
             update_sender,
             electrum_state,
             config_rx,
+            ..
         } = self;
 
         let next = {
@@ -647,6 +685,10 @@ impl ConnLoop {
                 }
             }
         };
+
+        // Every path out of a connection is a natural checkpoint, Stop (app going away)
+        // included, so persist before anything else here.
+        Self::persist_cache(self.network, &self.db, electrum_state.cache());
 
         // The control channel closed: stop without touching status (the app is going away).
         if matches!(next, Next::Stop) {

--- a/frostsnap_coordinator/src/bitcoin/chain_sync.rs
+++ b/frostsnap_coordinator/src/bitcoin/chain_sync.rs
@@ -819,6 +819,126 @@ mod test {
         ElectrumScriptHash::new(&spk)
     }
 
+    /// A transaction dropped from the mempool while we were disconnected must still be noticed
+    /// as evicted on the next startup.
+    ///
+    /// The chain source spots an eviction by missing a txid from the history the server now
+    /// reports, so it can only spot txids it already holds for that script — and that set
+    /// (`Cache::tx_cache::spk_txids`) is deliberately not persisted. If startup does not rebuild
+    /// it from the wallet, the eviction is invisible for as long as the script's history does not
+    /// change again, and the wallet goes on showing a transaction the network has forgotten.
+    #[test]
+    fn an_eviction_that_happened_while_disconnected_is_detected_after_a_restart() {
+        use bdk_chain::bitcoin::{Amount, TxIn, TxOut};
+        use bdk_chain::BlockId;
+        use bdk_electrum_streaming::{JobId, ReqCoord, ReqQueue, SpkJob, SpkProgress};
+
+        const NETWORK: bitcoin::Network = bitcoin::Network::Bitcoin;
+        const INDEX: u32 = 3;
+
+        let db = Arc::new(sync::Mutex::new(
+            rusqlite::Connection::open_in_memory().unwrap(),
+        ));
+        let master_appkey =
+            MasterAppkey::derive_from_rootkey(Point::random(&mut rand::thread_rng()));
+        let keychain = (master_appkey, BitcoinAccountKeychain::external());
+        let spk = crate::bitcoin::peek_spk(
+            master_appkey,
+            BitcoinBip32Path {
+                account_keychain: BitcoinAccountKeychain::external(),
+                index: NormalIndex::new(INDEX).unwrap(),
+            },
+        );
+
+        fn chain_client(
+            db: &Arc<sync::Mutex<rusqlite::Connection>>,
+        ) -> (ChainClient, ConnectionHandler) {
+            let trusted = {
+                let mut conn = db.lock().unwrap();
+                Persisted::new(&mut *conn, NETWORK).unwrap()
+            };
+            ChainClient::new(
+                NETWORK,
+                ElectrumConfig {
+                    enabled: ElectrumEnabled::None,
+                    primary: String::new(),
+                    backup: String::new(),
+                },
+                trusted,
+                db.clone(),
+            )
+        }
+
+        // A session that saw the transaction in the mempool and stored it.
+        let txid = {
+            let (client, _handler) = chain_client(&db);
+            let mut wallet = CoordSuperWallet::load_or_init(db.clone(), NETWORK, client).unwrap();
+            wallet.list_addresses(master_appkey);
+
+            let tx = bitcoin::Transaction {
+                version: bitcoin::transaction::Version::TWO,
+                lock_time: bitcoin::absolute::LockTime::ZERO,
+                input: vec![TxIn::default()],
+                output: vec![TxOut {
+                    value: Amount::from_sat(1_000_000),
+                    script_pubkey: spk.clone(),
+                }],
+            };
+            let txid = tx.compute_txid();
+            let mut tx_update = bdk_chain::TxUpdate::default();
+            tx_update.txs = vec![Arc::new(tx)];
+
+            wallet
+                .apply_update(Update {
+                    tx_update,
+                    last_active_indices: [(keychain, INDEX)].into(),
+                    chain_update: Some(
+                        CheckPoint::from_block_ids([BlockId {
+                            height: 0,
+                            hash: bitcoin::constants::genesis_block(NETWORK).block_hash(),
+                        }])
+                        .unwrap(),
+                    ),
+                })
+                .unwrap();
+            assert!(wallet.get_tx(txid).is_some(), "the wallet stored the tx");
+            txid
+        };
+
+        // Restart: same database, fresh wallet, and a cache with nothing carried over in memory.
+        let (client, _handler) = chain_client(&db);
+        let mut wallet = CoordSuperWallet::load_or_init(db.clone(), NETWORK, client).unwrap();
+        wallet.list_addresses(master_appkey);
+        assert!(
+            wallet.get_tx(txid).is_some(),
+            "the tx is still on disk after the restart"
+        );
+
+        let mut cache = Cache::default();
+        seed_tx_cache_from_wallet(&mut cache, &wallet);
+
+        // The server now reports no history at all for the script: while we were away, the
+        // transaction was dropped and nothing replaced it.
+        let spk_hash = ElectrumScriptHash::new(&spk);
+        let mut job = SpkJob::new(&cache, spk_hash, None);
+        let mut queue = ReqQueue::default();
+        let mut coord = ReqCoord::new(0);
+        let mut queuer = coord.queuer(&mut queue, JobId::Spk(spk_hash));
+        let progress = job.poll(&mut queuer, &cache).unwrap();
+
+        let SpkProgress::Done(tx_update) = progress else {
+            panic!("a script the server has no history for leaves nothing to fetch: {progress:?}");
+        };
+        assert!(
+            tx_update
+                .evicted_ats
+                .iter()
+                .any(|&(evicted, _)| evicted == txid),
+            "the dropped tx must be reported as evicted, got {:?}",
+            tx_update.evicted_ats,
+        );
+    }
+
     /// Pins the upstream contract `monitor_keychain` rides on (bdk_electrum_streaming >= 0.5.3):
     /// re-inserting the SAME descriptor with a larger `next_index` widens the tracked window in
     /// place, and equal or smaller never narrows it. Before 0.5.3 an unchanged descriptor was an

--- a/frostsnap_coordinator/src/bitcoin/electrum_cache.rs
+++ b/frostsnap_coordinator/src/bitcoin/electrum_cache.rs
@@ -1,0 +1,132 @@
+//! Persistence for [`bdk_electrum_streaming::Cache`].
+//!
+//! Only `subscriptions` and `headers` are persisted here — `tx_cache` is `#[serde(skip)]` on
+//! `Cache` itself, because it's fully derivable from the wallet (see `ConnectionHandler::run`,
+//! which seeds it from `super_wallet.tx_cache()` / `.anchor_cache()` on every startup).
+use anyhow::Result;
+use bdk_chain::{bitcoin, rusqlite_impl::migrate_schema};
+use rusqlite::{params, OptionalExtension};
+
+use crate::persist::Persist;
+
+pub struct ElectrumCache {
+    network: bitcoin::Network,
+    pub cache: bdk_electrum_streaming::Cache,
+}
+
+impl ElectrumCache {
+    pub fn new(network: bitcoin::Network, cache: bdk_electrum_streaming::Cache) -> Self {
+        Self { network, cache }
+    }
+}
+
+const SCHEMA_NAME: &str = "frostsnap_electrum_cache";
+const MIGRATIONS: &[&str] = &[
+    // Version 0 - initial schema
+    "CREATE TABLE IF NOT EXISTS fs_electrum_cache (
+        network TEXT PRIMARY KEY,
+        cache_blob BLOB NOT NULL
+    )",
+];
+
+impl Persist<rusqlite::Connection> for ElectrumCache {
+    type Update = ();
+    type LoadParams = bitcoin::Network;
+
+    fn migrate(conn: &mut rusqlite::Connection) -> Result<()> {
+        let db_tx = conn.transaction()?;
+        migrate_schema(&db_tx, SCHEMA_NAME, MIGRATIONS)?;
+        db_tx.commit()?;
+        Ok(())
+    }
+
+    fn load(conn: &mut rusqlite::Connection, network: Self::LoadParams) -> Result<Self> {
+        let blob: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT cache_blob FROM fs_electrum_cache WHERE network = ?1",
+                params![network.to_string()],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let cache = blob
+            .and_then(|blob| {
+                bincode::serde::decode_from_slice(&blob, bincode::config::standard())
+                    .inspect_err(|err| {
+                        tracing::warn!(
+                            error = err.to_string(),
+                            "Failed to decode persisted electrum cache, starting fresh"
+                        )
+                    })
+                    .ok()
+                    .map(|(cache, _)| cache)
+            })
+            .unwrap_or_default();
+        Ok(Self { network, cache })
+    }
+
+    fn persist_update(&self, conn: &mut rusqlite::Connection, _update: Self::Update) -> Result<()> {
+        let blob = bincode::serde::encode_to_vec(&self.cache, bincode::config::standard())?;
+        conn.execute(
+            "INSERT OR REPLACE INTO fs_electrum_cache (network, cache_blob) VALUES (?1, ?2)",
+            params![self.network.to_string(), blob],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bdk_chain::bitcoin::{
+        absolute::LockTime,
+        block::{Header, Version},
+        hashes::Hash,
+        BlockHash, CompactTarget, Transaction, TxMerkleNode,
+    };
+    use std::sync::Arc;
+
+    fn dummy_header() -> Header {
+        Header {
+            version: Version::ONE,
+            prev_blockhash: BlockHash::all_zeros(),
+            merkle_root: TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 0,
+        }
+    }
+
+    fn dummy_tx() -> Transaction {
+        Transaction {
+            version: bdk_chain::bitcoin::transaction::Version::ONE,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: Vec::new(),
+        }
+    }
+
+    /// `headers` (persisted) must survive a round trip; `tx_cache` (derived from wallet data,
+    /// never persisted) must not, so a fresh load never carries stale wallet data.
+    #[test]
+    fn persist_and_load_round_trips_headers_but_not_tx_cache() -> Result<()> {
+        let mut conn = rusqlite::Connection::open_in_memory()?;
+        ElectrumCache::migrate(&mut conn)?;
+
+        let mut cache = bdk_electrum_streaming::Cache::default();
+        let header = dummy_header();
+        cache.headers.insert(header.block_hash(), header);
+        let tx = dummy_tx();
+        cache.tx_cache.txs.insert(tx.compute_txid(), Arc::new(tx));
+
+        ElectrumCache::new(bitcoin::Network::Signet, cache).persist_update(&mut conn, ())?;
+
+        let loaded = ElectrumCache::load(&mut conn, bitcoin::Network::Signet)?;
+        assert_eq!(loaded.cache.headers.len(), 1, "headers must be persisted");
+        assert!(
+            loaded.cache.tx_cache.txs.is_empty(),
+            "tx_cache must never be persisted"
+        );
+
+        Ok(())
+    }
+}

--- a/frostsnap_coordinator/src/bitcoin/send.rs
+++ b/frostsnap_coordinator/src/bitcoin/send.rs
@@ -700,7 +700,7 @@ mod test {
             Persisted::new(&mut *conn, NETWORK).unwrap()
         };
         ChainClient::new(
-            bitcoin::constants::genesis_block(NETWORK).block_hash(),
+            NETWORK,
             ElectrumConfig {
                 enabled: ElectrumEnabled::None,
                 primary: String::new(),

--- a/frostsnap_coordinator/src/bitcoin/wallet.rs
+++ b/frostsnap_coordinator/src/bitcoin/wallet.rs
@@ -126,6 +126,37 @@ impl CoordSuperWallet {
             })
     }
 
+    /// Which of our scripts each transaction we hold appears in the history of, keyed the way
+    /// the server keys it.
+    ///
+    /// This is what lets an eviction be noticed: the chain source spots one by missing a txid
+    /// from the history the server now reports, so it can only spot the ones it knew about. It
+    /// is not persisted with the rest of the cache — this is the wallet data it is rebuilt from
+    /// on every startup, and without it an eviction that happened while we were disconnected is
+    /// never detected.
+    ///
+    /// Mirrors Electrum's definition of a script's history: a transaction is in it if it pays
+    /// the script or spends an output of it.
+    pub fn spk_txid_cache(&self) -> impl Iterator<Item = (ScriptBuf, Txid)> + '_ {
+        let graph = self.tx_graph.graph();
+        let index = &self.tx_graph.index;
+        graph.full_txs().flat_map(move |tx_node| {
+            let txid = tx_node.txid;
+            let paid_to = tx_node.tx.output.iter().map(|txout| &txout.script_pubkey);
+            let spent_from = tx_node
+                .tx
+                .input
+                .iter()
+                .filter_map(|txin| graph.get_txout(txin.previous_output))
+                .map(|txout| &txout.script_pubkey);
+            paid_to
+                .chain(spent_from)
+                .filter(|spk| index.index_of_spk((*spk).clone()).is_some())
+                .map(|spk| (spk.clone(), txid))
+                .collect::<Vec<_>>()
+        })
+    }
+
     /// How far past a frontier the indexer derives. Not what the chain source subscribes to — see
     /// `SUBSCRIPTION_LOOKAHEAD`.
     pub fn lookahead(&self) -> u32 {

--- a/frostsnapp/rust/src/api/settings.rs
+++ b/frostsnapp/rust/src/api/settings.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-use bitcoin::constants::genesis_block;
 use bitcoin::Network as BitcoinNetwork;
 use flutter_rust_bridge::frb;
 use frostsnap_coordinator::bitcoin::chain_sync::{ChainClient, ElectrumConfig, SUPPORTED_NETWORKS};
@@ -73,8 +72,6 @@ impl Settings {
                 backup: persisted.get_backup_electrum_server(network),
             };
 
-            let genesis_hash = genesis_block(bitcoin::params::Params::new(network)).block_hash();
-
             // Load trusted certificates for this network from the database
             let trusted_certificates = {
                 let mut db_ = db.lock().unwrap();
@@ -83,12 +80,8 @@ impl Settings {
                 Persisted::<TrustedCertificates>::new(&mut *db_, network)?
             };
 
-            let (chain_api, conn_handler) = ChainClient::new(
-                genesis_hash,
-                electrum_config,
-                trusted_certificates,
-                db.clone(),
-            );
+            let (chain_api, conn_handler) =
+                ChainClient::new(network, electrum_config, trusted_certificates, db.clone());
             let super_wallet =
                 SuperWallet::load_or_new(&app_directory, network, chain_api.clone())?;
             // FIXME: the dependency relationship here is overly convoluted.


### PR DESCRIPTION
Fixes #577.

## Summary

Upgrades `bdk_electrum_streaming` 0.5.3 → 0.7 and gives its `Cache` the handling #577 asks for: the derived half rebuilt from wallet data on startup, the rest persisted.

**This PR fixes:**
- Txs evicted when disconnected to electrum server not being detected after restart.
- Last used index not updating correctly.
- Txs potentially missing anchors after reorg.

**This PR improves:**
- Reduce bandwidth use by persisting cache.

## ⚠️ Needs physical testing

0.7 restructures how work is scheduled, so **transactions may take longer to appear in the wallet during a sync** than they did on 0.5.3. This is a behavioural change in the upstream architecture, not something this PR configures, and it is not covered by the unit tests here — it needs testing against a real server and a real device.

If the delay turns out to be bad enough to be user-visible, the follow-up is a sync progress indicator so the wallet isn't silently empty-looking while work is still in flight.

## Against #577's checklist

| Field | #577 says | This PR |
| --- | --- | --- |
| `spk_txids` | must be populated, else evictions are missed | seeded from the wallet on every startup |
| `txs` | can be populated to save bandwidth | seeded (as before) |
| `anchors` | can be populated to save bandwidth | seeded (as before) |
| `headers` | not persisted currently — good to have | persisted |

## Changes

- **`Cache` API move**: `Cache::txs`/`anchors` moved under a new `tx_cache` sub-struct in 0.7, so `chain_sync.rs` seeds them at `self.cache.tx_cache.{txs,anchors}`. `tx_cache` is never persisted (it's `#[serde(skip)]` upstream) — it's wallet-derived, so it is rebuilt on startup instead.
- **`spk_txids` seeding** (the correctness half of #577): eviction is reported by diffing the txids we already hold for a script against the history the server now gives, so a txid we were never told about cannot go missing. Nothing was seeding that set, so after a restart the first history fetch had nothing to diff against and an eviction that happened while we were offline was invisible until that script's history changed again. Now rebuilt from the wallet via `CoordSuperWallet::spk_txid_cache()`, mirroring Electrum's definition of a script's history (a tx is in it if it pays the script or spends an output of it).
- **Cache persistence** (the bandwidth half): new `frostsnap_coordinator/src/bitcoin/electrum_cache.rs` wraps the cache in an `ElectrumCache` implementing this crate's `Persist<rusqlite::Connection>`, storing `subscriptions` + `headers` as a per-network `bincode` blob. Loaded in `ChainClient::new` (replacing the `Cache::default()` the issue links to), written back on every exit from a connection (graceful stop, error, reconnect, or shutdown) as a best-effort checkpoint.
- **`ChainClient::new`** now takes `network` and derives `genesis_hash` from it, rather than taking both.

## Test plan
- [x] `cargo test -p frostsnap_coordinator -p rust_lib_frostsnapp --lib` — 58 + 10 pass
- [x] New test encodes #577's repro (pending tx → shutdown → tx dropped → restart): asserts the txid comes back in `evicted_ats`. Verified it fails (`got {}`) with the `spk_txids` seeding removed, so it is not vacuous.
- [x] New round-trip test asserting `headers` persist and `tx_cache` never does
- [x] `just build` — full Linux app build succeeds
- [ ] **Physical test against a real server + device**: how long txs take to show up during a sync (see above)