### PR TITLE
[app] Make validate_amount network-independent

### DIFF
--- a/frostsnapp/rust/src/api/bitcoin.rs
+++ b/frostsnapp/rust/src/api/bitcoin.rs
@@ -74,9 +74,6 @@ pub trait BitcoinNetworkExt {
     fn bdk_file(&self, app_dir: impl AsRef<Path>) -> PathBuf;
 
     #[frb(sync)]
-    fn validate_amount(&self, address: &str, value: u64) -> Option<String>;
-
-    #[frb(sync)]
     fn supported_networks() -> Vec<BitcoinNetwork>;
 }
 
@@ -151,30 +148,28 @@ impl BitcoinNetworkExt for BitcoinNetwork {
     fn supported_networks() -> Vec<BitcoinNetwork> {
         SUPPORTED_NETWORKS.into_iter().collect()
     }
+}
 
-    // FIXME: doesn't need to be on the network. Can get the script pubkey without the network.
-    #[frb(sync)]
-    fn validate_amount(&self, address: &str, value: u64) -> Option<String> {
-        match bitcoin::Address::from_str(address) {
-            Ok(address) => match address.require_network(*self) {
-                Ok(address) => {
-                    let dust_value = address.script_pubkey().minimal_non_dust().to_sat();
-                    if value < dust_value {
-                        event!(
-                            Level::DEBUG,
-                            value = value,
-                            dust_value = dust_value,
-                            "address validation rejected"
-                        );
-                        Some(format!("Too small to send. Must be at least {dust_value}"))
-                    } else {
-                        None
-                    }
-                }
-                Err(_e) => None,
-            },
-            Err(_e) => None,
-        }
+#[frb(sync)]
+pub fn validate_amount(address: &str, value: u64) -> Option<String> {
+    let Ok(address) = bitcoin::Address::from_str(address) else {
+        return None;
+    };
+    let dust_value = address
+        .assume_checked()
+        .script_pubkey()
+        .minimal_non_dust()
+        .to_sat();
+    if value < dust_value {
+        event!(
+            Level::DEBUG,
+            value = value,
+            dust_value = dust_value,
+            "address validation rejected"
+        );
+        Some(format!("Too small to send. Must be at least {dust_value}"))
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
fixes #598 

Changes

* **Signature:** moved `validate_amount` out of `BitcoinNetworkExt` into a standalone `pub fn validate_amount(address: &str, value: u64) -> Option<String>`, resolving the long-standing `FIXME` ("doesn't need to be on the network").

* **Network Decoupling:** replaced `.require_network(*self)` with `.assume_checked()`. The dust check only needs the script pubkey, which the address payload determines on its own...this fixes a silent bypass where a wrong-network address previously returned `None` (no error warning) instead of being dust-checked.
* **Flow Control:** flattened nested `match` blocks into a single `let Ok(address) = ... else { return None; }` guard.
* **Bindings:** re-ran FRB codegen, updating the Dart API to a top-level `validateAmount(...)` function instead of an extension method on `BitcoinNetwork`. no existing call sites in rust or dart required updates.


Verification: 
* **`cargo check` & `cargo test`:** Passed cleanly across all workspace default members.
* **Formatting & Analysis:** `cargo fmt --check` and `flutter analyze` both passed with zero issues.
* **`cargo clippy -Dwarnings`:** Clean across all touched crates (pre-existing `uninlined_format_args` warnings in untouched `desktop_camera`/`frost_backup` remain).
