### PR TITLE
Emphasize the device count in the keygen check

### DIFF
--- a/frostsnap_widgets/src/keygen_check.rs
+++ b/frostsnap_widgets/src/keygen_check.rs
@@ -65,7 +65,7 @@ impl KeygenCheck {
                 Gray4TextStyle::new(FONT_CONFIRM_TEXT, PALETTE.text_secondary),
             ),
             Text::new(
-                "on every device".to_string(),
+                format!("on all {} devices", t_of_n.1),
                 Gray4TextStyle::new(FONT_CONFIRM_TEXT, PALETTE.text_secondary),
             ),
         ))


### PR DESCRIPTION
"Check this code matches on every device" now says how many: "on all 3 devices". The count comes from the verified keygen input, so it is the real size of the wallet. Naming it reminds the user that the check means looking at every device, and makes it easy to notice if one of them never showed the code.